### PR TITLE
changing render to children

### DIFF
--- a/example/src/app/home.tsx
+++ b/example/src/app/home.tsx
@@ -13,7 +13,7 @@ const Home = () => (
       addTodo: mutation(AddTodo),
       removeTodo: mutation(RemoveTodo),
     }}
-    render={({ loaded, data, addTodo, removeTodo, refetch }) => {
+    children={({ loaded, data, addTodo, removeTodo, refetch }) => {
       return (
         <div>
           {!loaded ? (

--- a/src/components/client.tsx
+++ b/src/components/client.tsx
@@ -5,7 +5,7 @@ import { formatTypeNames } from '../modules/typenames';
 
 export interface IClientProps {
   client: IClient; // Client instance
-  render: (obj: object) => ReactNode; // Render prop
+  children: (obj: object) => ReactNode; // Render prop
   query: IQuery | IQuery[]; // Query object or array of Query objects
   mutation?: IMutation; // Mutation object (map)
   cache?: boolean;
@@ -287,8 +287,8 @@ export default class UrqlClient extends Component<IClientProps, IClientState> {
       update: this.updateCache,
     };
 
-    return this.props.render
-      ? this.props.render({
+    return typeof this.props.children === 'function'
+      ? this.props.children({
           ...this.state,
           ...this.mutations,
           cache,

--- a/src/components/connect-hoc.tsx
+++ b/src/components/connect-hoc.tsx
@@ -30,7 +30,7 @@ function ConnectHOC(opts?: IHOCProps | ((_) => IHOCProps)) {
         const connectProps =
           typeof opts === 'function' ? opts(this.props) : opts;
 
-        return <Connect {...connectProps} render={this.renderComponent} />;
+        return <Connect {...connectProps} children={this.renderComponent} />;
       }
     };
 }

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -4,7 +4,7 @@ import ClientWrapper from './client';
 import { Consumer } from './context';
 
 export interface IConnectProps {
-  render: (obj: object) => ReactNode; // Render prop
+  children: (obj: object) => ReactNode; // Render prop
   query?: IQuery | IQuery[]; // Query or queries
   mutation?: IMutation; // Mutation map
   cache?: boolean;
@@ -25,7 +25,7 @@ export default class Connect extends Component<IConnectProps> {
         {(client: IClient) => (
           <ClientWrapper
             client={client}
-            render={this.props.render}
+            children={this.props.children}
             query={this.props.query}
             mutation={this.props.mutation}
             cache={this.props.cache}

--- a/src/tests/components/client.test.tsx
+++ b/src/tests/components/client.test.tsx
@@ -17,7 +17,7 @@ describe('Client Component', () => {
     component.update(
       <Client
         // @ts-ignore
-        render={() => {
+        children={() => {
           return <div>hey</div>;
         }}
       />
@@ -31,7 +31,7 @@ describe('Client Component', () => {
     const client = renderer.create(
       <Client
         // @ts-ignore
-        render={({ data, error, fetching, loaded, refetch }) => {
+        children={({ data, error, fetching, loaded, refetch }) => {
           expect(data).toBeNull();
           expect(error).toBeNull();
           expect(fetching).toBe(false);
@@ -55,7 +55,7 @@ describe('Client Component', () => {
         // @ts-ignore
         query={{ query: `{ todos { id } }` }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -94,7 +94,7 @@ describe('Client Component', () => {
         // @ts-ignore
         query={{ query: `{ todos { id } }` }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -108,7 +108,7 @@ describe('Client Component', () => {
         // @ts-ignore
         query={{ query: `{ posts { id } }` }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -133,7 +133,7 @@ describe('Client Component', () => {
         // @ts-ignore
         query={[{ query: `{ posts { id } }` }, { query: `{ posts { id } }` }]}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -182,7 +182,7 @@ describe('Client Component', () => {
           addTodo: { query: `{ todos { id } }`, variables: undefined },
         }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -203,7 +203,7 @@ describe('Client Component', () => {
           removeTodo: { query: `{ todos { id } }`, variables: undefined },
         }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -226,7 +226,7 @@ describe('Client Component', () => {
         // @ts-ignore
         query={{ query: `{ todos { id } }` }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -265,7 +265,7 @@ describe('Client Component', () => {
         // @ts-ignore
         query={[{ query: `{ todos { id } }` }, { query: `{ todos { id } }` }]}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -305,7 +305,7 @@ describe('Client Component', () => {
         // @ts-ignore
         query={[{ query: `{ todos { id } }` }, { query: `{ todos { id } }` }]}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -355,7 +355,7 @@ describe('Client Component', () => {
           },
         }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -397,7 +397,7 @@ describe('Client Component', () => {
           },
         }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -431,7 +431,7 @@ describe('Client Component', () => {
         // @ts-ignore
         query={{ query: `{ todos { id } }` }}
         // @ts-ignore
-        render={() => {
+        children={() => {
           return null;
         }}
       />
@@ -477,7 +477,7 @@ describe('Client Component', () => {
           },
         }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -523,7 +523,7 @@ describe('Client Component', () => {
           },
         }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -568,7 +568,7 @@ describe('Client Component', () => {
           },
         }}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -595,7 +595,7 @@ describe('Client Component', () => {
         // @ts-ignore
         client={clientModule}
         // @ts-ignore
-        render={args => {
+        children={args => {
           result = args;
           return null;
         }}
@@ -631,7 +631,7 @@ describe('Client Component', () => {
         // @ts-ignore
         client={clientModule}
         // @ts-ignore
-        render={() => {
+        children={() => {
           return null;
         }}
       />
@@ -658,7 +658,7 @@ describe('Client Component', () => {
         // @ts-ignore
         client={clientModule}
         // @ts-ignore
-        render={() => {
+        children={() => {
           return null;
         }}
       />
@@ -693,7 +693,7 @@ describe('Client Component', () => {
         // @ts-ignore
         client={clientModule}
         // @ts-ignore
-        render={() => {
+        children={() => {
           return null;
         }}
       />
@@ -732,7 +732,7 @@ describe('Client Component', () => {
         // @ts-ignore
         client={clientModule}
         // @ts-ignore
-        render={() => {
+        children={() => {
           return null;
         }}
       />
@@ -772,7 +772,7 @@ describe('Client Component', () => {
         // @ts-ignore
         client={clientModule}
         // @ts-ignore
-        render={() => {
+        children={() => {
           return null;
         }}
       />
@@ -800,7 +800,7 @@ describe('Client Component', () => {
         // @ts-ignore
         client={clientModule}
         // @ts-ignore
-        render={() => {
+        children={() => {
           return null;
         }}
       />
@@ -830,7 +830,7 @@ describe('Client Component', () => {
         // @ts-ignore
         client={clientModule}
         // @ts-ignore
-        render={() => {
+        children={() => {
           return null;
         }}
       />

--- a/src/tests/components/connect.test.tsx
+++ b/src/tests/components/connect.test.tsx
@@ -8,7 +8,7 @@ describe('Client Component', () => {
   it('should provide a context consumer and pass through to client', () => {
     // @ts-ignore
     const component = renderer.create(
-      <Connect render={args => <div {...args} />} />
+      <Connect children={args => <div {...args} />} />
     );
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();


### PR DESCRIPTION
Fixes #33 

By naming the render prop 'children', allows both prop style and functional child style