### PR TITLE
Fix 103. Ensure that typeNames get retained and deduped in single query.

### DIFF
--- a/src/components/client.tsx
+++ b/src/components/client.tsx
@@ -191,7 +191,9 @@ export default class UrqlClient extends Component<IClientProps, IClientState> {
         .then(result => {
           // Store the typenames
           if (result.typeNames) {
-            this.typeNames = result.typeNames;
+            this.typeNames = [...this.typeNames, ...result.typeNames].filter(
+              (v, i, a) => a.indexOf(v) === i
+            );
           }
           // Update data
           this.setState({


### PR DESCRIPTION
This PR fixes issue #103.

![urql](https://user-images.githubusercontent.com/19421190/47946226-01ce7a80-dec6-11e8-8405-206e59f6bbf9.gif)

While there is an existing PR for this in #106, it attempts to fix the example rather than examining the source code itself. In looking at the source code, I noticed that `typeNames` for single queries were not getting properly retained. In the example, when the last todo is removed, the `Todo` `typeName` is getting removed from `this.typeNames`. So, when we attempt to add a new Todo after removing all of them, we hit this line: https://github.com/FormidableLabs/urql/blob/master/src/components/client.tsx#L154 to access `this.typeNames`, which no longer contains `Todo` as a `typeName`. Therefore, `invalidated` never gets set to `true` and the cached value of `todos` (an empty array) always gets returned.

This logic is already in place for multiple queries, so I'm wondering if there is a specific reason we did not set up single queries this way? The major idea is that we should retain all `typeNames` returned from the GraphQL server, whether or not the response contains values of that `typeName`, in order to handle no data situations like this. @kitten happy to write some tests for this as well, let me know if you'd like me to include them assuming the implementation looks good.