### PR TITLE
Enable --declaration emit for TypeScript.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 lib
 es
+types
 coverage
 .vscode
 yarn-error.log*

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 /*
 !/lib
 !/es
+!/types/**/*.d.ts
 **/tests/
 **/*.test.js
 !package.json

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "coverage": "jest --coverage",
     "clean-lib": "rimraf lib",
@@ -14,7 +15,9 @@
     "clean-es": "rimraf es",
     "build-es": "npm run clean-es && builder run build-babel -- -d es",
     "watch-es": "watch \"npm run build-es\" src/ -d",
-    "build": "builder concurrent --buffer build-lib build-es",
+    "clean-types": "rimraf types",
+    "build-types": "npm run clean-types && tsc -p ./tsconfig.dts.json",
+    "build": "builder concurrent --buffer build-lib build-es build-types",
     "demo:start:graphql-server": "node example/src/server/index.js",
     "demo:start:app":
       "webpack-dev-server --hot --inline --config \"example/webpack.config.js\"",
@@ -23,7 +26,7 @@
     "lint": "tslint 'src/**/*.{ts, tsx}'",
     "test": "jest",
     "prettier":
-      "prettier --write \"{,!(node_modules|custom-typings)/**/}*.{js,jsx,ts,tsx,json,md}\"",
+      "prettier --write \"{,!(node_modules|custom-typings|types)/**/}*.{js,jsx,ts,tsx,json,md}\"",
     "precommit": "lint-staged"
   },
   "author": "Ken Wheeler",

--- a/src/components/client.tsx
+++ b/src/components/client.tsx
@@ -5,7 +5,7 @@ import { formatTypeNames } from '../modules/typenames';
 
 export interface IClientProps {
   client: IClient; // Client instance
-  render: (object) => ReactNode; // Render prop
+  render: (obj: object) => ReactNode; // Render prop
   query: IQuery | IQuery[]; // Query object or array of Query objects
   mutation?: IMutation; // Mutation object (map)
   cache?: boolean;

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -4,7 +4,7 @@ import ClientWrapper from './client';
 import { Consumer } from './context';
 
 export interface IConnectProps {
-  render: (object) => ReactNode; // Render prop
+  render: (obj: object) => ReactNode; // Render prop
   query?: IQuery | IQuery[]; // Query or queries
   mutation?: IMutation; // Mutation map
   cache?: boolean;

--- a/src/components/context.tsx
+++ b/src/components/context.tsx
@@ -1,5 +1,18 @@
-import createReactContext from 'create-react-context';
+import createReactContext, {
+  ProviderProps,
+  ConsumerProps,
+} from 'create-react-context';
+import { ComponentClass } from 'react';
 
 const context = createReactContext({});
 
-export const { Provider, Consumer } = context;
+// TypeScript is very pedantic about re-exporting dependencies when doing
+// --declaration emit, so we need to import ComponentClass. But if we don't
+// explicitly use ComponentClass somewhere in the code, TypeScript *also*
+// ends up issuing an error. This is dumb, but this all gets erased anyway.
+interface Context {
+  Provider: ComponentClass<ProviderProps<{}>>;
+  Consumer: ComponentClass<ConsumerProps<{}>>;
+}
+
+export const { Provider, Consumer }: Context = context;

--- a/tsconfig.dts.json
+++ b/tsconfig.dts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./types"
+  },
+  "exclude": ["./src/tests/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
-    "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "baseUrl": "./",
-    "rootDir": "./",
+    "rootDir": "./src",
     "jsx": "react",
     "declaration": true,
     "module": "es2015",
@@ -15,7 +13,6 @@
     "noUnusedParameters": true,
     "skipLibCheck": true,
     "pretty": true,
-    "sourceMap": true,
     "experimentalPipelineStage1": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],


### PR DESCRIPTION
Fixes #25.

Here's the summary of what I did just so you feel more confident accepting this PR.

First, I added a new `tsconfig.dts.json` that extends the usual config, but turns emit back on. Building with `tsconfig.dts.json` will emit `.d.ts` files. Note this also produces `.js` files, but I've updated the `.npmignore` to ignore anything other than `.d.ts` files.

To get `--declaration` working, first I turned on `--declaration` in your `tsconfig.json` (as opposed to just in your `tsconfig.dts.json`, so that the editor can tell you about `--declaration` errors when they happen). I also had to turn `--allowJs` off since it's currently not a supported combo. Finally, I added a hack to get `--declaration` emit working with `noUnusuedLocals` (without needing a `// @ts-ignore`).

Lastly, I added a a `types` field to `package.json` pointing at the produced `index.d.ts`, so that when TypeScript can find the entry point for your types.

I think in the future we'd like to make the process easier (@mhegazy @bowdenk7), since it's slightly more complex with Babel, but I think that's okay. Hopefully this helps the next person who needs to figure it out!