### PR TITLE
Only emit declaration files with TypeScript

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 /*
 !/lib
 !/es
-!/types/**/*.d.ts
+!/types
 **/tests/
 **/*.test.js
 !package.json

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "tslint": "^5.9.1",
     "tslint-config-prettier": "^1.6.0",
     "tslint-react": "^3.4.0",
-    "typescript": "~2.7.1",
+    "typescript": "~2.7.2",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.0"
   },

--- a/tsconfig.dts.json
+++ b/tsconfig.dts.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
+    "emitDeclarationOnly": true,
     "outDir": "./types"
   },
   "exclude": ["./src/tests/**/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5930,9 +5930,9 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typescript@~2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+typescript@~2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
In TypeScript 2.8 (and in TypeScript 2.7.2, but low-key) [we added the `emitDeclarationOnly` flag](https://github.com/Microsoft/TypeScript/pull/20735). This flag basically says "I only want to create `.d.ts` files", which is basically perfect for libraries that use Babel to emit JS.

C.C. @mhegazy (and thanks @nojvek!)