### PR TITLE
Fix cache not invalidating when a Client component isn't listening

### DIFF
--- a/src/modules/cache-exchange.ts
+++ b/src/modules/cache-exchange.ts
@@ -3,18 +3,41 @@ import Observable from 'zen-observable-ts';
 import { ICache, IExchange, IExchangeResult } from '../interfaces/index';
 import { gankTypeNamesFromResponse } from './typenames';
 
+interface ITypenameInvalidate {
+  [typeName: string]: string[];
+}
+
 // Wraps an exchange and refers/updates the cache according to operations
 export const cacheExchange = (cache: ICache, forward: IExchange): IExchange => {
+  const typenameInvalidate: ITypenameInvalidate = {};
+
   return operation => {
+    const { operationName, key } = operation;
+
     const withTypenames$ = forward(operation).map(
       (response: IExchangeResult) => {
         // Grab typenames from response data
         const typeNames = gankTypeNamesFromResponse(response.data);
+
+        // For mutations, invalidate the cache early so that unmounted Client components don't mount with
+        // stale, cached responses
+        if (operationName === 'mutation') {
+          typeNames.forEach(typename => {
+            const cacheKeys = typenameInvalidate[typename];
+            typenameInvalidate[typename] = [];
+            if (cacheKeys !== undefined) {
+              cacheKeys.forEach(cacheKey => {
+                cache.invalidate(cacheKey);
+              });
+            }
+          });
+        }
+
         return { ...response, typeNames };
       }
     );
 
-    const { operationName, key, context } = operation;
+    const { context } = operation;
     if (operationName !== 'query') {
       return withTypenames$;
     }
@@ -35,6 +58,13 @@ export const cacheExchange = (cache: ICache, forward: IExchange): IExchange => {
           complete: () => observer.complete(),
           error: err => observer.error(err),
           next: (response: IExchangeResult) => {
+            // Mark typenames on typenameInvalidate for early invalidation
+            response.typeNames.forEach(typename => {
+              const cacheKeys =
+                typenameInvalidate[typename] ||
+                (typenameInvalidate[typename] = []);
+              cacheKeys.push(key);
+            });
             // Store data in cache, using serialized query as key
             cache.write(key, response);
             // Return response with typeNames

--- a/src/tests/modules/cache-exchange.test.ts
+++ b/src/tests/modules/cache-exchange.test.ts
@@ -1,0 +1,128 @@
+import Observable from 'zen-observable-ts';
+import { IExchange, IOperation } from '../../interfaces/index';
+import { cacheExchange } from '../../modules/cache-exchange';
+import { defaultCache } from '../../modules/default-cache';
+
+const result = {
+  data: {
+    item: {
+      __typename: 'Item',
+      id: 'item',
+    },
+  },
+};
+
+describe('cacheExchange', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('attaches typeNames to a result', done => {
+    const cache = defaultCache({});
+    const forward: IExchange = () => Observable.of(result);
+    const exchange = cacheExchange(cache, forward);
+    const operation = ({ operationName: 'x' } as any) as IOperation;
+
+    exchange(operation).subscribe(res => {
+      expect(res.typeNames).toEqual(['Item']);
+      expect(res.data).toEqual(result.data);
+      done();
+    });
+  });
+
+  it('reads a query result from the passed cache first', done => {
+    const testkey = 'TESTKEY';
+    const cache = defaultCache({ [testkey]: result });
+    const forward: IExchange = () => Observable.of(undefined);
+    const exchange = cacheExchange(cache, forward);
+
+    const operation = ({
+      context: {},
+      key: testkey,
+      operationName: 'query',
+    } as any) as IOperation;
+
+    exchange(operation).subscribe(res => {
+      expect(res).toBe(result);
+      done();
+    });
+  });
+
+  it('skips the cache when skipCache is set on context', done => {
+    const testkey = 'TESTKEY';
+    const newResult = { ...result, test: true };
+    const cache = defaultCache({ [testkey]: result });
+    const forward: IExchange = () => Observable.of(newResult);
+    const exchange = cacheExchange(cache, forward);
+
+    const operation = ({
+      context: { skipCache: true },
+      key: testkey,
+      operationName: 'query',
+    } as any) as IOperation;
+
+    exchange(operation).subscribe(res => {
+      expect((res as any).test).toBe(true);
+      expect(res.typeNames).toEqual(['Item']);
+      done();
+    });
+  });
+
+  it('writes query results to the cache', done => {
+    const testkey = 'TESTKEY';
+    const store = {};
+    const cache = defaultCache(store);
+    const forward: IExchange = () => Observable.of(result);
+    const exchange = cacheExchange(cache, forward);
+
+    const operation = ({
+      context: {},
+      key: testkey,
+      operationName: 'query',
+    } as any) as IOperation;
+
+    expect(store[testkey]).toBeUndefined();
+
+    exchange(operation).subscribe(res => {
+      expect(res.data).toEqual(result.data);
+      expect(store[testkey]).not.toBeUndefined();
+      expect(store[testkey].data).toEqual(result.data);
+      done();
+    });
+  });
+
+  it('records typename invalidations and invalidates parts of the cache when a mutation comes in', done => {
+    const testkey = 'TESTKEY';
+    const store = { unrelated: true };
+    const cache = defaultCache(store);
+    const forward: IExchange = () => Observable.of(result);
+    const exchange = cacheExchange(cache, forward);
+
+    const operationA = ({
+      context: {},
+      key: testkey,
+      operationName: 'query',
+    } as any) as IOperation;
+
+    const operationB = ({
+      context: {},
+      key: 'anything',
+      operationName: 'mutation',
+    } as any) as IOperation;
+
+    exchange(operationA).subscribe(res => {
+      expect(store[testkey]).toBe(res);
+      expect(store.unrelated).toBe(true);
+      exchange(operationB).subscribe(() => {
+        // Disappears due to typename
+        expect(store[testkey]).toBeUndefined();
+        // Remains untouched
+        expect(store.unrelated).toBe(true);
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fix #58

Suppose a Client component fetches some data and is then unmounted, its
response will still remain cached. When a mutation is then performed
that invalidates its data, the component is not mounted to invalidate
this response itself. Instead it will render with the stale, cached
response.

To prevent this change introduces a secondary cache control. This
control keeps track of typenames as well in the cacheExchange. It maps
typenames to operation keys (which are also cache keys, woohoo!). When
a mutation then invalidates a couple of typenames in the cache, the
cacheExchange can go ahead and look up all cache keys that should be
invalidated, all while the Client component can stay unmounted.