### PR TITLE
Change GraphQLRequest to always contain a parsed document

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@types/fast-json-stable-stringify": "^2.0.0",
     "create-react-context": "^0.2.3",
     "fast-json-stable-stringify": "^2.0.0",
+    "graphql-tag": "^2.10.1",
     "prop-types": "^15.6.0",
     "wonka": "^2.0.1"
   }

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,4 +1,5 @@
-import { parse, print } from 'graphql';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
 
 /** NOTE: Testing in this file is designed to test both the client and it's interaction with default Exchanges */
 
@@ -24,7 +25,13 @@ describe('createClient', () => {
 
 const query = {
   key: 1,
-  query: `{ todos { id } }`,
+  query: gql`
+    {
+      todos {
+        id
+      }
+    }
+  `,
   variables: { example: 1234 },
 };
 
@@ -66,7 +73,7 @@ describe('executeQuery', () => {
     );
 
     const receivedQuery = receivedOps[0].query;
-    expect(print(receivedQuery)).toBe(print(parse(query.query)));
+    expect(print(receivedQuery)).toBe(print(query.query));
   });
 
   it('passes variables type to exchange', () => {
@@ -105,7 +112,7 @@ describe('executeMutation', () => {
     );
 
     const receivedQuery = receivedOps[0].query;
-    expect(print(receivedQuery)).toBe(print(parse(query.query)));
+    expect(print(receivedQuery)).toBe(print(query.query));
   });
 
   it('passes variables type to exchange', () => {
@@ -144,7 +151,7 @@ describe('executeSubscription', () => {
     );
 
     const receivedQuery = receivedOps[0].query;
-    expect(print(receivedQuery)).toBe(print(parse(query.query)));
+    expect(print(receivedQuery)).toBe(print(query.query));
   });
 
   it('passes variables type to exchange', () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,3 @@
-import { parse } from 'graphql';
-
 import {
   filter,
   makeSubject,
@@ -101,7 +99,7 @@ export class Client {
     opts?: Partial<OperationContext>
   ): Operation => ({
     key,
-    query: typeof query === 'string' ? parse(query) : query,
+    query,
     variables,
     operationName: type,
     context: this.createOperationContext(opts),

--- a/src/components/Mutation.test.tsx
+++ b/src/components/Mutation.test.tsx
@@ -10,15 +10,19 @@ jest.mock('../context', () => {
 });
 
 import { mount } from 'enzyme';
+import { print } from 'graphql';
+import gql from 'graphql-tag';
 import React from 'react';
 import { fromValue } from 'wonka';
+
 // @ts-ignore - client is exclusively from mock
 import { client } from '../context';
 import { Mutation } from './Mutation';
 
 const props = {
-  query: 'examplequery',
+  query: 'mutation Example { example }',
 };
+
 let childProps: any;
 
 const childMock = (c: any) => {
@@ -59,10 +63,9 @@ describe('execute mutation', () => {
   it('calls executeMutation with query', () => {
     mountWrapper(props);
     childProps.executeMutation();
-    expect(client.executeMutation.mock.calls[0][0]).toHaveProperty(
-      'query',
-      props.query
-    );
+
+    const call = client.executeMutation.mock.calls[0][0];
+    expect(print(call.query)).toBe(print(gql([props.query])));
   });
 
   it('calls executeMutation with variables', () => {

--- a/src/components/Mutation.tsx
+++ b/src/components/Mutation.tsx
@@ -3,7 +3,7 @@ import React, { Component, FC, ReactNode } from 'react';
 import { pipe, toPromise } from 'wonka';
 import { Client } from '../client';
 import { Consumer } from '../context';
-import { OperationResult } from '../types';
+import { Omit, OperationResult } from '../types';
 import { CombinedError, createRequest } from '../utils';
 
 interface MutationHandlerProps {
@@ -67,7 +67,7 @@ class MutationHandler extends Component<
   };
 }
 
-type MutationProps = Exclude<MutationHandlerProps, 'client'>;
+type MutationProps = Omit<MutationHandlerProps, 'client'>;
 
 export const Mutation: FC<MutationProps> = props => (
   <Consumer>

--- a/src/components/Mutation.tsx
+++ b/src/components/Mutation.tsx
@@ -1,13 +1,14 @@
+import { DocumentNode } from 'graphql';
 import React, { Component, FC, ReactNode } from 'react';
 import { pipe, toPromise } from 'wonka';
 import { Client } from '../client';
 import { Consumer } from '../context';
-import { GraphQLRequest, OperationResult } from '../types';
+import { OperationResult } from '../types';
 import { CombinedError, createRequest } from '../utils';
 
 interface MutationHandlerProps {
   client: Client;
-  query: GraphQLRequest['query'];
+  query: string | DocumentNode;
   children: (arg: MutationChildProps) => ReactNode;
 }
 

--- a/src/components/Query.test.tsx
+++ b/src/components/Query.test.tsx
@@ -17,7 +17,7 @@ import { client } from '../context';
 import { Query } from './Query';
 
 const props = {
-  query: 'examplequery',
+  query: '{ example }',
 };
 let childProps: any;
 
@@ -64,7 +64,7 @@ describe('on change', () => {
     const wrapper = mountWrapper(props);
 
     // @ts-ignore
-    wrapper.setProps({ ...props, query: 'new query' });
+    wrapper.setProps({ ...props, query: '{ newQuery }' });
     expect(client.executeQuery).toBeCalledTimes(2);
   });
 });

--- a/src/components/Query.tsx
+++ b/src/components/Query.tsx
@@ -3,7 +3,7 @@ import React, { Component, FC, ReactNode } from 'react';
 import { pipe, subscribe } from 'wonka';
 import { Client } from '../client';
 import { Consumer } from '../context';
-import { OperationContext, RequestPolicy } from '../types';
+import { Omit, OperationContext, RequestPolicy } from '../types';
 import { CombinedError, createRequest, noop } from '../utils';
 
 interface QueryHandlerProps {

--- a/src/components/Query.tsx
+++ b/src/components/Query.tsx
@@ -1,11 +1,14 @@
+import { DocumentNode } from 'graphql';
 import React, { Component, FC, ReactNode } from 'react';
 import { pipe, subscribe } from 'wonka';
 import { Client } from '../client';
 import { Consumer } from '../context';
-import { GraphQLRequest, OperationContext, RequestPolicy } from '../types';
+import { OperationContext, RequestPolicy } from '../types';
 import { CombinedError, createRequest, noop } from '../utils';
 
-interface QueryHandlerProps extends Omit<GraphQLRequest, 'key'> {
+interface QueryHandlerProps {
+  query: string | DocumentNode;
+  variables?: object;
   client: Client;
   requestPolicy?: RequestPolicy;
   children: (arg: QueryHandlerState) => ReactNode;

--- a/src/components/Subscription.tsx
+++ b/src/components/Subscription.tsx
@@ -3,6 +3,7 @@ import React, { Component, FC, ReactNode } from 'react';
 import { pipe, subscribe } from 'wonka';
 import { Client } from '../client';
 import { Consumer } from '../context';
+import { Omit } from '../types';
 import { CombinedError, createRequest, noop } from '../utils';
 
 interface SubscriptionHandlerProps {
@@ -72,7 +73,7 @@ class SubscriptionHandler extends Component<
   }
 }
 
-type SubscriptionProps = Exclude<SubscriptionHandlerProps, 'client'>;
+type SubscriptionProps = Omit<SubscriptionHandlerProps, 'client'>;
 
 export const Subscription: FC<SubscriptionProps> = props => (
   <Consumer>

--- a/src/components/Subscription.tsx
+++ b/src/components/Subscription.tsx
@@ -1,11 +1,13 @@
+import { DocumentNode } from 'graphql';
 import React, { Component, FC, ReactNode } from 'react';
 import { pipe, subscribe } from 'wonka';
 import { Client } from '../client';
 import { Consumer } from '../context';
-import { GraphQLRequest } from '../types';
 import { CombinedError, createRequest, noop } from '../utils';
 
-interface SubscriptionHandlerProps extends GraphQLRequest {
+interface SubscriptionHandlerProps {
+  query: string | DocumentNode;
+  variables?: object;
   client: Client;
   handler?: (prev: any | void, data: any) => any;
   children: (arg: SubscriptionHandlerState) => ReactNode;

--- a/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -19,55 +19,27 @@ Object {
         Object {
           "directives": Array [],
           "kind": "OperationDefinition",
-          "loc": Object {
-            "end": 103,
-            "start": 0,
-          },
           "name": Object {
             "kind": "Name",
-            "loc": Object {
-              "end": 13,
-              "start": 6,
-            },
             "value": "getUser",
           },
           "operation": "query",
           "selectionSet": Object {
             "kind": "SelectionSet",
-            "loc": Object {
-              "end": 103,
-              "start": 28,
-            },
             "selections": Array [
               Object {
                 "alias": undefined,
                 "arguments": Array [
                   Object {
                     "kind": "Argument",
-                    "loc": Object {
-                      "end": 50,
-                      "start": 39,
-                    },
                     "name": Object {
                       "kind": "Name",
-                      "loc": Object {
-                        "end": 43,
-                        "start": 39,
-                      },
                       "value": "name",
                     },
                     "value": Object {
                       "kind": "Variable",
-                      "loc": Object {
-                        "end": 50,
-                        "start": 45,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 50,
-                          "start": 46,
-                        },
                         "value": "name",
                       },
                     },
@@ -75,40 +47,20 @@ Object {
                 ],
                 "directives": Array [],
                 "kind": "Field",
-                "loc": Object {
-                  "end": 99,
-                  "start": 34,
-                },
                 "name": Object {
                   "kind": "Name",
-                  "loc": Object {
-                    "end": 38,
-                    "start": 34,
-                  },
                   "value": "user",
                 },
                 "selectionSet": Object {
                   "kind": "SelectionSet",
-                  "loc": Object {
-                    "end": 99,
-                    "start": 52,
-                  },
                   "selections": Array [
                     Object {
                       "alias": undefined,
                       "arguments": Array [],
                       "directives": Array [],
                       "kind": "Field",
-                      "loc": Object {
-                        "end": 62,
-                        "start": 60,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 62,
-                          "start": 60,
-                        },
                         "value": "id",
                       },
                       "selectionSet": undefined,
@@ -118,16 +70,8 @@ Object {
                       "arguments": Array [],
                       "directives": Array [],
                       "kind": "Field",
-                      "loc": Object {
-                        "end": 78,
-                        "start": 69,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 78,
-                          "start": 69,
-                        },
                         "value": "firstName",
                       },
                       "selectionSet": undefined,
@@ -137,16 +81,8 @@ Object {
                       "arguments": Array [],
                       "directives": Array [],
                       "kind": "Field",
-                      "loc": Object {
-                        "end": 93,
-                        "start": 85,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 93,
-                          "start": 85,
-                        },
                         "value": "lastName",
                       },
                       "selectionSet": undefined,
@@ -161,37 +97,17 @@ Object {
               "defaultValue": undefined,
               "directives": Array [],
               "kind": "VariableDefinition",
-              "loc": Object {
-                "end": 27,
-                "start": 14,
-              },
               "type": Object {
                 "kind": "NamedType",
-                "loc": Object {
-                  "end": 27,
-                  "start": 21,
-                },
                 "name": Object {
                   "kind": "Name",
-                  "loc": Object {
-                    "end": 27,
-                    "start": 21,
-                  },
                   "value": "String",
                 },
               },
               "variable": Object {
                 "kind": "Variable",
-                "loc": Object {
-                  "end": 19,
-                  "start": 14,
-                },
                 "name": Object {
                   "kind": "Name",
-                  "loc": Object {
-                    "end": 19,
-                    "start": 15,
-                  },
                   "value": "name",
                 },
               },
@@ -243,55 +159,27 @@ Object {
         Object {
           "directives": Array [],
           "kind": "OperationDefinition",
-          "loc": Object {
-            "end": 103,
-            "start": 0,
-          },
           "name": Object {
             "kind": "Name",
-            "loc": Object {
-              "end": 13,
-              "start": 6,
-            },
             "value": "getUser",
           },
           "operation": "query",
           "selectionSet": Object {
             "kind": "SelectionSet",
-            "loc": Object {
-              "end": 103,
-              "start": 28,
-            },
             "selections": Array [
               Object {
                 "alias": undefined,
                 "arguments": Array [
                   Object {
                     "kind": "Argument",
-                    "loc": Object {
-                      "end": 50,
-                      "start": 39,
-                    },
                     "name": Object {
                       "kind": "Name",
-                      "loc": Object {
-                        "end": 43,
-                        "start": 39,
-                      },
                       "value": "name",
                     },
                     "value": Object {
                       "kind": "Variable",
-                      "loc": Object {
-                        "end": 50,
-                        "start": 45,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 50,
-                          "start": 46,
-                        },
                         "value": "name",
                       },
                     },
@@ -299,40 +187,20 @@ Object {
                 ],
                 "directives": Array [],
                 "kind": "Field",
-                "loc": Object {
-                  "end": 99,
-                  "start": 34,
-                },
                 "name": Object {
                   "kind": "Name",
-                  "loc": Object {
-                    "end": 38,
-                    "start": 34,
-                  },
                   "value": "user",
                 },
                 "selectionSet": Object {
                   "kind": "SelectionSet",
-                  "loc": Object {
-                    "end": 99,
-                    "start": 52,
-                  },
                   "selections": Array [
                     Object {
                       "alias": undefined,
                       "arguments": Array [],
                       "directives": Array [],
                       "kind": "Field",
-                      "loc": Object {
-                        "end": 62,
-                        "start": 60,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 62,
-                          "start": 60,
-                        },
                         "value": "id",
                       },
                       "selectionSet": undefined,
@@ -342,16 +210,8 @@ Object {
                       "arguments": Array [],
                       "directives": Array [],
                       "kind": "Field",
-                      "loc": Object {
-                        "end": 78,
-                        "start": 69,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 78,
-                          "start": 69,
-                        },
                         "value": "firstName",
                       },
                       "selectionSet": undefined,
@@ -361,16 +221,8 @@ Object {
                       "arguments": Array [],
                       "directives": Array [],
                       "kind": "Field",
-                      "loc": Object {
-                        "end": 93,
-                        "start": 85,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 93,
-                          "start": 85,
-                        },
                         "value": "lastName",
                       },
                       "selectionSet": undefined,
@@ -385,37 +237,17 @@ Object {
               "defaultValue": undefined,
               "directives": Array [],
               "kind": "VariableDefinition",
-              "loc": Object {
-                "end": 27,
-                "start": 14,
-              },
               "type": Object {
                 "kind": "NamedType",
-                "loc": Object {
-                  "end": 27,
-                  "start": 21,
-                },
                 "name": Object {
                   "kind": "Name",
-                  "loc": Object {
-                    "end": 27,
-                    "start": 21,
-                  },
                   "value": "String",
                 },
               },
               "variable": Object {
                 "kind": "Variable",
-                "loc": Object {
-                  "end": 19,
-                  "start": 14,
-                },
                 "name": Object {
                   "kind": "Name",
-                  "loc": Object {
-                    "end": 19,
-                    "start": 15,
-                  },
                   "value": "name",
                 },
               },

--- a/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -117,7 +117,7 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 103,
+        "end": 124,
         "start": 0,
       },
     },
@@ -257,7 +257,7 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 103,
+        "end": 124,
         "start": 0,
       },
     },

--- a/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -19,55 +19,27 @@ Object {
         Object {
           "directives": Array [],
           "kind": "OperationDefinition",
-          "loc": Object {
-            "end": 89,
-            "start": 0,
-          },
           "name": Object {
             "kind": "Name",
-            "loc": Object {
-              "end": 28,
-              "start": 13,
-            },
             "value": "subscribeToUser",
           },
           "operation": "subscription",
           "selectionSet": Object {
             "kind": "SelectionSet",
-            "loc": Object {
-              "end": 89,
-              "start": 43,
-            },
             "selections": Array [
               Object {
                 "alias": undefined,
                 "arguments": Array [
                   Object {
                     "kind": "Argument",
-                    "loc": Object {
-                      "end": 65,
-                      "start": 54,
-                    },
                     "name": Object {
                       "kind": "Name",
-                      "loc": Object {
-                        "end": 58,
-                        "start": 54,
-                      },
                       "value": "user",
                     },
                     "value": Object {
                       "kind": "Variable",
-                      "loc": Object {
-                        "end": 65,
-                        "start": 60,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 65,
-                          "start": 61,
-                        },
                         "value": "user",
                       },
                     },
@@ -75,40 +47,20 @@ Object {
                 ],
                 "directives": Array [],
                 "kind": "Field",
-                "loc": Object {
-                  "end": 85,
-                  "start": 49,
-                },
                 "name": Object {
                   "kind": "Name",
-                  "loc": Object {
-                    "end": 53,
-                    "start": 49,
-                  },
                   "value": "user",
                 },
                 "selectionSet": Object {
                   "kind": "SelectionSet",
-                  "loc": Object {
-                    "end": 85,
-                    "start": 67,
-                  },
                   "selections": Array [
                     Object {
                       "alias": undefined,
                       "arguments": Array [],
                       "directives": Array [],
                       "kind": "Field",
-                      "loc": Object {
-                        "end": 79,
-                        "start": 75,
-                      },
                       "name": Object {
                         "kind": "Name",
-                        "loc": Object {
-                          "end": 79,
-                          "start": 75,
-                        },
                         "value": "name",
                       },
                       "selectionSet": undefined,
@@ -123,37 +75,17 @@ Object {
               "defaultValue": undefined,
               "directives": Array [],
               "kind": "VariableDefinition",
-              "loc": Object {
-                "end": 42,
-                "start": 29,
-              },
               "type": Object {
                 "kind": "NamedType",
-                "loc": Object {
-                  "end": 42,
-                  "start": 36,
-                },
                 "name": Object {
                   "kind": "Name",
-                  "loc": Object {
-                    "end": 42,
-                    "start": 36,
-                  },
                   "value": "String",
                 },
               },
               "variable": Object {
                 "kind": "Variable",
-                "loc": Object {
-                  "end": 34,
-                  "start": 29,
-                },
                 "name": Object {
                   "kind": "Name",
-                  "loc": Object {
-                    "end": 34,
-                    "start": 30,
-                  },
                   "value": "user",
                 },
               },

--- a/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -95,7 +95,7 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 92,
+        "end": 106,
         "start": 0,
       },
     },

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -16,5 +16,3 @@ declare module 'create-react-context' {
     children: (value: T) => React.ReactNode;
   }
 }
-
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;

--- a/src/hooks/useMutation.test.tsx
+++ b/src/hooks/useMutation.test.tsx
@@ -17,6 +17,8 @@ jest.mock('../client', () => {
   };
 });
 
+import { print } from 'graphql';
+import gql from 'graphql-tag';
 import React, { FC } from 'react';
 import renderer, { act } from 'react-test-renderer';
 // @ts-ignore - data is imported from mock only
@@ -26,7 +28,7 @@ import { useMutation } from './useMutation';
 // @ts-ignore
 const client = createClient() as { executeMutation: jest.Mock };
 const props = {
-  query: 'example query',
+  query: 'mutation Example { example }',
 };
 let state: any;
 let execute: any;
@@ -88,10 +90,9 @@ describe('on execute', () => {
     act(() => {
       execute(vars);
     });
-    expect(client.executeMutation.mock.calls[0][0]).toHaveProperty(
-      'query',
-      props.query
-    );
+
+    const call = client.executeMutation.mock.calls[0][0];
+    expect(print(call.query)).toBe(print(gql([props.query])));
   });
 
   it('calls executeMutation with variables', () => {

--- a/src/hooks/useQuery.test.tsx
+++ b/src/hooks/useQuery.test.tsx
@@ -26,7 +26,7 @@ import { useQuery } from './useQuery';
 // @ts-ignore
 const client = createClient() as { executeQuery: jest.Mock };
 const props = {
-  query: 'example query',
+  query: '{ example }',
   variables: {
     myVar: 1234,
   },
@@ -68,10 +68,11 @@ describe('on initial useEffect', () => {
 
   it('passes query and vars to executeQuery', () => {
     renderer.create(<QueryUser {...props} />);
+
     expect(client.executeQuery).toBeCalledWith(
       {
         key: expect.any(Number),
-        query: props.query,
+        query: expect.any(Object),
         variables: props.variables,
       },
       {
@@ -137,7 +138,7 @@ describe('on subscription update', () => {
 });
 
 describe('on change', () => {
-  const q = 'new query';
+  const q = 'query NewQuery { example }';
 
   it('new query executes subscription', () => {
     const wrapper = renderer.create(<QueryUser {...props} />);

--- a/src/hooks/useSubscription.test.tsx
+++ b/src/hooks/useSubscription.test.tsx
@@ -20,7 +20,7 @@ import { useSubscription } from './useSubscription';
 
 // @ts-ignore
 const client = createClient() as { executeSubscription: jest.Mock };
-const query = `example query`;
+const query = 'subscription Example { example }';
 let state: any;
 
 const SubscriptionUser: FC<{ q: string }> = ({ q }) => {
@@ -49,7 +49,7 @@ describe('on initial useEffect', () => {
     renderer.create(<SubscriptionUser q={query} />);
     expect(client.executeSubscription).toBeCalledWith({
       key: expect.any(Number),
-      query,
+      query: expect.any(Object),
       variables: {},
     });
   });
@@ -68,7 +68,8 @@ describe('on subscription', () => {
 });
 
 describe('on change', () => {
-  const q = 'new query';
+  const qa = 'subscription NewSubA { exampleA }';
+  const qb = 'subscription NewSubB { exampleB }';
 
   it('executes subscription', () => {
     const wrapper = renderer.create(<SubscriptionUser q={query} />);
@@ -78,9 +79,9 @@ describe('on change', () => {
      * Only a single change is detected (updating 5 times still only calls
      * execute subscription twice).
      */
-    wrapper.update(<SubscriptionUser q={q} />);
-    wrapper.update(<SubscriptionUser q={q} />);
-    wrapper.update(<SubscriptionUser q={q + 'diff'} />);
+    wrapper.update(<SubscriptionUser q={qa} />);
+    wrapper.update(<SubscriptionUser q={qa} />);
+    wrapper.update(<SubscriptionUser q={qb} />);
     expect(client.executeSubscription).toBeCalledTimes(2);
   });
 });

--- a/src/test-utils/samples.ts
+++ b/src/test-utils/samples.ts
@@ -1,4 +1,4 @@
-import { parse } from 'graphql';
+import gql from 'graphql-tag';
 
 import {
   ExecutionResult,
@@ -18,13 +18,15 @@ const context: OperationContext = {
 
 export const queryGql: GraphQLRequest = {
   key: 2,
-  query: `query getUser($name: String){
-    user(name: $name) {
-      id
-      firstName
-      lastName
+  query: gql`
+    query getUser($name: String) {
+      user(name: $name) {
+        id
+        firstName
+        lastName
+      }
     }
-  }`,
+  `,
   variables: {
     name: 'Clara',
   },
@@ -32,11 +34,13 @@ export const queryGql: GraphQLRequest = {
 
 export const mutationGql: GraphQLRequest = {
   key: 3,
-  query: `mutation AddUser($name: String){
-    addUser(name: $name) {
-      name
+  query: gql`
+    mutation AddUser($name: String) {
+      addUser(name: $name) {
+        name
+      }
     }
-  }`,
+  `,
   variables: {
     name: 'Clara',
   },
@@ -44,11 +48,12 @@ export const mutationGql: GraphQLRequest = {
 
 export const subscriptionGql: GraphQLRequest = {
   key: 4,
-  query: `subscription subscribeToUser($user: String){
-    user(user: $user) {
-      name
+  query: gql`
+    subscription subscribeToUser($user: String) {
+      user(user: $user) {
+        name
+      }
     }
-  }
   `,
   variables: {
     user: 'colin',
@@ -56,8 +61,7 @@ export const subscriptionGql: GraphQLRequest = {
 };
 
 export const teardownOperation: Operation = {
-  // @ts-ignore
-  query: parse(queryGql.query),
+  query: queryGql.query,
   variables: queryGql.variables,
   key: queryGql.key,
   operationName: 'teardown',
@@ -73,8 +77,7 @@ export const queryOperation: Operation = {
 };
 
 export const mutationOperation: Operation = {
-  // @ts-ignore
-  query: parse(mutationGql.query),
+  query: mutationGql.query,
   variables: mutationGql.variables,
   key: mutationGql.key,
   operationName: 'mutation',
@@ -82,8 +85,7 @@ export const mutationOperation: Operation = {
 };
 
 export const subscriptionOperation: Operation = {
-  // @ts-ignore
-  query: parse(subscriptionGql.query),
+  query: subscriptionGql.query,
   variables: subscriptionGql.variables,
   key: subscriptionGql.key,
   operationName: 'subscription',

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,9 @@ import { CombinedError } from './utils/error';
 
 export { ExecutionResult } from 'graphql';
 
+/** Utility type to Omit keys from an interface/object type */
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
 /** The type of GraphQL operation being executed. */
 export type OperationType = 'subscription' | 'query' | 'mutation' | 'teardown';
 
@@ -58,6 +61,3 @@ export type Exchange = (input: ExchangeInput) => ExchangeIO;
 
 /** Function responsible for receiving an observable [operation]{@link Operation} and returning a [result]{@link OperationResult}. */
 export type ExchangeIO = (ops$: Source<Operation>) => Source<OperationResult>;
-
-// /** The arguments for the child function of a connector. */
-// export type ChildArgs<MutationDeclarations> = ClientState<MutationDeclarations>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export type RequestPolicy =
 export interface GraphQLRequest {
   /** Unique identifier of the request. */
   key: number;
-  query: DocumentNode | string;
+  query: DocumentNode;
   variables?: object;
 }
 
@@ -32,10 +32,7 @@ export interface OperationContext {
 }
 
 /** A [query]{@link Query} or [mutation]{@link Mutation} with additional metadata for use during transmission. */
-export interface Operation {
-  query: DocumentNode;
-  variables?: object;
-  key: number;
+export interface Operation extends GraphQLRequest {
   operationName: OperationType;
   context: OperationContext;
 }

--- a/src/utils/__snapshots__/keyForQuery.test.ts.snap
+++ b/src/utils/__snapshots__/keyForQuery.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`returns consistent hashes for strings 1`] = `2090756197`;

--- a/src/utils/keyForQuery.test.ts
+++ b/src/utils/keyForQuery.test.ts
@@ -11,12 +11,6 @@ afterAll(() => {
   console.warn = consoleWarn;
 });
 
-it('returns consistent hashes for strings', () => {
-  expect(getKeyForQuery('test')).toBe(getKeyForQuery('test'));
-  expect(getKeyForQuery('test')).not.toBe(getKeyForQuery('test2'));
-  expect(getKeyForQuery('test')).toMatchSnapshot();
-});
-
 it('returns consistent hashes for DocumentNodes', () => {
   const query = gql`
     query Test {

--- a/src/utils/keyForQuery.ts
+++ b/src/utils/keyForQuery.ts
@@ -26,7 +26,7 @@ const hash = (x: string): number => {
 
 const docNameCache = Object.create(null) as NameCache;
 
-const getKeyForDocNode = (doc: DocumentNode): number => {
+export const getKeyForQuery = (doc: DocumentNode): number => {
   if ((doc as WithCacheProperty).__key !== undefined) {
     return (doc as WithCacheProperty).__key as number;
   }
@@ -60,18 +60,8 @@ const getKeyForDocNode = (doc: DocumentNode): number => {
   return key;
 };
 
-const getKeyForDocString = (doc: string): number => hash(doc);
-
-export const getKeyForQuery = (doc: string | DocumentNode): number => {
-  if (typeof doc === 'string') {
-    return getKeyForDocString(doc);
-  } else {
-    return getKeyForDocNode(doc);
-  }
-};
-
 export const getKeyForRequest = (
-  query: string | DocumentNode,
+  query: DocumentNode,
   vars?: object
 ): number => {
   const docKey = getKeyForQuery(query);

--- a/src/utils/request.test.ts
+++ b/src/utils/request.test.ts
@@ -1,14 +1,35 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
 import { createRequest } from './request';
 
+const doc = print(
+  gql`
+    {
+      todos {
+        id
+      }
+    }
+  `
+);
+
 it('should return a valid query object', () => {
-  const val = createRequest(`{ todos { id } }`);
-  expect(val).toMatchObject({ query: `{ todos { id } }`, variables: {} });
+  const val = createRequest(doc);
+
+  expect(print(val.query)).toBe(doc);
+  expect(val).toMatchObject({
+    key: expect.any(Number),
+    query: expect.any(Object),
+    variables: {},
+  });
 });
 
 it('should return a valid query object with variables', () => {
-  const val = createRequest(`{ todos { id } }`, { test: 5 });
+  const val = createRequest(doc, { test: 5 });
 
-  expect(val.query).toBe(`{ todos { id } }`);
-  expect(val.variables).toMatchObject({ test: 5 });
-  expect(typeof val.key).toBe('number');
+  expect(print(val.query)).toBe(doc);
+  expect(val).toMatchObject({
+    key: expect.any(Number),
+    query: expect.any(Object),
+    variables: { test: 5 },
+  });
 });

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,8 +1,13 @@
 import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
 import { getKeyForRequest } from './keyForQuery';
 
-export const createRequest = (q: string | DocumentNode, vars?: object) => ({
-  key: getKeyForRequest(q, vars),
-  query: q,
-  variables: vars || {},
-});
+export const createRequest = (q: string | DocumentNode, vars?: object) => {
+  const query = typeof q === 'string' ? gql([q]) : q;
+
+  return {
+    key: getKeyForRequest(query, vars),
+    query,
+    variables: vars || {},
+  };
+};


### PR DESCRIPTION
We always parse the document now when we receive a string.
This ensures a consistent request data structure and makes
things easier, since there's not much else to expect.

Also addresses a bug where `parse` is undefined.

Fix #206
Fix #219 (Related)