### PR TITLE
[refactor] replace soon to be deprecated `componentWillReceiveProps`

### DIFF
--- a/src/components/client.tsx
+++ b/src/components/client.tsx
@@ -51,10 +51,12 @@ export default class UrqlClient extends Component<IClientProps, IClientState> {
     this.formatProps(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
+    const nextProps = this.props;
+
     if (
-      this.props.query !== nextProps.query ||
-      this.props.mutation !== nextProps.mutation
+      prevProps.query !== nextProps.query ||
+      prevProps.mutation !== nextProps.mutation
     ) {
       this.formatProps(nextProps);
     }


### PR DESCRIPTION
with `componentDidUpdate`.

The new recommendation for making network requests when there is a difference between current + previous props is to do so in `componentDidUpdate` (see: https://reactjs.org/docs/react-component.html#componentdidupdate)

When react enables async rendering in future releases of react, this will break lifecycle methods into "render" phase and "commit" phase. Methods in the "render" phase (includes `componentWillReceiveProps`) are meant to be side-effect free as they might be called multiple times.

`componentDidMount` and `componentDidUpdate` are called in the "commit" phase and are the recommended place for side-effects (includes network calls). see: https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects

twitter thread with more context: https://twitter.com/ken_wheeler/status/983022255746768897?s=20