### PR TITLE
Support additional IGraphQLError fields on rehydration

### DIFF
--- a/src/interfaces/error.ts
+++ b/src/interfaces/error.ts
@@ -1,3 +1,18 @@
-export interface IGraphQLError {
-  message?: string;
+export interface IGraphQLLocation {
+  line: number;
+  column: number;
+}
+
+export interface IGraphQLErrorInput {
+  message: string;
+  path?: Array<string | number>;
+  locations?: IGraphQLLocation[];
+  extensions?: { [key: string]: any };
+}
+
+export interface IGraphQLError extends Error {
+  message: string;
+  path?: Array<string | number>;
+  locations?: IGraphQLLocation[];
+  extensions?: { [key: string]: any };
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -4,7 +4,7 @@ export { IQuery } from './query';
 export { IClientOptions } from './client-options';
 export { ICache } from './cache';
 export { IExchange, IExchangeResult } from './exchange';
-export { IGraphQLError } from './error';
+export { IGraphQLError, IGraphQLErrorInput } from './error';
 export { ClientEventType, ClientEvent } from './events';
 export { IOperation } from './operation';
 export { ISubscriptionObserver, ISubscription } from './subscription';

--- a/src/modules/error.ts
+++ b/src/modules/error.ts
@@ -1,4 +1,4 @@
-import { IGraphQLError } from '../interfaces/index';
+import { IGraphQLError, IGraphQLErrorInput } from '../interfaces/index';
 
 const generateErrorMessage = (
   networkErr?: Error,
@@ -17,11 +17,17 @@ const generateErrorMessage = (
   return error.trim();
 };
 
-const rehydrateGraphQlError = (error: string | IGraphQLError): Error => {
+const rehydrateGraphQlError = (
+  error: string | IGraphQLError
+): IGraphQLError => {
   if (typeof error === 'string') {
     return new Error(error);
   } else if (error.message) {
-    return new Error(error.message);
+    const err: IGraphQLError = new Error(error.message);
+    err.path = error.path;
+    err.locations = error.locations;
+    err.extensions = error.extensions;
+    return err;
   } else {
     return error as any;
   }
@@ -34,7 +40,7 @@ export interface CombinedError extends Error {}
 export class CombinedError {
   public name: string;
   public message: string;
-  public graphQLErrors: Error[];
+  public graphQLErrors: IGraphQLError[];
   public networkError?: Error;
   public response?: any;
 
@@ -44,7 +50,7 @@ export class CombinedError {
     response,
   }: {
     networkError?: Error;
-    graphQLErrors?: Array<string | IGraphQLError>;
+    graphQLErrors?: Array<string | IGraphQLErrorInput | IGraphQLError>;
     response?: any;
   }) {
     this.name = 'CombinedError';

--- a/src/tests/modules/error.test.ts
+++ b/src/tests/modules/error.test.ts
@@ -51,6 +51,21 @@ describe('CombinedError', () => {
     expect(err.graphQLErrors).toEqual(graphQLErrors);
   });
 
+  it('rehydrates graphql errors from the server', () => {
+    const graphQLErrors = [
+      { message: 'Error Message A', extensions: {}, path: [], locations: [] },
+    ];
+
+    const err = new CombinedError({ graphQLErrors });
+    const gqlErr = err.graphQLErrors[0];
+
+    expect(gqlErr).toBeInstanceOf(Error);
+    expect(gqlErr.message).toBe(graphQLErrors[0].message);
+    expect(gqlErr.extensions).toBe(graphQLErrors[0].extensions);
+    expect(gqlErr.path).toBe(graphQLErrors[0].path);
+    expect(gqlErr.locations).toBe(graphQLErrors[0].locations);
+  });
+
   it('passes graphQLErrors through as a last resort', () => {
     const graphQLErrors = [{ x: 'y' }] as any;
     const err = new CombinedError({ graphQLErrors });


### PR DESCRIPTION
Fix #88

This rehydrates additional fields onto the errors in `CombinedError#graphQLErrors` and types them correctly as instances of `Error`