### PR TITLE
Improve/Fix TS types

### DIFF
--- a/example/src/app/home.tsx
+++ b/example/src/app/home.tsx
@@ -1,19 +1,39 @@
 /* tslint:disable */
 
-import React from 'react';
-import { Connect, query, mutation } from '../../../src/index';
+import * as React from 'react';
+import { Connect, query, mutation, UrqlProps } from '../../../src/index';
 import TodoList from './todo-list';
 import TodoForm from './todo-form';
 import Loading from './loading';
+import { Url } from 'url';
 
-const Home = () => (
+export interface ITodoQuery {
+  todos: Array<{ id: string; text: string }>;
+  user: {
+    name: string;
+  };
+}
+
+export interface ITodoMutations {
+  addTodo: (input: { text: string }) => void;
+  removeTodo: (input: { id: string }) => void;
+}
+
+const Home: React.SFC<{}> = () => (
   <Connect
     query={query(TodoQuery)}
     mutation={{
       addTodo: mutation(AddTodo),
       removeTodo: mutation(RemoveTodo),
     }}
-    children={({ loaded, data, addTodo, removeTodo, refetch }) => {
+    children={({
+      cache,
+      loaded,
+      data,
+      addTodo,
+      removeTodo,
+      refetch,
+    }: UrqlProps<ITodoQuery, ITodoMutations>) => {
       return (
         <div>
           {!loaded ? (
@@ -22,7 +42,7 @@ const Home = () => (
             <TodoList todos={data.todos} removeTodo={removeTodo} />
           )}
           <TodoForm addTodo={addTodo} />
-          <button type="button" onClick={refetch}>
+          <button type="button" onClick={() => refetch({})}>
             Refetch
           </button>
           <button

--- a/example/src/app/index.tsx
+++ b/example/src/app/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 
 import { Provider, Client } from '../../../src/index';
 import Home from './home';
@@ -8,7 +8,7 @@ const client = new Client({
   url: 'http://localhost:3001/graphql',
 });
 
-export const App = () => (
+export const App: React.SFC<{}> = () => (
   <Provider client={client}>
     <Home />
   </Provider>

--- a/example/src/app/loading.tsx
+++ b/example/src/app/loading.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
+import * as React from 'react';
 
-const Loading = () => <p>Loading...</p>;
+const Loading: React.SFC<{}> = () => <p>Loading...</p>;
 
 export default Loading;

--- a/example/src/app/todo-form.tsx
+++ b/example/src/app/todo-form.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 
-type TodoFormProps = {
-  addTodo: (text: object) => void;
-};
+export interface TodoFormProps {
+  addTodo: (input: { text: string }) => void;
+}
 
 class TodoForm extends React.Component<TodoFormProps> {
   input: HTMLInputElement;
   addTodo = () => {
-    this.props.addTodo({ text: this.input.value });
-    this.input.value = '';
+    if (this.input !== null) {
+      this.props.addTodo({ text: this.input.value });
+      this.input.value = '';
+    }
   };
   render() {
     return (

--- a/example/src/app/todo-list.tsx
+++ b/example/src/app/todo-list.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import * as React from 'react';
 
-const TodoList = ({ todos, removeTodo }) => (
+export interface TodoListProps {
+  todos: Array<{ id: string; text: string }>;
+  removeTodo: (input: { id: string }) => void;
+}
+
+const TodoList: React.SFC<TodoListProps> = ({ todos, removeTodo }) => (
   <ul>
     {todos.map(todo => (
       <li key={todo.id}>

--- a/src/components/client.tsx
+++ b/src/components/client.tsx
@@ -294,9 +294,9 @@ export default class UrqlClient extends Component<IClientProps, IClientState> {
           ...this.state,
           ...this.mutations,
           cache,
+          client: this.props.client,
           refetch: this.fetch,
           refreshAllFromCache: this.refreshAllFromCache,
-          client: this.props.client,
         })
       : null;
   }

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -3,7 +3,7 @@ import { ICache, IClient, IMutation, IQuery } from '../interfaces/index';
 import ClientWrapper from './client';
 import { Consumer } from './context';
 
-export interface IConnectProps<Data = {}, Mutations = {}> {
+export interface IConnectProps<Data, Mutations> {
   children: (props: UrqlProps<Data, Mutations>) => ReactNode; // Render prop
   query?: IQuery | IQuery[]; // Query or queries
   mutation?: IMutation; // Mutation map
@@ -60,7 +60,9 @@ export type UrqlProps<Data, Mutations = {}> = {
   refreshAllFromCache: () => void;
 } & Mutations;
 
-export default class Connect extends Component<IConnectProps> {
+export default class Connect<Data = {}, Mutations = {}> extends Component<
+  IConnectProps<Data, Mutations>
+> {
   render() {
     // Use react-create-context to provide context to ClientWrapper
     return (

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -1,10 +1,10 @@
 import React, { Component, ReactNode } from 'react';
-import { IClient, IMutation, IQuery } from '../interfaces/index';
+import { ICache, IClient, IMutation, IQuery } from '../interfaces/index';
 import ClientWrapper from './client';
 import { Consumer } from './context';
 
-export interface IConnectProps {
-  children: (obj: object) => ReactNode; // Render prop
+export interface IConnectProps<Data = {}, Mutations = {}> {
+  children: (obj: UrqlProps<Data, Mutations>) => ReactNode; // Render prop
   query?: IQuery | IQuery[]; // Query or queries
   mutation?: IMutation; // Mutation map
   cache?: boolean;
@@ -16,6 +16,20 @@ export interface IConnectProps {
     data: object
   ) => boolean;
 }
+
+// This is the type used for the Render Prop. It requires
+// one generic so that TypeScript can properly infer the shape
+// of data and an optional second generic to describe the mutations
+// that will be made available.
+export type UrqlProps<Data, Mutations = {}> = {
+  cache: ICache;
+  loaded: boolean;
+  fetching: boolean;
+  refetch: (options: { skipFetch?: boolean }, initial?: boolean) => void;
+  refreshAllFromCache: () => void;
+  data: Data | null;
+  error: any;
+} & Mutations;
 
 export default class Connect extends Component<IConnectProps> {
   render() {

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -4,7 +4,7 @@ import ClientWrapper from './client';
 import { Consumer } from './context';
 
 export interface IConnectProps<Data = {}, Mutations = {}> {
-  children: (obj: UrqlProps<Data, Mutations>) => ReactNode; // Render prop
+  children: (props: UrqlProps<Data, Mutations>) => ReactNode; // Render prop
   query?: IQuery | IQuery[]; // Query or queries
   mutation?: IMutation; // Mutation map
   cache?: boolean;
@@ -21,14 +21,43 @@ export interface IConnectProps<Data = {}, Mutations = {}> {
 // one generic so that TypeScript can properly infer the shape
 // of data and an optional second generic to describe the mutations
 // that will be made available.
+// Note: The following verbose comments are for TypeScript user's autocomplete.
+
+/**
+ * Urql's render props.
+ */
 export type UrqlProps<Data, Mutations = {}> = {
+  /**
+   * Urql cache
+   */
   cache: ICache;
-  loaded: boolean;
-  fetching: boolean;
-  refetch: (options: { skipFetch?: boolean }, initial?: boolean) => void;
-  refreshAllFromCache: () => void;
+  /**
+   * The data returned by your Urql query.
+   */
   data: Data | null;
+  /**
+   * Query error, if present.
+   */
   error: any;
+  /**
+   * Returns true if Urql is fetching data
+   */
+  fetching: boolean;
+  /**
+   * This is like loading but it's false by default, and becomes true after
+   * the first time your query loads. This makes initial loading states easy
+   * and reduces flicker on subsequent fetch/refetches.
+   */
+  loaded: boolean;
+  /**
+   * Manually refetch the query. You can skip the cache, hit the server
+   * and repopulate the cache by calling this like `refetch({ skipCache: true })`.
+   */
+  refetch: (options: { skipFetch?: boolean }, initial?: boolean) => void;
+  /**
+   * Manually refetch all queries from the cache.
+   */
+  refreshAllFromCache: () => void;
 } & Mutations;
 
 export default class Connect extends Component<IConnectProps> {

--- a/src/tests/components/connect.test.tsx
+++ b/src/tests/components/connect.test.tsx
@@ -8,7 +8,7 @@ describe('Client Component', () => {
   it('should provide a context consumer and pass through to client', () => {
     // @ts-ignore
     const component = renderer.create(
-      <Connect children={args => <div {...args} />} />
+      <Connect children={args => <div {...args as any} />} />
     );
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();


### PR DESCRIPTION
This PR does a few things:

- Introduces a new generic TS type `UrqlProps<Data, Mutations>` that works pretty much like Formik's `FormikProps<Values>` and React Router 4's `RouteComponentProps<Params>`, (i.e. you use it to properly type the children of the render prop function). 
- Fixes the example to use the new generic
- Adds detailed comments around the generic for improved editor integration for Urql x TS consumers.

What does it look like?

```tsx
// ...

export interface ITodoQuery {
  todos: Array<{ id: string; text: string }>;
  user: {
    name: string;
  };
}

export interface ITodoMutations {
  addTodo: (input: { text: string }) => void;
  removeTodo: (input: { id: string }) => void;
}

const Home: React.SFC<{}> = () => (
  <Connect
    query={query(TodoQuery)}
    mutation={{
      addTodo: mutation(AddTodo),
      removeTodo: mutation(RemoveTodo),
    }}
    children={({
      cache,
      loaded,
      data,
      addTodo,
      removeTodo,
      refetch,
    }: UrqlProps<ITodoQuery, ITodoMutations>) => {
      return (
        <div>
          {!loaded ? (
            <Loading />
          ) : (
            <TodoList todos={data.todos} removeTodo={removeTodo} />
          )}
          <TodoForm addTodo={addTodo} />
          <button type="button" onClick={() => refetch({})}>
            Refetch
          </button>
          <button
            type="button"
            onClick={refetch.bind(null, { skipCache: true })}
          >
            Refetch (Skip Cache)
          </button>
        </div>
      );
    }}
  />
);

```

More improvements can be made to the type signature `ICache`'s methods. 
 