### PR TITLE
Export formatTypeNames for SSR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,6 @@ export * from './modules/dedup-exchange';
 export * from './modules/error';
 export * from './modules/http-exchange';
 export * from './modules/subscription-exchange';
+export { formatTypeNames } from './modules/typenames';
 
 export * from './interfaces/index';


### PR DESCRIPTION
I have found a way to do SSR with after.js. See https://github.com/jaredpalmer/after.js/pull/153. Mainly it's powered by this function: 

```js
  static async getInitialProps({urql}) {
    if (urql) {
      const q = formatTypeNames(query(QUERY));
      return urql.executeQuery(q).then(props => {
        props.loaded = true;
        return props;
      });
    }
  }
```

So I need `formatTypeNames` for that otherwise the cache/store made server-side isn't using the same queries.

This way of doing SSR probably also works with [next.js](https://github.com/zeit/next.js) as after.js is modelled after that and next.js uses a similar `getInitialProps` method. 