### PR TITLE
Fix server example 'todo' query

### DIFF
--- a/example/src/server/schema.js
+++ b/example/src/server/schema.js
@@ -50,7 +50,7 @@ const resolvers = {
       return store.todos;
     },
     todo: (root, args, context) => {
-      return store.todos.find(a => a.id == args.id);
+      return store.todos.find(a => a.id === args.id);
     },
     user: (root, args, context) => {
       return store.user;

--- a/example/src/server/schema.js
+++ b/example/src/server/schema.js
@@ -50,7 +50,7 @@ const resolvers = {
       return store.todos;
     },
     todo: (root, args, context) => {
-      return store.todos.find(a => (a.id = args.id));
+      return store.todos.find(a => a.id == args.id);
     },
     user: (root, args, context) => {
       return store.user;


### PR DESCRIPTION
Found a single `=` instead of `==` in the example todo resolver.