### PR TITLE
handle val === null in getTypeNameFromField

### DIFF
--- a/src/utils/typenames.ts
+++ b/src/utils/typenames.ts
@@ -9,7 +9,7 @@ import {
 const getTypeNameFromField = (obj: object) =>
   Object.values(obj).reduce(
     (all, val) =>
-      typeof val !== 'object'
+      typeof val !== 'object' || val === null
         ? all
         : val.__typename !== undefined
         ? { ...all, [val.__typename]: true }


### PR DESCRIPTION
I ran into a case where my `val` was `null`, and the stacktrace pointed me here. 

Apparently `typeof null === 'object'` 😄 