### PR TITLE
add typing for exchange (receiving type and returning type)

### DIFF
--- a/src/exchanges/cache.ts
+++ b/src/exchanges/cache.ts
@@ -4,7 +4,10 @@ import { formatTypeNames, gankTypeNamesFromResponse } from '../lib';
 import { Exchange, ExchangeResult, Operation } from '../types';
 
 /** A default exchange for caching GraphQL requests. */
-export const cacheExchange: Exchange = ({ forward, subject }) => {
+export const cacheExchange: Exchange<Operation, Operation> = ({
+  forward,
+  subject,
+}) => {
   const cache = new Map<string, ExchangeResult>();
   const cachedTypenames = new Map<string, Set<string>>();
 

--- a/src/exchanges/dedup.ts
+++ b/src/exchanges/dedup.ts
@@ -1,8 +1,8 @@
 import { filter, tap } from 'rxjs/operators';
-import { Exchange } from '../types';
+import { Exchange, Operation } from '../types';
 
 /** A default exchange for debouncing GraphQL requests. */
-export const dedupeExchange: Exchange = ({ forward }) => {
+export const dedupeExchange: Exchange<Operation, Operation> = ({ forward }) => {
   const inFlight = new Set<string>();
 
   return ops$ =>

--- a/src/exchanges/fetch.test.ts
+++ b/src/exchanges/fetch.test.ts
@@ -1,14 +1,9 @@
 import { of } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { fetchExchange } from './fetch';
-import { Exchange } from '../types';
 import { queryOperation, subscriptionOperation } from '../test-utils';
+import { fetchExchange } from './fetch';
 
 const fetch = (global as any).fetch as jest.Mock;
-
-beforeEach(() => {
-  fetch.mockClear();
-});
 
 const repsonse = {
   status: 200,
@@ -24,15 +19,19 @@ const args = {
   subject: {},
 } as any;
 
+beforeEach(() => {
+  fetch.mockClear();
+  args.forward.mockClear();
+});
+
 it('should return response data from fetch', async () => {
   fetch.mockResolvedValue({
     status: 200,
     json: jest.fn().mockResolvedValue(repsonse),
   });
 
-  const data = await fetchExchange(args)(of(queryOperation))
-    .pipe(take(1))
-    .toPromise();
+  fetchExchange(args)(of(queryOperation));
+  const data = await args.forward.mock.calls[0][0].pipe(take(1)).toPromise();
   expect(data).toMatchSnapshot();
 });
 
@@ -42,15 +41,15 @@ it('should return error data from fetch', async () => {
     json: jest.fn().mockResolvedValue(repsonse),
   });
 
-  const data = await fetchExchange(args)(of(queryOperation))
-    .pipe(take(1))
-    .toPromise();
+  fetchExchange(args)(of(queryOperation));
+  const data = await args.forward.mock.calls[0][0].pipe(take(1)).toPromise();
   expect(data).toMatchSnapshot();
 });
 
 it('should throw error when operationName is subscription', async () => {
   try {
-    await fetchExchange(args)(of(subscriptionOperation)).toPromise();
+    fetchExchange(args)(of(subscriptionOperation));
+    await args.forward.mock.calls[0][0].pipe(take(1)).toPromise();
     fail();
   } catch (err) {
     expect(err).toMatchSnapshot();

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -9,6 +9,7 @@ import {
   ClientOptions,
   CreateClientInstanceOpts,
   Exchange,
+  ExchangeData,
   ExchangeResult,
   Mutation,
   Operation,
@@ -140,12 +141,16 @@ export const createClient = (opts: ClientOptions): Client => {
 };
 
 /** Create pipe of exchanges */
-const pipeExchanges = (exchanges: Exchange[], subject?: Subject<Operation>) => (
-  operation: Observable<Operation>
-) => {
+const pipeExchanges = (
+  exchanges: Array<Exchange<ExchangeData, ExchangeData>>,
+  subject?: Subject<Operation>
+) => (operation: Observable<Operation>) => {
   /** Recursively pipe to each exchange */
-  const callExchanges = (value: Observable<Operation>, index: number = 0) => {
-    if (exchanges.length < index) {
+  const callExchanges = (
+    value: Observable<Operation | ExchangeResult>,
+    index: number = 0
+  ) => {
+    if (index >= exchanges.length) {
       return value;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,20 +23,27 @@ export interface Operation extends Query {
   context: Record<string, any>;
 }
 
+export type ExchangeData = Operation | ExchangeResult;
+
 /** Function responsible for listening for streamed [operations]{@link Operation}. */
-export type Exchange = (
+export type Exchange<
+  /** Exchange receiving type */
+  I extends ExchangeData,
+  /** Exchange returning type */
+  O extends ExchangeData
+> = (
   args: {
     /** Function to call the next [exchange]{@link Exchange} in the chain. */
-    forward: ExchangeIO;
+    forward: ExchangeIO<O>;
     /** Subject from which the stream of [operations]{@link Operation} is created. */
     subject: Subject<Operation>;
   }
-) => ExchangeIO;
+) => ExchangeIO<I>;
 
 /** Function responsible for receiving an observable [operation]{@link Operation} and returning a [result]{@link ExchangeResult}. */
-export type ExchangeIO = (
+export type ExchangeIO<T> = (
   /** A stream of operations. */
-  ops$: Observable<Operation>
+  ops$: Observable<T>
 ) => Observable<ExchangeResult>;
 
 /** Resulting data from an [operation]{@link Operation}. */
@@ -70,7 +77,7 @@ export interface ClientOptions {
   /** Any additional options to pass to fetch. */
   fetchOptions?: RequestInit | (() => RequestInit);
   /** An ordered array of Exchanges. */
-  exchanges?: Exchange[];
+  exchanges?: Array<Exchange<ExchangeData, ExchangeData>>;
 }
 
 /** The URQL applicaiton-wide client library. */


### PR DESCRIPTION
This change allows for exchanges to be implemented for use after the response stage. This could be useful for transforming data after a request has been received from the fetchExchange.

While exchanges can now be typed based on the Observable stream type they expect to receive and the Observable stream type they forward on, it is proving to be challenging to implement type-safety on an API level without introducing recursive data types.

The below example would be a valid sequence as the forwarded Observable type lines up with the receiving type of the next item.

```
[
  Exchange<Operator, Operator>,
  Exchange<Operator, ExchangeResponse>,
  Exchange<ExchangeResponse, ExchangeResponse>,
]
```

This next example however should throw an error due to the returning type of the second exchange conflicting with the returning type of the third.

```
[
  Exchange<Operator, Operator>,
  Exchange<Operator, Operator>,
  Exchange<ExchangeResponse, ExchangeResponse>,
]
```

The desired solutions (in order) would be one of:
 * Throw error at compile time - static typing.
 * Throw error at runtime when client is created. This would require the ability to differentiate types `Observable<X>` and `Observable<Y>` which is not possible with runtime/dynamic typing.