### PR TITLE
fix: Guard resultCache access in cacheExchange

### DIFF
--- a/src/exchanges/cache.ts
+++ b/src/exchanges/cache.ts
@@ -132,9 +132,11 @@ export const afterMutation = (
   });
 
   pendingOperations.forEach(key => {
-    const operation = (resultCache.get(key) as OperationResult).operation; // Result is guaranteed
-    resultCache.delete(key);
-    reexecuteOperation(client, operation);
+    if (resultCache.has(key)) {
+      const operation = (resultCache.get(key) as OperationResult).operation;
+      resultCache.delete(key);
+      reexecuteOperation(client, operation);
+    }
   });
 };
 


### PR DESCRIPTION
Fix #210 

The `operationCache` might already contain stale operation keys if particular queries are run while a mutation is looking to invalidate some results, hence the `resultCache` might not contain all operations anymore, if a result has already been invalidated.