### PR TITLE
nit. use function default parameter

### DIFF
--- a/src/modules/query.ts
+++ b/src/modules/query.ts
@@ -1,7 +1,7 @@
-const query = (q: string, vars?: object) => {
+const query = (q: string, vars: object = {}) => {
   return {
     query: q,
-    variables: vars || {},
+    variables: vars,
   };
 };
 


### PR DESCRIPTION
This is very minor. Use default function parameter for vars argument. Feel free to reject if you think this is not needed.