### PR TITLE
Swap out uuid for counter based subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "tslint-config-prettier": "^1.6.0",
     "tslint-react": "^3.4.0",
     "typescript": "~2.7.2",
+    "uuid": "^3.2.1",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.0"
   },
@@ -123,8 +124,7 @@
   },
   "dependencies": {
     "create-react-context": "^0.1.3",
-    "graphql": "^0.13.1",
-    "uuid": "^3.2.1"
+    "graphql": "^0.13.1"
   },
   "sideEffects": false
 }

--- a/src/components/client.tsx
+++ b/src/components/client.tsx
@@ -45,7 +45,7 @@ export default class UrqlClient extends Component<IClientProps, IClientState> {
   query = null; // Stored Query
   mutations = {}; // Stored Mutation
   typeNames = []; // Typenames that exist on current query
-  subscriptionID = null; // Change subscription ID
+  unsubscribe = null; // Unsubscription function calling back to the client
 
   componentDidMount() {
     this.formatProps(this.props);
@@ -64,7 +64,9 @@ export default class UrqlClient extends Component<IClientProps, IClientState> {
 
   componentWillUnmount() {
     // Unsub from change listener
-    this.props.client.unsubscribe(this.subscriptionID);
+    if (this.unsubscribe !== null) {
+      this.unsubscribe();
+    }
   }
 
   invalidate = queryObject => {
@@ -107,7 +109,7 @@ export default class UrqlClient extends Component<IClientProps, IClientState> {
         ? props.query.map(formatTypeNames)
         : formatTypeNames(props.query);
       // Subscribe to change listener
-      this.subscriptionID = props.client.subscribe(this.update);
+      this.unsubscribe = props.client.subscribe(this.update);
       // Fetch initial data
       this.fetch(undefined, true);
     }

--- a/src/interfaces/client.ts
+++ b/src/interfaces/client.ts
@@ -13,6 +13,5 @@ export interface IClient {
   refreshAllFromCache(): void;
   subscribe(
     callback: (changedTypes: string[], reponse: object) => void
-  ): number;
-  unsubscribe(id: number): void;
+  ): () => void;
 }

--- a/src/interfaces/client.ts
+++ b/src/interfaces/client.ts
@@ -13,6 +13,6 @@ export interface IClient {
   refreshAllFromCache(): void;
   subscribe(
     callback: (changedTypes: string[], reponse: object) => void
-  ): string;
-  unsubscribe(id: string): void;
+  ): number;
+  unsubscribe(id: number): void;
 }

--- a/src/modules/client.ts
+++ b/src/modules/client.ts
@@ -1,5 +1,3 @@
-import uuid from 'uuid/v4';
-
 import { ICache, IClientOptions, IMutation, IQuery } from '../interfaces/index';
 import { gankTypeNamesFromResponse } from '../modules/typenames';
 import { hashString } from './hash';
@@ -61,6 +59,7 @@ export default class Client {
   store: object; // Internal store
   fetchOptions: RequestInit | (() => RequestInit); // Options for fetch call
   subscriptions: object; // Map of subscribed Connect components
+  subscriptionSize: number; // Used to generate IDs for subscriptions
   cache: ICache; // Cache object
 
   constructor(opts?: IClientOptions) {
@@ -77,6 +76,7 @@ export default class Client {
     this.store = opts.initialCache || {};
     this.cache = opts.cache || defaultCache(this.store);
     this.subscriptions = {};
+    this.subscriptionSize = 0;
     // Bind methods
     this.executeQuery = this.executeQuery.bind(this);
     this.executeMutation = this.executeMutation.bind(this);
@@ -95,14 +95,14 @@ export default class Client {
 
   subscribe(
     callback: (changedTypes: string[], response: object) => void
-  ): string {
+  ): number {
     // Create an identifier, add callback to subscriptions, return identifier
-    const id = uuid();
+    const id = this.subscriptionSize++;
     this.subscriptions[id] = callback;
     return id;
   }
 
-  unsubscribe(id: string) {
+  unsubscribe(id: number) {
     // Delete from subscriptions by identifier
     delete this.subscriptions[id];
   }

--- a/src/modules/client.ts
+++ b/src/modules/client.ts
@@ -95,16 +95,15 @@ export default class Client {
 
   subscribe(
     callback: (changedTypes: string[], response: object) => void
-  ): number {
-    // Create an identifier, add callback to subscriptions, return identifier
+  ): () => void {
+    // Create an identifier, add callback to subscriptions
     const id = this.subscriptionSize++;
     this.subscriptions[id] = callback;
-    return id;
-  }
 
-  unsubscribe(id: number) {
-    // Delete from subscriptions by identifier
-    delete this.subscriptions[id];
+    // Return unsubscription function
+    return () => {
+      delete this.subscriptions[id];
+    };
   }
 
   refreshAllFromCache() {

--- a/src/tests/modules/client.test.ts
+++ b/src/tests/modules/client.test.ts
@@ -152,29 +152,30 @@ describe('Client', () => {
   describe('subscribe', () => {
     let client;
 
-    beforeAll(() => {
+    beforeEach(() => {
       client = new Client({
         url: 'test',
       });
     });
 
-    it('should return a unique id', () => {
+    it('should return an unsubscribe callback', () => {
       const callback = () => {};
-      const id = client.subscribe(callback);
-      expect(id).not.toBeNull();
+      const unsubscribe = client.subscribe(callback);
+      expect(unsubscribe).not.toBeNull();
     });
 
-    it('should add function arguments to the internal subscriptions array', () => {
+    it('should add function arguments to the internal subscriptions object', () => {
       const callback = () => {};
-      const id = client.subscribe(callback);
-      expect(client.subscriptions[id]).toBe(callback);
+      expect(Object.keys(client.subscriptions).length).toBe(0);
+      client.subscribe(callback);
+      expect(Object.keys(client.subscriptions).length).toBe(1);
     });
   });
 
   describe('unsubscribe', () => {
     let client;
 
-    beforeAll(() => {
+    beforeEach(() => {
       client = new Client({
         url: 'test',
       });
@@ -182,9 +183,10 @@ describe('Client', () => {
 
     it('should remove from subscriptions by id', () => {
       const callback = () => {};
-      const id = client.subscribe(callback);
-      client.unsubscribe(id);
-      expect(client.subscriptions[id]).toBeUndefined();
+      const unsubscribe = client.subscribe(callback);
+      expect(Object.keys(client.subscriptions).length).toBe(1);
+      unsubscribe();
+      expect(Object.keys(client.subscriptions).length).toBe(0);
     });
   });
 


### PR DESCRIPTION
I'm not sure why uuid was used to determine IDs for subscriptions on
the client. Instead we can use a create-broadcast like approach, where
we just count up the number of created (not active) subscriptions as
IDs.

Note: `uuid` is still necessary as a `devDependency` for the example as far as I can tell.