### PR TITLE
Fix spelling of context key for graphqlHttp.

### DIFF
--- a/example/src/server/index.js
+++ b/example/src/server/index.js
@@ -17,7 +17,7 @@ const initializedGraphQLMiddleware = graphqlHttp({
   // Enable GraphiQL dev tool
   graphiql: true,
   // A function that returns extra data available to every resolver
-  constex: context,
+  context: context,
 });
 
 app.use(initializedGraphQLMiddleware);


### PR DESCRIPTION
The spelling of the `context` key on the `graphqlHttp` options object in the example server appears to be off. The [`express-graphql` docs](http://graphql.org/graphql-js/express-graphql/) provide this structure for the options object:
```
graphqlHTTP({
  schema: GraphQLSchema,
  graphiql?: ?boolean,
  rootValue?: ?any,
  context?: ?any,
  pretty?: ?boolean,
  formatError?: ?Function,
  validationRules?: ?Array<any>,
}): Middleware
```