### PR TITLE
V1 Hooks | Add experimental API for supporting hooks

### DIFF
--- a/cypress/integration/integration.spec.js
+++ b/cypress/integration/integration.spec.js
@@ -1,50 +1,54 @@
 const defaultStore = ['test', 'test2', 'test3'];
 
+const routes = { context: '/', hooks: '/hooks' };
+
 context('Integration', () => {
-  describe('on page load', () => {
+  Object.entries(routes).forEach(([type, path]) => {
     afterEach(() => {
-      cy.wait(100);
+      cy.get('#reset').click();
     });
 
-    it('executes/loads query', () => {
-      cy.visit('/');
-      cy.get('p').should('have.text', 'Loading...');
+    describe(`on page load (${type})`, () => {
+      it('executes/loads query', () => {
+        cy.visit(path);
+        cy.get('p').should('have.text', 'Loading...');
+      });
+
+      it('returns query data', () => {
+        cy.visit(path);
+        cy.get('ul > li').should('have.length', defaultStore.length);
+        cy.get('ul > li').each((li, i) =>
+          expect(li).to.have.text(`${defaultStore[i]} Remove`)
+        );
+      });
     });
 
-    it('returns query data', () => {
-      cy.visit('/');
-      cy.get('ul > li').should('have.length', defaultStore.length);
-      cy.get('ul > li').each((li, i) =>
-        expect(li).to.have.text(`${defaultStore[i]} Remove`)
-      );
-    });
-  });
+    describe(`on mutation (${type})`, () => {
+      it('updates list after addition', () => {
+        const newText = 'Hello Cypress!';
+        cy.visit(path);
 
-  describe('on mutation', () => {
-    it('updates list after deletion', () => {
-      cy.visit('/');
-      cy.get('ul > li')
-        .first()
-        .find('button')
-        .click();
+        // Add new todo
+        cy.get('.form input').type(newText);
+        cy.get('.form button').click();
 
-      cy.get('ul > li').should('have.length', defaultStore.length - 1);
-      cy.get('ul > li').each((li, i) =>
-        expect(li).to.have.text(`${defaultStore[i + 1]} Remove`)
-      );
-    });
+        cy.get('ul > li').should('have.length', defaultStore.length + 1);
+        cy.get('ul > li > span')
+          .last()
+          .should('have.text', newText);
+      });
 
-    it('updates list after addition', () => {
-      const newText = 'Hello Cypress!';
+      it('updates list after removal', () => {
+        cy.visit(path);
+        cy.get('ul > li button')
+          .first()
+          .click();
 
-      cy.visit('/');
-      cy.get('.form input').type(newText);
-      cy.get('.form button').click();
-
-      cy.get('ul > li').should('have.length', defaultStore.length);
-      cy.get('ul > li')
-        .last()
-        .should('have.text', `${newText} Remove`);
+        cy.get('ul > li').should('have.length', defaultStore.length - 1);
+        cy.get('ul > li').each((li, i) =>
+          expect(li).to.have.text(`${defaultStore[i + 1]} Remove`)
+        );
+      });
     });
   });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -14,4 +14,4 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-}
+};

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/example/src/app/connect.tsx
+++ b/example/src/app/connect.tsx
@@ -17,7 +17,7 @@ export interface ITodoMutations {
   removeTodo: (input: { id: string }) => void;
 }
 
-const Home: React.SFC<{}> = () => (
+const TodoApp: React.SFC<{ path: string }> = () => (
   <Connect
     query={createQuery(TodoQuery)}
     mutations={{
@@ -82,4 +82,4 @@ query {
 }
 `;
 
-export default Home;
+export default TodoApp;

--- a/example/src/app/connect.tsx
+++ b/example/src/app/connect.tsx
@@ -23,6 +23,7 @@ const TodoApp: React.SFC<{ path: string }> = () => (
     mutations={{
       addTodo: createMutation(AddTodo),
       removeTodo: createMutation(RemoveTodo),
+      reset: createMutation(Reset),
     }}
     children={({ data, error, mutations, fetching, refetch }) => {
       const content = fetching ? (
@@ -40,8 +41,11 @@ const TodoApp: React.SFC<{ path: string }> = () => (
           <button type="button" onClick={() => refetch()}>
             Refetch
           </button>
-          <button type="button" onClick={() => refetch(true)}>
+          <button id="refetch" type="button" onClick={() => refetch(true)}>
             Refetch (Skip Cache)
+          </button>
+          <button id="reset" type="button" onClick={() => mutations.reset({})}>
+            Reset Backend Store
           </button>
         </div>
       );
@@ -52,6 +56,15 @@ const TodoApp: React.SFC<{ path: string }> = () => (
 const Loading = () => <p>Loading...</p>;
 
 const Error = () => <p>Error!</p>;
+
+const Reset = `
+mutation {
+  reset {
+    id
+    text
+  }
+}
+`;
 
 const AddTodo = `
 mutation($text: String!) {

--- a/example/src/app/hooks.tsx
+++ b/example/src/app/hooks.tsx
@@ -14,6 +14,7 @@ const TodoApp: React.SFC<{ path: string }> = () => {
   const { data, loaded, refetch } = useQuery<{ todos: Todo[] }>(TodoQuery);
   const addTodo = useMutation<{ text: string }>(AddTodo);
   const removeTodo = useMutation<{ id: string }>(RemoveTodo);
+  const reset = useMutation<{}>(Reset);
 
   return (
     <div>
@@ -28,8 +29,15 @@ const TodoApp: React.SFC<{ path: string }> = () => {
       <button type="button" onClick={() => refetch({})}>
         Refetch
       </button>
-      <button type="button" onClick={refetch.bind(null, { skipCache: true })}>
+      <button
+        id="refetch"
+        type="button"
+        onClick={refetch.bind(null, { skipCache: true })}
+      >
         Refetch (Skip Cache)
+      </button>
+      <button id="reset" type="button" onClick={() => reset({})}>
+        Reset Backend Store
       </button>
     </div>
   );
@@ -38,6 +46,15 @@ const TodoApp: React.SFC<{ path: string }> = () => {
 const Loading = () => <p>Loading...</p>;
 
 const Error = () => <p>Error!</p>;
+
+const Reset = `
+mutation {
+  reset {
+    id
+    text
+  }
+}
+`;
 
 const AddTodo = `
 mutation($text: String!) {

--- a/example/src/app/hooks.tsx
+++ b/example/src/app/hooks.tsx
@@ -1,0 +1,71 @@
+/* tslint:disable */
+
+import * as React from 'react';
+import {
+  unstable_useQuery as useQuery,
+  unstable_useMutation as useMutation,
+} from '../../../src/index';
+import TodoList from './todo-list';
+import TodoForm from './todo-form';
+
+type Todo = { id: string; text: string };
+
+const TodoApp: React.SFC<{ path: string }> = () => {
+  const { data, loaded, refetch } = useQuery<{ todos: Todo[] }>(TodoQuery);
+  const addTodo = useMutation<{ text: string }>(AddTodo);
+  const removeTodo = useMutation<{ id: string }>(RemoveTodo);
+
+  return (
+    <div>
+      {!loaded ? (
+        <Loading />
+      ) : (
+        <TodoList todos={data.todos} removeTodo={removeTodo} />
+      )}
+
+      <TodoForm addTodo={addTodo} />
+
+      <button type="button" onClick={() => refetch({})}>
+        Refetch
+      </button>
+      <button type="button" onClick={refetch.bind(null, { skipCache: true })}>
+        Refetch (Skip Cache)
+      </button>
+    </div>
+  );
+};
+
+const Loading = () => <p>Loading...</p>;
+
+const Error = () => <p>Error!</p>;
+
+const AddTodo = `
+mutation($text: String!) {
+  addTodo(text: $text) {
+    id
+    text
+  }
+}
+`;
+
+const RemoveTodo = `
+mutation($id: ID!) {
+  removeTodo(id: $id) {
+    id
+  }
+}
+`;
+
+const TodoQuery = `
+query {
+  todos {
+    id
+    text
+  }
+  user {
+    name
+  }
+}
+`;
+
+export default TodoApp;

--- a/example/src/app/index.tsx
+++ b/example/src/app/index.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { Router } from '@reach/router';
 
 import { Provider, createClient } from '../../../src/index';
-import Home from './home';
+import ConnectTodoApp from './connect';
+import HooksTodoApp from './hooks';
 
 const client = createClient({
   url: 'http://localhost:3001/graphql',
@@ -10,7 +12,10 @@ const client = createClient({
 
 export const App: React.SFC<{}> = () => (
   <Provider client={client}>
-    <Home />
+    <Router>
+      <ConnectTodoApp path="/" />
+      <HooksTodoApp path="/hooks" />
+    </Router>
   </Provider>
 );
 

--- a/example/src/app/todo-form.tsx
+++ b/example/src/app/todo-form.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export interface TodoFormProps {
   addTodo: (input: { text: string }) => void;

--- a/example/src/app/todo-list.tsx
+++ b/example/src/app/todo-list.tsx
@@ -9,7 +9,7 @@ const TodoList: React.SFC<TodoListProps> = ({ todos, removeTodo }) => (
   <ul>
     {todos.map(todo => (
       <li key={todo.id}>
-        {todo.text}{' '}
+        <span>{todo.text}</span>{' '}
         <button type="button" onClick={() => removeTodo({ id: todo.id })}>
           Remove
         </button>

--- a/example/src/server/schema.js
+++ b/example/src/server/schema.js
@@ -2,6 +2,21 @@ const fetch = require('isomorphic-fetch');
 const { makeExecutableSchema } = require('graphql-tools');
 const uuid = require('uuid/v4');
 
+let initTodos = [
+  {
+    id: uuid(),
+    text: 'test',
+  },
+  {
+    id: uuid(),
+    text: 'test2',
+  },
+  {
+    id: uuid(),
+    text: 'test3',
+  },
+];
+
 const store = {
   todos: [
     {
@@ -33,6 +48,7 @@ const typeDefs = `
     addTodo(text: String!): Todo
     removeTodo(id: ID!): Todo
     editTodo(id: ID!, text: String!): Todo
+    reset: [Todo]
   }
   type Todo {
     id: ID,
@@ -77,6 +93,10 @@ const resolvers = {
         text,
         id,
       };
+    },
+    reset: () => {
+      store.todos = [...initTodos];
+      return store.todos;
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
-    "snapshotSerializers": ["enzyme-to-json/serializer"],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ],
     "testRegex": "(src/.*(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
@@ -64,6 +66,7 @@
     }
   ],
   "devDependencies": {
+    "@reach/router": "^1.2.1",
     "@types/enzyme": "^3.1.15",
     "@types/graphql": "^14.0.3",
     "@types/jest": "^23.3.9",
@@ -88,10 +91,10 @@
     "microbundle": "^0.7.0",
     "prettier": "^1.15.2",
     "prop-types": "^15.6.0",
-    "react": "^16.0.0-0",
+    "react": "^16.7.0-alpha",
     "react-addons-test-utils": "^15.6.2",
-    "react-dom": "^16.0.0-0",
-    "react-test-renderer": "^16.2.0",
+    "react-dom": "^16.7.0-alpha",
+    "react-test-renderer": "^16.7.0-alpha",
     "regenerator-runtime": "^0.11.1",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.10.5",

--- a/src/components/context.tsx
+++ b/src/components/context.tsx
@@ -2,20 +2,16 @@ import createReactContext, {
   ConsumerProps,
   ProviderProps,
 } from 'create-react-context';
-import { ComponentClass } from 'react';
+// @ts-ignore
+import { ComponentClass, Context } from 'react';
 
-const context = createReactContext({});
+const Context = createReactContext({});
 
-// TypeScript is very pedantic about re-exporting dependencies when doing
-// --declaration emit, so we need to import ComponentClass. But if we don't
-// explicitly use ComponentClass somewhere in the code, TypeScript *also*
-// ends up issuing an error. This is dumb, but this all gets erased anyway.
-interface Context {
-  Provider: ComponentClass<ProviderProps<{}>>;
-  Consumer: ComponentClass<ConsumerProps<{}>>;
-}
+export const context = (Context as any) as Context<{}>;
 
-export const {
-  Provider: ContextProvider,
-  Consumer: ContextConsumer,
-}: Context = context;
+export const ContextConsumer = Context.Consumer as ComponentClass<
+  ConsumerProps<{}>
+>;
+export const ContextProvider = Context.Provider as ComponentClass<
+  ProviderProps<{}>
+>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export { Connect, ConnectHOC, Provider } from './components';
+export { useQuery as unstable_useQuery } from './lib/hook-query';
+export { useMutation as unstable_useMutation } from './lib/hook-mutation';
 export {
   CombinedError,
   createQuery,

--- a/src/lib/hook-mutation.test.tsx
+++ b/src/lib/hook-mutation.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { useMutation } from './hook-mutation';
+import { ContextProvider } from '../components/context';
+
+const executeMutation = jest.fn();
+
+const client = {
+  createInstance: () => ({
+    executeMutation,
+  }),
+};
+
+describe('useMutation', () => {
+  const query = `foobar`;
+
+  it('returns a promise with the mutation resolution', () => {
+    const Component = () => {
+      const mutation = useMutation(query);
+
+      return <div onClick={() => mutation({})} />;
+    };
+
+    const wrapper = mount(
+      <div>
+        <ContextProvider value={client}>
+          <Component />
+        </ContextProvider>
+      </div>
+    );
+
+    wrapper.find('[onClick]').simulate('click');
+
+    expect(executeMutation).toBeCalledWith(
+      expect.objectContaining({
+        query,
+      })
+    );
+  });
+
+  it('takes variables as part of the hook definition and/or the callsite', () => {
+    const Component = () => {
+      const mutation = useMutation(query, { arg1: true });
+
+      return <div onClick={() => mutation({ arg2: true })} />;
+    };
+
+    const wrapper = mount(
+      <div>
+        <ContextProvider value={client}>
+          <Component />
+        </ContextProvider>
+      </div>
+    );
+
+    wrapper.find('[onClick]').simulate('click');
+
+    expect(executeMutation).toBeCalledWith(
+      expect.objectContaining({
+        variables: {
+          arg1: true,
+          arg2: true,
+        },
+      })
+    );
+  });
+});

--- a/src/lib/hook-mutation.ts
+++ b/src/lib/hook-mutation.ts
@@ -1,0 +1,33 @@
+// @ts-ignore
+import { useContext, useEffect, useState } from 'react';
+import { context } from '../components/context';
+import { Client, ExchangeResult, MutationHook } from '../types';
+
+export function useMutation<Args>(
+  mutationQuery: string,
+  passedVars: object = {}
+): MutationHook<Args> {
+  const client = (useContext(context) as any) as Client;
+
+  return variables =>
+    new Promise((resolve, reject) => {
+      const inst = client.createInstance({
+        onChange: result => {
+          if (result.error) {
+            reject(result.error);
+            return;
+          }
+
+          resolve(result);
+        },
+      });
+
+      inst.executeMutation({
+        query: mutationQuery,
+        variables: {
+          ...passedVars,
+          ...((variables as any) as object),
+        },
+      });
+    });
+}

--- a/src/lib/hook-mutation.ts
+++ b/src/lib/hook-mutation.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { context } from '../components/context';
-import { Client, ExchangeResult, MutationHook } from '../types';
+import { Client, MutationHook } from '../types';
 
 export function useMutation<Args>(
   mutationQuery: string,

--- a/src/lib/hook-query.test.tsx
+++ b/src/lib/hook-query.test.tsx
@@ -1,0 +1,3 @@
+describe('useQuery', () => {
+  it('Testing useQuery is not yet supported with testing environments', () => {});
+});

--- a/src/lib/hook-query.ts
+++ b/src/lib/hook-query.ts
@@ -1,0 +1,70 @@
+// @ts-ignore
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { context } from '../components/context';
+import { CombinedError } from '../lib';
+import {
+  Client,
+  ExchangeResult,
+  HookFetchOptions,
+  QueryHook,
+  QueryHookOpts,
+} from '../types';
+
+const DEFAULT_RESPONSE = {
+  fetching: true,
+  error: null,
+  data: null,
+  loaded: false,
+};
+
+interface Response<Data> {
+  fetching: boolean;
+  error?: Error | CombinedError;
+  data?: Data;
+  loaded: boolean;
+}
+
+type ResponseState<Data> = [Response<Data>, (response: Response<Data>) => void];
+
+// return state of a query fetch
+export function useQuery<Data>(
+  query: string,
+  { variables }: QueryHookOpts = {}
+): QueryHook<Data> {
+  const COMPARISON = [query, variables];
+
+  const client = (useContext(context) as any) as Client;
+
+  const [response, setResponse] = useState(DEFAULT_RESPONSE) as ResponseState<
+    Data
+  >;
+
+  // These are bound to unsubscribe functions to be used in the callback of useEffect
+  // during the unmounting phase.
+  let clientInstance;
+
+  const fetch = useCallback((options: HookFetchOptions = {}) => {
+    clientInstance = client.createInstance({
+      onChange: stream => {
+        setResponse({
+          ...stream,
+          loaded: stream.fetching === false,
+        });
+      },
+    });
+
+    clientInstance.executeQuery({ query, variables }, !!options.skipCache);
+  }, COMPARISON);
+
+  useEffect(() => {
+    fetch();
+
+    return () => {
+      if (clientInstance) {
+        clientInstance.unsubscribe();
+      }
+    };
+  }, COMPARISON);
+
+  return { ...response, refetch: fetch };
+}

--- a/src/lib/hook-query.ts
+++ b/src/lib/hook-query.ts
@@ -1,14 +1,8 @@
 // @ts-ignore
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { context } from '../components/context';
 import { CombinedError } from '../lib';
-import {
-  Client,
-  ExchangeResult,
-  HookFetchOptions,
-  QueryHook,
-  QueryHookOpts,
-} from '../types';
+import { Client, HookFetchOptions, QueryHook } from '../types';
 
 const DEFAULT_RESPONSE = {
   fetching: true,
@@ -29,7 +23,7 @@ type ResponseState<Data> = [Response<Data>, (response: Response<Data>) => void];
 // return state of a query fetch
 export function useQuery<Data>(
   query: string,
-  { variables }: QueryHookOpts = {}
+  variables: object = {}
 ): QueryHook<Data> {
   const COMPARISON = [query, variables];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,3 +125,28 @@ export interface Operation extends Query {
   /** Additional request-related information. */
   context: Record<string, any>;
 }
+
+export interface HookFetchOptions {
+  skipCache?: boolean;
+}
+
+export interface QueryHookOpts {
+  variables?: object;
+}
+
+export interface QueryHook<Data> {
+  data?: Data;
+  loaded: boolean;
+  error?: Error | CombinedError;
+  fetching: boolean;
+  refetch(options: HookFetchOptions): void;
+}
+
+export interface SubscriptionHook<Data> {
+  data: Data;
+  loaded: boolean;
+  error: Error | null;
+  fetching: boolean;
+}
+
+export type MutationHook<Args> = (data: Args) => Promise<StreamUpdate>; // TODO

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,10 +130,6 @@ export interface HookFetchOptions {
   skipCache?: boolean;
 }
 
-export interface QueryHookOpts {
-  variables?: object;
-}
-
 export interface QueryHook<Data> {
   data?: Data;
   loaded: boolean;
@@ -149,4 +145,4 @@ export interface SubscriptionHook<Data> {
   fetching: boolean;
 }
 
-export type MutationHook<Args> = (data: Args) => Promise<StreamUpdate>; // TODO
+export type MutationHook<Args> = (data?: Args) => Promise<StreamUpdate>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,17 @@
     log-update "^2.3.0"
     strip-ansi "^3.0.1"
 
+"@reach/router@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
+  integrity sha512-kTaX08X4g27tzIFQGRukaHmNbtMYDS3LEWIS8+l6OayGIw6Oyo1HIF/JzeuR2FoF9z6oV+x/wJSVSq4v8tcUGQ==
+  dependencies:
+    create-react-context "^0.2.1"
+    invariant "^2.2.3"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+    warning "^3.0.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -1757,7 +1768,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@^0.2.3:
+create-react-context@^0.2.1, create-react-context@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
   integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
@@ -2486,6 +2497,13 @@ enzyme-adapter-utils@^1.9.0:
     object.assign "^4.1.0"
     prop-types "^15.6.2"
     semver "^5.6.0"
+
+enzyme-to-json@^3.3.5:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz#f8eb82bd3d5941c9d8bc6fd9140030777d17d0af"
+  integrity sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==
+  dependencies:
+    lodash "^4.17.4"
 
 enzyme@^3.7.0:
   version "3.7.0"
@@ -3830,7 +3848,7 @@ interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
   integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
 
-invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -7035,7 +7053,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
@@ -7233,22 +7251,32 @@ react-addons-test-utils@^15.6.2:
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
   integrity sha1-wStu/cIkfBDae4dw0YUICnsEcVY=
 
-react-dom@^16.0.0-0:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
-  integrity sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==
+react-dom@^16.7.0-alpha:
+  version "16.7.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0-alpha.2.tgz#16632880ed43676315991d8b412cce6975a30282"
+  integrity sha512-o0mMw8jBlwHjGZEy/vvKd/6giAX0+skREMOTs3/QHmgi+yAhUClp4My4Z9lsKy3SXV+03uPdm1l/QM7NTcGuMw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.2"
+    scheduler "^0.12.0-alpha.2"
 
 react-is@^16.6.1, react-is@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
   integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
-react-test-renderer@^16.0.0-0, react-test-renderer@^16.2.0:
+react-is@^16.7.0-alpha.2:
+  version "16.7.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0-alpha.2.tgz#0dd7f95d45ad5318b7f7bcb99dcb84da9385cb57"
+  integrity sha512-1Q3qN8nMWUfFcRz/bBC1f9zSL3il9OcSxMd9CNnpJbeFf4VCX0qYxL3TuwT4f+tFk1TkidwIL11yYgk4HjldYg==
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-test-renderer@^16.0.0-0:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.6.3.tgz#5f3a1a7d5c3379d46f7052b848b4b72e47c89f38"
   integrity sha512-B5bCer+qymrQz/wN03lT0LppbZUDRq6AMfzMKrovzkGzfO81a9T+PWQW6MzkWknbwODQH/qpJno/yFQLX5IWrQ==
@@ -7258,15 +7286,25 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.2.0:
     react-is "^16.6.3"
     scheduler "^0.11.2"
 
-react@^16.0.0-0:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
-  integrity sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==
+react-test-renderer@^16.7.0-alpha:
+  version "16.7.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.7.0-alpha.2.tgz#8606a5a82240c405539da0401d7b3572898b5611"
+  integrity sha512-taA9MrHMi7hEM/cKgvcvht+9cszhPirCaSP99yxkVQ2JwQxYSltGYq2gFf/UQBqGJMgmgEghN62rxziaL1EK+A==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.7.0-alpha.2"
+    scheduler "^0.12.0-alpha.2"
+
+react@^16.7.0-alpha:
+  version "16.7.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0-alpha.2.tgz#924f2ae843a46ea82d104a8def7a599fbf2c78ce"
+  integrity sha512-Xh1CC8KkqIojhC+LFXd21jxlVtzoVYdGnQAi/I2+dxbmos9ghbx5TQf9/nDxc4WxaFfUQJkya0w1k6rMeyIaxQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.2"
+    scheduler "^0.12.0-alpha.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -7831,6 +7869,14 @@ scheduler@^0.11.2:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
   integrity sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.12.0-alpha.2:
+  version "0.12.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0-alpha.3.tgz#59afcaba1cb79e3e8bee91de94eb8f42c9152c2b"
+  integrity sha512-KADuBlOWSrT/DCt/oA+NgsNamRCsfz7wj+leaeGjGHipNClsqhjOPogKkJgem6WLAv/QzxW8bE7zlGc9OxiYSQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -9032,6 +9078,13 @@ walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.18.0:
   version "0.18.0"


### PR DESCRIPTION
_This branch is a rewrite of #156 in the v1 architecture._

This PR is an experiment in adding an API to support React 16.7 hooks. It is currently exported as `unstable_` in case anything with the spec changes between the alpha and the release.

The new APIs are as follows:

```js
// useQuery returns an object of network lifecycle values and methods
const { loading, fetching, data, error, refetch } = useQuery(`{ todos { id } }`);

// useMutation returns a function which casts a mutation and returns a promise of the results 
const addTodo = useMutation(`mutation($text: string) { addTodo(text: $text) { id, text } }`, optionalArgs);
```
     
Things todo in order to ship this feature:

- [ ] decide if this API design is desirable. A potentially controversial aspect is not needing to wrap strings in query/mutation calls.
- [ ] decide if we want to ship this early under the `unstable_` flag or wait until react 16.7 ships
- [ ] decide if we want to merge this as part of v1 or pre-v1.
- [ ] add integration tests with cypress
- [ ] support subscriptions. v1 currently doesn't have any support for subscriptions.