### PR TITLE
Proposal: Rename query in example docs and example projects from query to res.

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -264,15 +264,15 @@ const handleSubscription = (messages = [], response) => {
 };
 
 const Messages = () => {
-  const [result] = useSubscription({ query: newMessages }, handleSubscription);
+  const [res] = useSubscription({ query: newMessages }, handleSubscription);
 
-  if (!result.data) {
+  if (!res.data) {
     return <p>No new messages</p>;
   }
 
   return (
     <ul>
-      {result.data.map(message => (
+      {res.data.map(message => (
         <p key={message.id}>
           {message.from}: "{message.text}"
         </p>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,20 +131,20 @@ const getTodos = `
 `;
 
 const TodoList = ({ limit = 10 }) => {
-  const [query] = useQuery({
+  const [res] = useQuery({
     query: getTodos,
     variables: { limit },
   });
 
-  if (query.fetching) {
+  if (res.fetching) {
     return 'Loading...';
-  } else if (query.error) {
+  } else if (res.error) {
     return 'Oh no!';
   }
 
   return (
     <ul>
-      {query.data.todos.map(({ id, text }) => (
+      {res.data.todos.map(({ id, text }) => (
         <li key={id}>{text}</li>
       ))}
     </ul>
@@ -317,9 +317,9 @@ const addTodo = `
 `;
 
 const TodoForm = () => {
-  const [result, executeMutation] = useMutation(addTodo);
+  const [res, executeMutation] = useMutation(addTodo);
 
-  if (result.error) {
+  if (res.error) {
     return 'Oh no!';
   }
 
@@ -444,19 +444,19 @@ const getTodos = `
 `;
 
 const TodoList = ({ limit = 10 }) => {
-  const [query, executeQuery] = useQuery({ 
+  const [res, executeQuery] = useQuery({
     query: getTodos,
     variables: { limit }
   });
 
-  if (!query.data) {
+  if (!res.data) {
     return null;
   }
 
   return (
     <div>
       <ul>
-        {query.data.todos.map(({ id, text }) => (
+        {res.data.todos.map(({ id, text }) => (
           <li key={id}>{text}</li>
         ))}
       </ul>

--- a/examples/1-getting-started/src/app/Home.tsx
+++ b/examples/1-getting-started/src/app/Home.tsx
@@ -11,24 +11,24 @@ interface QueryResponse {
 }
 
 export const Home: FC = () => {
-  const [query, executeQuery] = useQuery<QueryResponse>({ query: TodoQuery });
+  const [res, executeQuery] = useQuery<QueryResponse>({ query: TodoQuery });
   const refetch = useCallback(
     () => executeQuery({ requestPolicy: 'network-only' }),
     []
   );
 
   const getContent = () => {
-    if (query.fetching || query.data === undefined) {
+    if (res.fetching || res.data === undefined) {
       return <Loading />;
     }
 
-    if (query.error) {
-      return <Error>{query.error.message}</Error>;
+    if (res.error) {
+      return <Error>{res.error.message}</Error>;
     }
 
     return (
       <ul>
-        {query.data.todos.map(todo => (
+        {res.data.todos.map(todo => (
           <Todo key={todo.id} {...todo} />
         ))}
       </ul>

--- a/examples/2-using-subscriptions/src/app/Messages.tsx
+++ b/examples/2-using-subscriptions/src/app/Messages.tsx
@@ -9,22 +9,22 @@ export const Messages: FC = () => {
     response: MessageResponse
   ) => [response.newMessages, ...messages];
 
-  const [subscription] = useSubscription(
+  const [res] = useSubscription(
     { query: NewMessageSubQuery },
     handleSubscription
   );
 
-  if (subscription.error !== undefined) {
+  if (res.error !== undefined) {
     return <Error>{subscription.error.message}</Error>;
   }
 
-  if (subscription.data === undefined) {
+  if (res.data === undefined) {
     return <p>No new messages</p>;
   }
 
   return (
     <ul>
-      {subscription.data.map(notif => (
+      {res.data.map(notif => (
         <Message key={notif.id} {...notif} />
       ))}
     </ul>


### PR DESCRIPTION
Tidied up res language in docs for more consistency between examples.

* Changed query -> res in getting-started.md examples.
* Changed result -> res in basics.md example.
* Changed query -> res in Home.tsx of example project getting-started.
* Changed subscription -> res in Messages.tsx of example using-subscription (happy to let this go if people think it worsens comprehension.)