### PR TITLE
Use forEach in README's cache update example to match urql's internal caching mechanism.

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ const defaultCache = store => {
     update: callback =>
       new Promise(resolve => {
         if (typeof callback === 'function') {
-          Object.keys(store).map(key => {
+          Object.keys(store).forEach(key => {
             callback(store, key, store[key]);
           });
         }


### PR DESCRIPTION
The world's smolest diff! I just noticed this back while working on `reason-urql`'s support for custom caching. The README shows `urql`'s default cache using a `.map` to iterate over cache entries, but it actually (correctly) uses a `.forEach`: https://github.com/FormidableLabs/urql/blob/master/src/modules/client.ts#L45