### PR TITLE
[Draft] Refactor fetch logic to be separated from Client

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,8 @@
   },
   "dependencies": {
     "create-react-context": "^0.1.3",
-    "graphql": "^0.13.1"
+    "graphql": "^0.13.1",
+    "zen-observable-ts": "^0.8.9"
   },
   "sideEffects": false
 }

--- a/src/components/client.tsx
+++ b/src/components/client.tsx
@@ -26,7 +26,7 @@ export interface IClientState {
   fetching: boolean; // Loading
   loaded: boolean; // Initial load
   error?: Error; // Error
-  data: object[] | IClientState[]; // Data
+  data: object | object[] | IClientState[]; // Data
 }
 
 export default class UrqlClient extends Component<IClientProps, IClientState> {

--- a/src/interfaces/client.ts
+++ b/src/interfaces/client.ts
@@ -1,6 +1,5 @@
 import { IQueryResponse } from './../modules/client';
 import { ICache } from './cache';
-import { IMutation } from './mutation';
 import { IQuery } from './query';
 
 export interface IClient {
@@ -9,7 +8,7 @@ export interface IClient {
     queryObject: IQuery,
     skipCache: boolean
   ): Promise<IQueryResponse>;
-  executeMutation(mutationObject: IMutation): Promise<object[]>;
+  executeMutation(mutationObject: IQuery): Promise<object>;
   refreshAllFromCache(): void;
   subscribe(
     callback: (changedTypes: string[], reponse: object) => void

--- a/src/interfaces/exchange.ts
+++ b/src/interfaces/exchange.ts
@@ -1,0 +1,6 @@
+import Observable from 'zen-observable-ts';
+
+import { ExecutionResult } from 'graphql';
+import { IOperation } from './operation';
+
+export type IExchange = (operation: IOperation) => Observable<ExecutionResult>;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,3 +3,5 @@ export { IMutation } from './mutation';
 export { IQuery } from './query';
 export { IClientOptions } from './client-options';
 export { ICache } from './cache';
+export { IExchange } from './exchange';
+export { IOperation } from './operation';

--- a/src/interfaces/operation.ts
+++ b/src/interfaces/operation.ts
@@ -1,0 +1,14 @@
+import { IQuery } from './query';
+
+/* This is an "enriched" Query which makes it ready to
+ * go through an OperationQueue. It contains a context
+ * that will be relevant to the Exchange.
+ * - `key`: The unique identifier of the Query
+ * - `operationName`: The GraphQL operation like "query" or "mutation"
+ * - `context`: Any options that the Exchange should receive
+ */
+export interface IOperation extends IQuery {
+  key: string;
+  operationName: string;
+  context: Record<string, any>;
+}

--- a/src/modules/client.ts
+++ b/src/modules/client.ts
@@ -44,6 +44,7 @@ export const defaultCache = store => {
 };
 
 export default class Client {
+  url: string;
   store: object; // Internal store
   subscriptions: object; // Map of subscribed Connect components
   subscriptionSize: number; // Used to generate IDs for subscriptions
@@ -58,11 +59,12 @@ export default class Client {
       throw new Error('Please provide a URL for your GraphQL API');
     }
 
+    this.url = opts.url;
     this.store = opts.initialCache || {};
     this.subscriptions = {};
     this.subscriptionSize = 0;
     this.cache = opts.cache || defaultCache(this.store);
-    this.exchange = dedupExchange(httpExchange({ url: opts.url }));
+    this.exchange = dedupExchange(httpExchange());
     this.fetchOptions = opts.fetchOptions || {};
 
     // Bind methods
@@ -112,6 +114,7 @@ export default class Client {
         typeof this.fetchOptions === 'function'
           ? this.fetchOptions()
           : this.fetchOptions,
+      url: this.url,
     };
   }
 

--- a/src/modules/dedup-exchange.ts
+++ b/src/modules/dedup-exchange.ts
@@ -1,0 +1,49 @@
+import Observable from 'zen-observable-ts';
+
+import { IExchange } from '../interfaces/exchange';
+
+// Wraps an exchange and deduplicates in-flight operations by their key
+export const dedupExchange = (forward: IExchange): IExchange => {
+  const inFlight = {};
+
+  return operation => {
+    const { key } = operation;
+
+    // Take existing intermediate observable if it has been created
+    if (inFlight[key] !== undefined) {
+      return inFlight[key];
+    }
+
+    // Keep around one subscription and collect observers for this observable
+    const observers = [];
+    let subscription;
+
+    // Create intermediate observable and only forward to the next exchange once
+    return (inFlight[key] = new Observable(observer => {
+      observers.push(observer);
+
+      if (subscription === undefined) {
+        subscription = forward(operation).subscribe({
+          complete: () => {
+            observers.forEach(x => x.complete());
+            delete inFlight[key];
+          },
+          error: error => {
+            observers.forEach(x => x.error(error));
+          },
+          next: emission => {
+            observers.forEach(x => x.next(emission));
+          },
+        });
+      }
+
+      return () => {
+        if (subscription !== undefined) {
+          subscription.unsubscribe();
+        }
+
+        delete inFlight[key];
+      };
+    }));
+  };
+};

--- a/src/modules/dedup-exchange.ts
+++ b/src/modules/dedup-exchange.ts
@@ -1,6 +1,6 @@
 import Observable from 'zen-observable-ts';
 
-import { IExchange } from '../interfaces/exchange';
+import { IExchange } from '../interfaces/index';
 
 // Wraps an exchange and deduplicates in-flight operations by their key
 export const dedupExchange = (forward: IExchange): IExchange => {

--- a/src/modules/dedup-exchange.ts
+++ b/src/modules/dedup-exchange.ts
@@ -14,6 +14,8 @@ export const dedupExchange = (forward: IExchange): IExchange => {
       return inFlight[key];
     }
 
+    const forwarded$ = forward(operation);
+
     // Keep around one subscription and collect observers for this observable
     const observers = [];
     let refCounter = 0;
@@ -25,10 +27,10 @@ export const dedupExchange = (forward: IExchange): IExchange => {
       observers.push(observer);
 
       if (subscription === undefined) {
-        subscription = forward(operation).subscribe({
+        subscription = forwarded$.subscribe({
           complete: () => {
-            observers.forEach(x => x.complete());
             delete inFlight[key];
+            observers.forEach(x => x.complete());
           },
           error: error => {
             observers.forEach(x => x.error(error));

--- a/src/modules/http-exchange.ts
+++ b/src/modules/http-exchange.ts
@@ -23,12 +23,8 @@ const createAbortController = () => {
   return new AbortController();
 };
 
-export const httpExchange = ({
-  url,
-}: {
-  url: string;
-}): IExchange => operation => {
-  const { fetchOptions } = operation.context;
+export const httpExchange = (): IExchange => operation => {
+  const { url, fetchOptions } = operation.context;
 
   const body = JSON.stringify({
     query: operation.query,

--- a/src/modules/http-exchange.ts
+++ b/src/modules/http-exchange.ts
@@ -1,6 +1,6 @@
 import Observable from 'zen-observable-ts';
 
-import { IExchange } from '../interfaces/exchange';
+import { IExchange } from '../interfaces/index';
 
 const checkStatus = (redirectMode: string = 'follow') => (
   response: Response
@@ -23,8 +23,12 @@ const createAbortController = () => {
   return new AbortController();
 };
 
-export const httpExchange: IExchange = operation => {
-  const { context } = operation;
+export const httpExchange = ({
+  url,
+}: {
+  url: string;
+}): IExchange => operation => {
+  const { fetchOptions } = operation.context;
 
   const body = JSON.stringify({
     query: operation.query,
@@ -34,13 +38,8 @@ export const httpExchange: IExchange = operation => {
   // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/AbortController
   const abortController = createAbortController();
 
-  const fetchOptions =
-    typeof context.fetchOptions === 'function'
-      ? context.fetchOptions()
-      : context.fetchOptions;
-
   return new Observable(observer => {
-    fetch(context.url, {
+    fetch(url, {
       body,
       headers: { 'Content-Type': 'application/json' },
       method: 'POST',
@@ -54,7 +53,8 @@ export const httpExchange: IExchange = operation => {
           observer.next(response);
           observer.complete();
         } else {
-          observer.error(new Error('No data'));
+          // TODO: Proper error handling
+          observer.error({ message: 'No data' });
         }
       })
       .catch(err => {

--- a/src/modules/http-exchange.ts
+++ b/src/modules/http-exchange.ts
@@ -1,0 +1,74 @@
+import Observable from 'zen-observable-ts';
+
+import { IExchange } from '../interfaces/exchange';
+
+const checkStatus = (redirectMode: string = 'follow') => (
+  response: Response
+) => {
+  // If using manual redirect mode, don't error on redirect!
+  const statusRangeEnd = redirectMode === 'manual' ? 400 : 300;
+  if (response.status >= 200 && response.status < statusRangeEnd) {
+    return response;
+  }
+  const err = new Error(response.statusText);
+  (err as any).response = response;
+  throw err;
+};
+
+const createAbortController = () => {
+  if (typeof AbortController === 'undefined') {
+    return { abort: null, signal: undefined };
+  }
+
+  return new AbortController();
+};
+
+export const httpExchange: IExchange = operation => {
+  const { context } = operation;
+
+  const body = JSON.stringify({
+    query: operation.query,
+    variables: operation.variables,
+  });
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/AbortController
+  const abortController = createAbortController();
+
+  const fetchOptions =
+    typeof context.fetchOptions === 'function'
+      ? context.fetchOptions()
+      : context.fetchOptions;
+
+  return new Observable(observer => {
+    fetch(context.url, {
+      body,
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      signal: abortController.signal,
+      ...fetchOptions,
+    })
+      .then(checkStatus(fetchOptions.redirect))
+      .then(res => res.json())
+      .then(response => {
+        if (response.data) {
+          observer.next(response);
+          observer.complete();
+        } else {
+          observer.error(new Error('No data'));
+        }
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') {
+          return;
+        }
+
+        observer.error(err);
+      });
+
+    return () => {
+      if (abortController.abort) {
+        abortController.abort();
+      }
+    };
+  });
+};

--- a/src/tests/components/client.test.tsx
+++ b/src/tests/components/client.test.tsx
@@ -519,12 +519,16 @@ describe('Client Component', () => {
       />
     );
 
-    client.getInstance().update(null, null, true);
-
+    // NOTE: Delay here waits for the fetch to flush and complete, since
+    // dedupExchange would deduplicate it otherwise
     setTimeout(() => {
-      expect(spy).toHaveBeenCalledTimes(2);
-      spy.mockRestore();
-      done();
+      client.getInstance().update(null, null, true);
+
+      setTimeout(() => {
+        expect(spy).toHaveBeenCalledTimes(2);
+        spy.mockRestore();
+        done();
+      }, 100);
     }, 100);
   });
 
@@ -566,12 +570,16 @@ describe('Client Component', () => {
       />
     );
 
-    client.getInstance().fetch();
-
+    // NOTE: Delay here waits for the fetch to flush and complete, since
+    // dedupExchange would deduplicate it otherwise
     setTimeout(() => {
-      expect((global as any).fetch).toHaveBeenCalledTimes(2);
-      done();
-    }, 0);
+      client.getInstance().fetch();
+
+      setTimeout(() => {
+        expect((global as any).fetch).toHaveBeenCalledTimes(2);
+        done();
+      }, 0);
+    }, 100);
   });
 
   it('should use shouldInvalidate if present', done => {

--- a/src/tests/modules/dedup-exchange.test.ts
+++ b/src/tests/modules/dedup-exchange.test.ts
@@ -1,0 +1,80 @@
+import Observable from 'zen-observable-ts';
+import { IExchange } from '../../interfaces/exchange';
+import { dedupExchange } from '../../modules/dedup-exchange';
+
+describe('dedupExchange', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('forwards operations and subscribes', done => {
+    let mockOp;
+
+    const mockExchange = operation =>
+      new Observable(observer => {
+        mockOp = operation;
+        observer.next(operation);
+        observer.complete();
+      });
+
+    const testExchange = dedupExchange(mockExchange);
+    const testOperation = { key: 'test' } as any;
+
+    testExchange(testOperation).subscribe({
+      complete: done,
+      next: op => {
+        expect(op).toBe(testOperation);
+        expect(mockOp).toBe(testOperation);
+      },
+    });
+  });
+
+  it('returns the same intermediate observable when called with same operation', () => {
+    const mockExchange = jest.fn() as IExchange;
+    const testExchange = dedupExchange(mockExchange);
+
+    const obsA = testExchange({ key: 'a' } as any);
+    expect(mockExchange).toHaveBeenLastCalledWith({ key: 'a' });
+    const obsB = testExchange({ key: 'a' } as any);
+    const obsC = testExchange({ key: 'b' } as any);
+    expect(mockExchange).toHaveBeenLastCalledWith({ key: 'b' });
+    expect(obsA).toBe(obsB);
+    expect(obsA).not.toBe(obsC);
+    expect(mockExchange).toHaveBeenCalledTimes(2);
+  });
+
+  it('deletes intermediate observable when in-flight operation completed', done => {
+    const mockExchange = () =>
+      new Observable(observer => {
+        observer.next(null);
+        observer.complete();
+      });
+
+    const testExchange = dedupExchange(mockExchange);
+    const obsA = testExchange({ key: 'a' } as any);
+
+    obsA.subscribe({
+      complete: () => {
+        const obsB = testExchange({ key: 'a' } as any);
+        expect(obsA).not.toBe(obsB);
+        done();
+      },
+    });
+  });
+
+  it('invokes unsubscribe when all subscribers on the intermediate observable unsubscribed', () => {
+    const mockUnsubscription = jest.fn();
+    const testExchange = dedupExchange(
+      () => new Observable(() => mockUnsubscription)
+    );
+    const obs = testExchange({ key: 'a' } as any);
+
+    const sub = obs.subscribe({});
+    obs.subscribe({}).unsubscribe();
+    expect(mockUnsubscription).toHaveBeenCalledTimes(0);
+    sub.unsubscribe();
+    expect(mockUnsubscription).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/setup.js
+++ b/src/tests/setup.js
@@ -1,5 +1,6 @@
 'use strict';
 
+global.AbortController = undefined;
 global.fetch = jest.fn();
 
 process.on('unhandledRejection', error => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6492,6 +6492,16 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
+zen-observable-ts@^0.8.9:
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz#d3c97af08c0afdca37ebcadf7cc3ee96bda9bab1"
+  dependencies:
+    zen-observable "^0.8.0"
+
 zen-observable@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.6.1.tgz#01dbed3bc8d02cbe9ee1112c83e04c807f647244"
+
+zen-observable@^0.8.0:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.8.tgz#1ea93995bf098754a58215a1e0a7309e5749ec42"


### PR DESCRIPTION
This PR is an initial draft/proposal to introduce "exchanges". It's a structure that will enable us to implement more features in the future and to clean up the existing logic. It's flexible enough to allow us to implement batching and even subscriptions cleanly.

On the **TypeScript** side it introduces some new interfaces:

- `IOperation` — This is an instruction for an "Exchange" to go talk to the GraphQL API
- `IExchange` — This is an "Exchange". It's a function that accepts an `IOperation` and returns an Observable of a GraphQL `ExecutionResult`

Effectively with just two new type "primitives" we can separate the fetch logic from the Client and clean everything up. This means that the Client now calls the exchange to actually start a request.

To demonstrate what this means I've implemented the `dedupExchange`. This is a first attempt at separating some concerns out of the client. We might even want the cache to be an exchange eventually? The `dedupExchange` looks at the operation's `key` (which is the `hash` that we had before) and only sends off a single request, i.e. passes the operation on only once.

As an experiment of what we might want to do with Observables I've added some request cancellation to the `httpExchange`. It's unused as currently we pass on `Promise`s to the components and not `Observable`s.

There might be a couple of details that I've left out here in the description, so just post comments with any concerns and questions please 😅 

Edit: @kenwheeler the `executeMutation` accepted an `IMutation` which is the component prop's type before. I suppose that was a mistake so I swapped it out with the `IQuery` :+1:

Also, their promises resolved to `object[]` quite often, which I guess should be `object`? I've also refactored more things to use `ExecutionResult` instead.