### PR TITLE
Append typenames via visitor and graphql-ast-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
   "dependencies": {
     "create-react-context": "^0.1.3",
     "graphql": "^0.13.1",
+    "graphql-ast-types": "^1.0.2",
     "hoist-non-react-statics": "^2.5.0",
     "zen-observable-ts": "^0.8.9"
   },

--- a/src/components/client.tsx
+++ b/src/components/client.tsx
@@ -374,7 +374,7 @@ export default class UrqlClient extends Component<IClientProps, IClientState> {
       fetching: true,
     });
 
-    return new Promise<IExchangeResult['data']>((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       // Execute mutation
       client.executeMutation$(mutation).subscribe({
         error: e => {

--- a/src/interfaces/client.ts
+++ b/src/interfaces/client.ts
@@ -1,9 +1,9 @@
 import Observable from 'zen-observable-ts';
 
+import { IClientEvent } from '../modules/events';
 import { ICache } from './cache';
 import { IExchangeResult } from './exchange';
 import { IQuery } from './query';
-import { IClientEvent } from '../modules/events';
 
 export interface IClient {
   cache: ICache;

--- a/src/interfaces/client.ts
+++ b/src/interfaces/client.ts
@@ -2,7 +2,7 @@ import Observable from 'zen-observable-ts';
 
 import { IClientEvent } from '../modules/events';
 import { ICache } from './cache';
-import { IExchangeResult } from './exchange';
+import { IExchangeResult, IExecutionData } from './exchange';
 import { IQuery } from './query';
 
 export interface IClient {
@@ -16,8 +16,8 @@ export interface IClient {
     queryObject: IQuery,
     skipCache: boolean
   ): Promise<IExchangeResult>;
-  executeMutation$(mutationObject: IQuery): Observable<IExchangeResult['data']>;
-  executeMutation(mutationObject: IQuery): Promise<IExchangeResult['data']>;
+  executeMutation$(mutationObject: IQuery): Observable<IExecutionData>;
+  executeMutation(mutationObject: IQuery): Promise<IExecutionData>;
   invalidateQuery(queryObject: IQuery): Promise<void>;
   refreshAllFromCache(): void;
   subscribe(callback: (event: IClientEvent) => void): () => void;

--- a/src/interfaces/exchange.ts
+++ b/src/interfaces/exchange.ts
@@ -3,10 +3,17 @@ import Observable from 'zen-observable-ts';
 import { CombinedError } from '../modules/error';
 import { IOperation } from './operation';
 
+type Scalar = string | number | boolean;
+
+export interface IExecutionData {
+  __typename?: string;
+  [field: string]: IExecutionData | Scalar | Scalar[] | IExecutionData[];
+}
+
 // Adapted from: https://github.com/graphql/graphql-js/blob/ae5b163d2e6c124107fa0971f6d838c8a7d29f51/src/execution/execute.js#L105-L114<Paste>
 export interface IExecutionResult {
   errors?: Error[];
-  data?: object;
+  data?: IExecutionData;
 }
 
 export interface IExchangeResult {

--- a/src/interfaces/exchange.ts
+++ b/src/interfaces/exchange.ts
@@ -3,11 +3,11 @@ import Observable from 'zen-observable-ts';
 import { CombinedError } from '../modules/error';
 import { IOperation } from './operation';
 
-type Scalar = string | number | boolean;
+export type GqlScalar = string | number | boolean;
 
 export interface IExecutionData {
   __typename?: string;
-  [field: string]: IExecutionData | Scalar | Scalar[] | IExecutionData[];
+  [field: string]: IExecutionData | IExecutionData[] | GqlScalar | GqlScalar[];
 }
 
 // Adapted from: https://github.com/graphql/graphql-js/blob/ae5b163d2e6c124107fa0971f6d838c8a7d29f51/src/execution/execute.js#L105-L114<Paste>
@@ -17,7 +17,7 @@ export interface IExecutionResult {
 }
 
 export interface IExchangeResult {
-  data: IExecutionResult['data'];
+  data: IExecutionData;
   error?: CombinedError;
   typeNames?: string[];
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,7 +3,7 @@ export { IMutation } from './mutation';
 export { IQuery } from './query';
 export { IClientOptions } from './client-options';
 export { ICache } from './cache';
-export { IExchange, IExchangeResult } from './exchange';
+export { IExchange, IExecutionData, IExchangeResult } from './exchange';
 export { IGraphQLError, IGraphQLErrorInput } from './error';
 export { IOperation } from './operation';
 export { ISubscriptionObserver, ISubscription } from './subscription';

--- a/src/modules/client.ts
+++ b/src/modules/client.ts
@@ -168,7 +168,7 @@ export default class Client {
   }
 
   executeMutation(mutationObject: IQuery): Promise<IExchangeResult['data']> {
-    return new Promise<IExchangeResult>((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       this.executeMutation$(mutationObject).subscribe({
         error: reject,
         next: resolve,

--- a/src/modules/client.ts
+++ b/src/modules/client.ts
@@ -8,10 +8,10 @@ import {
   IQuery,
 } from '../interfaces';
 
-import { IClientEvent, ClientEventType } from './events';
 import { cacheExchange } from './cache-exchange';
 import { dedupExchange } from './dedup-exchange';
 import { defaultCache } from './default-cache';
+import { ClientEventType, IClientEvent } from './events';
 import { hashString } from './hash';
 import { httpExchange } from './http-exchange';
 

--- a/src/modules/typenames.ts
+++ b/src/modules/typenames.ts
@@ -3,6 +3,7 @@ import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql';
 import { visit } from 'graphql/language';
 import { parse } from 'graphql/language/parser';
 import { print } from 'graphql/language/printer';
+import { IExecutionData } from '../interfaces/exchange';
 
 import { field, isField, isOperationDefinition, name } from 'graphql-ast-types';
 import { IQuery } from '../interfaces/index';
@@ -36,21 +37,24 @@ export function formatTypeNames(query: IQuery) {
   };
 }
 
-export function gankTypeNamesFromResponse(response: object) {
+export function gankTypeNamesFromResponse(response: IExecutionData) {
   const typeNames = [];
   getTypeNameFromField(response, typeNames);
   return typeNames.filter((v, i, a) => a.indexOf(v) === i);
 }
 
-function getTypeNameFromField(obj: object, typenames: string[]) {
+function isObject(obj): obj is IExecutionData {
+  return obj && typeof obj === 'object';
+}
+
+function getTypeNameFromField(obj: IExecutionData, typenames: string[]) {
   Object.keys(obj).map(item => {
-    if (typeof obj[item] === 'object') {
-      if (obj[item] && '__typename' in obj[item]) {
-        typenames.push(obj[item].__typename);
+    const value = obj[item];
+    if (isObject(value)) {
+      if (value.__typename) {
+        typenames.push(value.__typename);
       }
-      if (obj[item]) {
-        getTypeNameFromField(obj[item], typenames);
-      }
+      getTypeNameFromField(value, typenames);
     }
   });
 }

--- a/src/modules/typenames.ts
+++ b/src/modules/typenames.ts
@@ -3,10 +3,9 @@ import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql';
 import { visit } from 'graphql/language';
 import { parse } from 'graphql/language/parser';
 import { print } from 'graphql/language/printer';
-import { IExecutionData } from '../interfaces/exchange';
 
 import { field, isField, isOperationDefinition, name } from 'graphql-ast-types';
-import { IQuery } from '../interfaces/index';
+import { IQuery, IExecutionData } from '../interfaces/index';
 
 const TYPENAME_FIELD: FieldNode = field(name('__typename'));
 

--- a/src/tests/modules/typenames.test.ts
+++ b/src/tests/modules/typenames.test.ts
@@ -17,6 +17,20 @@ describe('formatTypeNames', () => {
 }
 `);
   });
+
+  it('should not add duplicates typenames', () => {
+    let newQuery = formatTypeNames({
+      query: `{ todos { id __typename } }`,
+      variables: {},
+    });
+    expect(newQuery.query).toBe(`{
+  todos {
+    id
+    __typename
+  }
+}
+`);
+  });
 });
 
 describe('gankTypeNamesFromResponse', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,9 @@
     "exclude": ["src/tests/**/*", "example/**/*"]
   },
   "rules": {
+    "object-literal-sort-keys": false,
+    "member-ordering": false,
+    "ordered-imports": false,
     "member-access": false,
     "no-submodule-imports": false
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,6 +2862,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graphql-ast-types@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-ast-types/-/graphql-ast-types-1.0.2.tgz#49f2ae8f52be9ae426263f95320888f0cb772711"
+
 graphql-subscriptions@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-0.5.6.tgz#0d8e960fbaaf9ecbe7900366e86da2fc143fc5b2"


### PR DESCRIPTION
Updates the typenames utilities to use `graphql/language/visit` and `graphql-ast-types`