### PR TITLE
Add requestPolicy to manage cache strategy

### DIFF
--- a/examples/1-getting-started/src/app/Home.tsx
+++ b/examples/1-getting-started/src/app/Home.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useQuery } from 'urql';
 import { Error, Loading, Todo } from './components';
 
@@ -11,6 +11,10 @@ interface QueryResponse {
 
 export const Home: FC = () => {
   const [query, executeQuery] = useQuery<QueryResponse>({ query: TodoQuery });
+  const refetch = useCallback(
+    () => executeQuery({ requestPolicy: 'network-only' }),
+    []
+  );
 
   const getContent = () => {
     if (query.fetching || query.data === undefined) {
@@ -33,7 +37,7 @@ export const Home: FC = () => {
   return (
     <>
       {getContent()}
-      <button onClick={executeQuery}>Refetch</button>
+      <button onClick={refetch}>Refetch</button>
     </>
   );
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,6 +92,7 @@ export class Client {
     opts?: Partial<OperationContext>
   ): OperationContext => ({
     url: this.url,
+    requestPolicy: 'cache-first',
     fetchOptions: this.fetchOptions,
     ...opts,
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -90,12 +90,16 @@ export class Client {
 
   private createOperationContext = (
     opts?: Partial<OperationContext>
-  ): OperationContext => ({
-    url: this.url,
-    requestPolicy: 'cache-first',
-    fetchOptions: this.fetchOptions,
-    ...opts,
-  });
+  ): OperationContext => {
+    const { requestPolicy = 'cache-first' } = opts || {};
+
+    return {
+      url: this.url,
+      fetchOptions: this.fetchOptions,
+      ...opts,
+      requestPolicy,
+    };
+  };
 
   private createRequestOperation = (
     type: OperationType,

--- a/src/components/Query.tsx
+++ b/src/components/Query.tsx
@@ -2,7 +2,7 @@ import React, { Component, FC, ReactNode } from 'react';
 import { pipe, subscribe } from 'wonka';
 import { Client } from '../client';
 import { Consumer } from '../context';
-import { RequestPolicy } from '../types';
+import { OperationContext, RequestPolicy } from '../types';
 import { CombinedError, createQuery, noop } from '../utils';
 
 interface QueryHandlerProps {
@@ -17,39 +17,13 @@ interface QueryHandlerState {
   fetching: boolean;
   data?: any;
   error?: CombinedError;
+  executeQuery: (opts?: Partial<OperationContext>) => void;
 }
 
 class QueryHandler extends Component<QueryHandlerProps, QueryHandlerState> {
   private unsubscribe = noop;
 
-  public state = {
-    fetching: false,
-  };
-
-  public componentDidMount() {
-    this.executeQuery();
-  }
-
-  public componentDidUpdate(oldProps) {
-    if (
-      this.props.query === oldProps.query &&
-      this.props.variables === oldProps.variables
-    ) {
-      return;
-    }
-
-    this.executeQuery();
-  }
-
-  public componentWillUnmount() {
-    this.unsubscribe();
-  }
-
-  public render() {
-    return this.props.children(this.state);
-  }
-
-  private executeQuery() {
+  executeQuery = () => {
     if (this.unsubscribe !== undefined) {
       this.unsubscribe();
     }
@@ -78,6 +52,34 @@ class QueryHandler extends Component<QueryHandlerProps, QueryHandlerState> {
     );
 
     this.unsubscribe = teardown;
+  };
+
+  state = {
+    executeQuery: this.executeQuery,
+    fetching: false,
+  };
+
+  componentDidMount() {
+    this.executeQuery();
+  }
+
+  componentDidUpdate(oldProps) {
+    if (
+      this.props.query === oldProps.query &&
+      this.props.variables === oldProps.variables
+    ) {
+      return;
+    }
+
+    this.executeQuery();
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe();
+  }
+
+  render() {
+    return this.props.children(this.state);
   }
 }
 

--- a/src/components/__snapshots__/Query.test.tsx.snap
+++ b/src/components/__snapshots__/Query.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`on init default values match snapshot 1`] = `
 Object {
   "data": 1234,
   "error": undefined,
+  "executeQuery": [Function],
   "fetching": false,
 }
 `;

--- a/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -18,6 +18,7 @@ Object {
       "fetchOptions": Object {
         "method": "POST",
       },
+      "requestPolicy": "cache-first",
       "url": "http://localhost:3000/graphql",
     },
     "key": "2",
@@ -49,6 +50,7 @@ Object {
       "fetchOptions": Object {
         "method": "POST",
       },
+      "requestPolicy": "cache-first",
       "url": "http://localhost:3000/graphql",
     },
     "key": "2",

--- a/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -9,6 +9,7 @@ Object {
       "fetchOptions": Object {
         "method": "POST",
       },
+      "requestPolicy": "cache-first",
       "url": "http://localhost:3000/graphql",
     },
     "key": "{\\"query\\":\\"subscription subscribeToUser($user: String){\\\\n    user(user: $user) {\\\\n      name\\\\n    }\\\\n  }\\\\n  \\",\\"variables\\":{\\"user\\":\\"colin\\"}}",

--- a/src/hooks/useQuery.test.tsx
+++ b/src/hooks/useQuery.test.tsx
@@ -68,7 +68,9 @@ describe('on initial useEffect', () => {
 
   it('passes query and vars to executeQuery', () => {
     renderer.create(<QueryUser {...props} />);
-    expect(client.executeQuery).toBeCalledWith(props);
+    expect(client.executeQuery).toBeCalledWith(props, {
+      requestPolicy: undefined,
+    });
   });
 });
 

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -37,7 +37,10 @@ export const useQuery = <T = any>(args: UseQueryArgs): UseQueryResponse<T> => {
 
     const request = createQuery(args.query, args.variables);
     const [teardown] = pipe(
-      client.executeQuery(request, opts),
+      client.executeQuery(request, {
+        requestPolicy: args.requestPolicy,
+        ...opts,
+      }),
       subscribe(({ data, error }) => setState({ fetching: false, data, error }))
     );
 
@@ -45,7 +48,7 @@ export const useQuery = <T = any>(args: UseQueryArgs): UseQueryResponse<T> => {
   };
 
   useEffect(() => {
-    executeQuery({ requestPolicy: args.requestPolicy });
+    executeQuery();
     return unsubscribe;
   }, [args.query, args.variables]);
 

--- a/src/test-utils/samples.ts
+++ b/src/test-utils/samples.ts
@@ -4,13 +4,15 @@ import {
   GraphqlQuery,
   GraphqlSubscription,
   Operation,
+  OperationContext,
   OperationResult,
 } from '../types';
 
-const context = {
+const context: OperationContext = {
   fetchOptions: {
     method: 'POST',
   },
+  requestPolicy: 'cache-first',
   url: 'http://localhost:3000/graphql',
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,13 @@ export { ExecutionResult } from 'graphql';
 /** The type of GraphQL operation being executed. */
 export type OperationType = 'subscription' | 'query' | 'mutation' | 'teardown';
 
+/** The strategy that is used to request results from network and/or the cache. */
+export type RequestPolicy =
+  | 'cache-first'
+  | 'cache-only'
+  | 'network-only'
+  | 'cache-and-network';
+
 /** A Graphql query, mutation, or subscription. */
 export interface GraphQLRequest {
   query: string;
@@ -21,6 +28,7 @@ export type GraphqlSubscription = GraphQLRequest;
 export interface OperationContext {
   [key: string]: any;
   fetchOptions?: RequestInit;
+  requestPolicy: RequestPolicy;
   url: string;
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,7 @@ export { CombinedError } from './error';
 export { hashString } from './hash';
 export { createQuery, createMutation, createSubscription } from './query';
 export { formatTypeNames, gankTypeNamesFromResponse } from './typenames';
+
+export const noop = () => {
+  /* noop */
+};


### PR DESCRIPTION
This adds `requestPolicy` as a property on operation contexts. It has four modes, like in Apollo:

- `cache-first`: The default. It skips the network request (i.e. the other exchanges) when a result can be retrieved from the cache.
- `cache-only`: It returns an empty result when the data is not cached but also skips the network request. (With a normalised cache this would return a partial result if possible)
- `network-only`: This skips the cache entirely and forwards the request on to the other exchanges.
- `cache-and-network`: If data is cached it is first returned but another operation is then triggered using `network-only`, effectively using the cache and then updating it.

This can now be used as a prop on `useQuery`:

```js
const [res, executeQuery] = useQuery({ /* ... */ requestPolicy: 'network-only' });
```

But it can also be used to replace our clunky `refetch` that hasn't been reimplemented yet:

```js
const [res, executeQuery] = useQuery({ /* ... */ });
/* ... */
executeQuery({ requestPolicy: 'network-only' })
```

It can also be used on the `<Query>` component which now also has an `executeQuery` method
on the render prop arguments.