### PR TITLE
Ignore package.json when formatting with prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "coverage": "jest --coverage",
     "clean-lib": "rimraf lib",
     "build-babel": "babel src --extensions \".ts,.tsx\"",
-    "build-lib":
-      "npm run clean-lib && builder run --env \"{\\\"BABEL_ENV\\\":\\\"commonjs\\\"}\" build-babel -- -d lib",
+    "build-lib": "npm run clean-lib && builder run --env \"{\\\"BABEL_ENV\\\":\\\"commonjs\\\"}\" build-babel -- -d lib",
     "clean-es": "rimraf es",
     "build-es": "npm run clean-es && builder run build-babel -- -d es",
     "watch-es": "watch \"npm run build-es\" src/ -d",
@@ -19,14 +18,12 @@
     "build-types": "npm run clean-types && tsc -p tsconfig.dts.json",
     "build": "builder concurrent --buffer build-lib build-es build-types",
     "demo:start:graphql-server": "node example/src/server/index.js",
-    "demo:start:app":
-      "webpack-dev-server --hot --inline --config \"example/webpack.config.js\"",
+    "demo:start:app": "webpack-dev-server --hot --inline --config \"example/webpack.config.js\"",
     "demo:start": "builder concurrent demo:start:app demo:start:graphql-server",
     "type-check": "tsc",
     "lint": "tslint 'src/**/*.{ts, tsx}'",
     "test": "jest",
-    "prettier":
-      "prettier --write \"{,!(node_modules|custom-typings|types)/**/}*.{js,jsx,ts,tsx,json,md}\"",
+    "prettier": "prettier --write \"{,!(node_modules|custom-typings|types)/**/}*.{js,jsx,ts,tsx,json,md}\"",
     "precommit": "lint-staged"
   },
   "author": "Ken Wheeler",
@@ -54,10 +51,20 @@
       "!src/**/typenames.*"
     ],
     "testRegex": "(src/tests/.*(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,md}": ["prettier --write", "git add"]
+    "*.{js,jsx,ts,tsx,json,md}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.38",


### PR DESCRIPTION
**What**:

Ignore `package.json` when formatting with `prettier` to avoid conflicting with the `npm`/`yarn` format.

**Why**:

`npm` and `yarn` both format `package.json` in a common, opinionated way. Formatting JSON files with `prettier` yields a different result. `prettier` will currently reformat `package.json` and clutter up commits going back and forth between the two formats any time `npm` or `yarn` modifies `package.json`.

**How**:

* added `package.json` to `.prettierignore`
* reformatted `package.json` to prevent future diffs

**See also**:

[Stop re-formatting package.json with Prettier and VSCode once and for all](https://medium.com/@martin_hotell/stop-re-formatting-package-json-with-prettier-and-vscode-once-and-for-all-52d283067f9a) by Martin Hochel
