### PR TITLE
Expose client in Connect child function

### DIFF
--- a/src/components/client.tsx
+++ b/src/components/client.tsx
@@ -294,6 +294,7 @@ export default class UrqlClient extends Component<IClientProps, IClientState> {
           cache,
           refetch: this.fetch,
           refreshAllFromCache: this.refreshAllFromCache,
+          client: this.props.client,
         })
       : null;
   }

--- a/src/tests/components/__snapshots__/connect-hoc.test.tsx.snap
+++ b/src/tests/components/__snapshots__/connect-hoc.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Connect HOC should wrap its component argument with connect 1`] = `
       "update": [Function],
     }
   }
+  client={Object {}}
   data={null}
   error={null}
   fetching={false}
@@ -22,6 +23,7 @@ exports[`Connect HOC should wrap its component argument with connect 1`] = `
 exports[`Connect HOC should wrap its component argument with connect with functional options 1`] = `
 <div
   cache={false}
+  client={Object {}}
   data={null}
   error={null}
   fetching={false}

--- a/src/tests/components/__snapshots__/connect.test.tsx.snap
+++ b/src/tests/components/__snapshots__/connect.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Client Component should provide a context consumer and pass through to 
       "update": [Function],
     }
   }
+  client={Object {}}
   data={null}
   error={null}
   fetching={false}


### PR DESCRIPTION
This PR exposes the client to `Connect`'s child function in case child components want to manually fetch from the client.