### PR TITLE
Fix test blacklist for publishing.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 /*
 !/lib
 !/es
+**/tests/
 **/*.test.js
 !package.json
 !LICENSE.md


### PR DESCRIPTION
- Adds extra blacklist to `.npmignore` as not all files match `*.test.js`

/cc @kenwheeler 