### PR TITLE
Fix back-to-front ternary in Connect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Example:
 <Connect
   query={query(MyQuery)}
   children={({loaded, data}) => {
-    return loaded ? <Loading/> : <List data={data.todos}>
+    return loaded ? <List data={data.todos}> : <Loading/>
   }}
 />
 


### PR DESCRIPTION
Hi folks, I noticed a back-to-front ternary while I was reading the docs, here's a fix for it 🙂 