### PR TITLE
Add null check in getTypeNameFromField

### DIFF
--- a/src/modules/typenames.ts
+++ b/src/modules/typenames.ts
@@ -75,7 +75,7 @@ export function gankTypeNamesFromResponse(response: object) {
 
 function getTypeNameFromField(obj: object, typenames: string[]) {
   Object.keys(obj).map(item => {
-    if (typeof obj[item] === 'object') {
+    if (obj[item] && typeof obj[item] === 'object') {
       if ('__typename' in obj[item]) {
         typenames.push(obj[item].__typename);
       }

--- a/src/tests/modules/typenames.test.ts
+++ b/src/tests/modules/typenames.test.ts
@@ -32,4 +32,9 @@ describe('gankTypeNamesFromResponse', () => {
     });
     expect(typeNames).toMatchObject(['Todo']);
   });
+
+  it('should work when field returns null', () => {
+    let typeNames = gankTypeNamesFromResponse({ todo: null });
+    expect(typeNames).toMatchObject([]);
+  });
 });


### PR DESCRIPTION
Hi, thanks for making this library✌️ I ran into this issue, and thought i would try to fix it.


Before this change if a field returned null the following error would be raised:

> TypeError: Cannot use 'in' operator to search for '__typename' in null

The problem seems to be that `typeof null` is "object".