### PR TITLE
Support injecting custom fetch() implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json.*
 bundles
 dist
 .rpt2_cache
+.DS_Store

--- a/src/interfaces/client-options.ts
+++ b/src/interfaces/client-options.ts
@@ -2,6 +2,7 @@ import { ICache } from './cache';
 
 export interface IClientOptions {
   url: string;
+  fetch?: (input?: Request | string, init?: RequestInit) => Promise<Response>;
   fetchOptions?: object | (() => object);
   cache?: ICache;
   initialCache?: object;

--- a/src/modules/client.ts
+++ b/src/modules/client.ts
@@ -74,7 +74,7 @@ export default class Client {
     }
 
     this.url = opts.url;
-    this.fetch = opts.fetch || fetch;
+    this.fetch = opts.fetch || fetch.bind(undefined);
     this.fetchOptions = opts.fetchOptions || {};
     this.store = opts.initialCache || {};
     this.cache = opts.cache || defaultCache(this.store);

--- a/src/modules/client.ts
+++ b/src/modules/client.ts
@@ -59,6 +59,7 @@ export const defaultCache = store => {
 export default class Client {
   url?: string; // Graphql API URL
   store: object; // Internal store
+  fetch: (input?: Request | string, init?: RequestInit) => Promise<Response>; // global or custom fetch implementation.
   fetchOptions: RequestInit | (() => RequestInit); // Options for fetch call
   subscriptions: object; // Map of subscribed Connect components
   cache: ICache; // Cache object
@@ -73,6 +74,7 @@ export default class Client {
     }
 
     this.url = opts.url;
+    this.fetch = opts.fetch || fetch;
     this.fetchOptions = opts.fetchOptions || {};
     this.store = opts.initialCache || {};
     this.cache = opts.cache || defaultCache(this.store);
@@ -145,7 +147,7 @@ export default class Client {
               ? this.fetchOptions()
               : this.fetchOptions;
           // Fetch data
-          fetch(this.url, {
+          this.fetch(this.url, {
             body,
             headers: { 'Content-Type': 'application/json' },
             method: 'POST',
@@ -191,7 +193,7 @@ export default class Client {
           ? this.fetchOptions()
           : this.fetchOptions;
       // Call mutation
-      fetch(this.url, {
+      this.fetch(this.url, {
         body,
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',

--- a/src/tests/modules/client.test.ts
+++ b/src/tests/modules/client.test.ts
@@ -37,6 +37,13 @@ describe('Client', () => {
     expect(client.fetchOptions).toMatchObject({ test: 5 });
   });
 
+  it('should set fetch to a function if not provided', () => {
+    const client = new Client({
+      url: 'test',
+    });
+    expect(typeof client.fetch).toBe('function');
+  });
+
   it('should set fetchOptions to an object if not provided', () => {
     const client = new Client({
       url: 'test',
@@ -190,6 +197,34 @@ describe('Client', () => {
 
   describe('executeQuery', () => {
     let client;
+
+    it('should use a custom fetch function if provided', done => {
+      const customFetch = jest.fn();
+      customFetch.mockReturnValue(
+        Promise.resolve({
+          status: 200,
+          json: () => ({ data: [{ id: 5 }] }),
+        })
+      );
+      client = new Client({
+        url: 'http://localhost:3000/graphql',
+        fetch: customFetch,
+      });
+
+      client
+        .executeQuery({
+          query: `{
+          todos {
+            id
+            name
+          }
+        }`,
+        })
+        .then(result => {
+          expect(result).toMatchObject({ data: [{ id: 5 }], typeNames: [] });
+          done();
+        });
+    });
 
     it('should return data if there is data', done => {
       client = new Client({


### PR DESCRIPTION
Hi! I needed to be able to use a custom transport for urql and this seems like the least intrusive way to add it. This PR adds an optional `fetch` field to `IClientOptions`, it defaults to the global `fetch()`. 

For my particular use case (running graphql in a webworker) it would actually be better to be able to inject a `makeRequest()` method that abstracts over fetch completely but that's a bigger change and would conflict with `fetchOptions` so I left it out.