### PR TITLE
Adding 'skip' prop to query and mutation components and hooks.

### DIFF
--- a/src/components/Mutation.tsx
+++ b/src/components/Mutation.tsx
@@ -20,7 +20,8 @@ interface MutationHandlerState {
 
 interface MutationChildProps extends MutationHandlerState {
   executeMutation: <T = any, V = object>(
-    variables?: V
+    variables?: V,
+    skip?: boolean
   ) => Promise<OperationResult<T>>;
 }
 
@@ -41,7 +42,9 @@ class MutationHandler extends Component<
     });
   }
 
-  executeMutation: MutationChildProps['executeMutation'] = variables => {
+  executeMutation: MutationChildProps['executeMutation'] = (variables, skip) => {
+    if (skip) return;
+    
     this.setState({
       fetching: true,
       error: undefined,

--- a/src/components/Query.tsx
+++ b/src/components/Query.tsx
@@ -9,6 +9,7 @@ import { CombinedError, createRequest, noop } from '../utils';
 interface QueryHandlerProps {
   query: string | DocumentNode;
   variables?: object;
+  skip?: boolean;
   client: Client;
   requestPolicy?: RequestPolicy;
   children: (arg: QueryHandlerState) => ReactNode;
@@ -26,6 +27,8 @@ class QueryHandler extends Component<QueryHandlerProps, QueryHandlerState> {
   private request = createRequest(this.props.query, this.props.variables);
 
   executeQuery = (opts?: Partial<OperationContext>) => {
+    if (this.props.skip) return;
+    
     this.unsubscribe();
 
     this.setState({ fetching: true });

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -26,7 +26,9 @@ export const useMutation = <T = any, V = object>(
     data: undefined,
   });
 
-  const executeMutation = (variables?: V) => {
+  const executeMutation = (variables?: V, skip?: boolean) => {
+    if (skip) return;
+    
     setState({ fetching: true, error: undefined, data: undefined });
 
     const request = createRequest(query, variables as any);

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -8,6 +8,7 @@ import { CombinedError, createRequest, noop } from '../utils';
 interface UseQueryArgs<V> {
   query: string | DocumentNode;
   variables?: V;
+  skip?: boolean;
   requestPolicy?: RequestPolicy;
 }
 
@@ -38,6 +39,8 @@ export const useQuery = <T = any, V = object>(
 
   const executeQuery = useCallback(
     (opts?: Partial<OperationContext>) => {
+      if (args.skip) return;
+
       unsubscribe();
       setState(s => ({ ...s, fetching: true }));
 


### PR DESCRIPTION
Hi!

So the idea is to have a prop that can tell `Query` and `Mutation` components and `useQuery` and `useMutation` hooks, "hey, I know I'm asking you to execute the request, but because of something, don't do that now -- skip this for me".

Skip must be a boolean (not making something like `!!skip`).
It won't prevent creating a new request; `createRequest` will be called anyway. This behaviour is due to `createRequest` not being responsible for checking if the request must be made or not; it only makes a request and returns it. Checking is `Query`, `useQuery`, `Mutation` and `useMutation` business.

Usage on `Query` (as a prop on `Query` component):

```javascript
import React from 'react';
import { Query } from 'urql';

const getTodos = `
  query GetTodos($limit: Int!) {
    todos(limit: $limit) {
      id
      text
      isDone
    }
  }
`;

const TodoList = ({ limit = 10 }) => {
  let skip = true; // here should have some checking
  return (
    <Query query={getTodos} variables={{ limit }} skip={skip}>
      {({ fetching, data, error }) => {
        if (fetching) {
          return 'Loading...';
        } else if (error) {
          return 'Oh no!';
        }

        return (
          <ul>
            {data.todos.map(({ id, text }) => (
              <li key={id}>{text}</li>
            ))}
          </ul>
        );
      }}
    </Query>;
  );
};
```

Usage on `Mutation` (as second parameter of `executeMutation`):

```javascript
import React, { Component } from 'react';
import { Mutation } from 'urql';

const addTodo = `
  mutation AddTodo($text: String!) {
    addTodo(text: $text) {
      id
      text
    }
  }
`;

class TodoForm extends Component {
  state = {
    error: null,
    skip: true, // here should have some checking
  };

  add = () => {
    this.props.addTodo({ text: 'something!' }, this.state.skip)
      .catch(error => {
        this.setState({ error });
      });
  };

  render() {
    if (this.state.error) {
      return 'Oh no!';
    }

    return <button onClick={this.add}>Add something!</button>
  }
}

const WithMutation = () => (
  <Mutation query={addTodo}>
    {({ executeMutation }) => <TodoForm addTodo={executeMutation} />
  </Mutation>
);
```

Usage on `useQuery` (as as prop of the object passed to the hook):

```javascript
import React from 'react';
import { useQuery } from 'urql';

const getTodos = `
  query GetTodos($limit: Int!) {
    todos(limit: $limit) {
      id
      text
      isDone
    }
  }
`;

const TodoList = ({ limit = 10 }) => {
  const [res] = useQuery({
    query: getTodos,
    variables: { limit },
    skip: true, // here should have some checking
  });

  if (res.fetching) {
    return 'Loading...';
  } else if (res.error) {
    return 'Oh no!';
  }

  return (
    <ul>
      {res.data.todos.map(({ id, text }) => (
        <li key={id}>{text}</li>
      ))}
    </ul>
  );
};
```

Usage on `useMutation` (as second parameter of `executeMutation`):

```javascript
import React, { useCallback } from 'react';
import { useMutation } from 'urql';

const addTodo = `
  mutation AddTodo($text: String!) {
    addTodo(text: $text) {
      id
      text
    }
  }
`;

const TodoForm = () => {
  const [res, executeMutation] = useMutation(addTodo);
  const skip = true; // here should have some checking

  if (res.error) {
    return 'Oh no!';
  }

  return (
    <button onClick={() => executeMutation({ text: 'something!' }, skip)}>
      Add something!
    </button>
  );
};
```

This behaviour is great because sometimes we can notice that we don't have something that we need for making a request, and don't wanna return `null`, be it through a component itself or through a HOC.

If any of these starts with `skip = true`, it'll hold its state as it was initialized (`{ data: undefined, error: undefined, fetching: false }`).

I'm out of time for writing tests. Sorry for that.

Thank you for your attention! 😸