### PR TITLE
[WIP] Add client.createQuery and client.createMutation

### DIFF
--- a/src/__snapshots__/client.test.ts.snap
+++ b/src/__snapshots__/client.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`createClient passes snapshot 1`] = `
 Client {
   "activeOperations": Object {},
+  "createMutation": [Function],
   "createOperationContext": [Function],
+  "createQuery": [Function],
   "createRequestOperation": [Function],
   "dispatchOperation": [Function],
   "exchange": [Function],

--- a/src/__snapshots__/context.test.ts.snap
+++ b/src/__snapshots__/context.test.ts.snap
@@ -16,7 +16,9 @@ Object {
     "_currentRenderer2": null,
     "_currentValue": Client {
       "activeOperations": Object {},
+      "createMutation": [Function],
       "createOperationContext": [Function],
+      "createQuery": [Function],
       "createRequestOperation": [Function],
       "dispatchOperation": [Function],
       "exchange": [Function],
@@ -31,7 +33,9 @@ Object {
     },
     "_currentValue2": Client {
       "activeOperations": Object {},
+      "createMutation": [Function],
       "createOperationContext": [Function],
+      "createQuery": [Function],
       "createRequestOperation": [Function],
       "dispatchOperation": [Function],
       "exchange": [Function],
@@ -65,7 +69,9 @@ Object {
     "_currentRenderer2": null,
     "_currentValue": Client {
       "activeOperations": Object {},
+      "createMutation": [Function],
       "createOperationContext": [Function],
+      "createQuery": [Function],
       "createRequestOperation": [Function],
       "dispatchOperation": [Function],
       "exchange": [Function],
@@ -80,7 +86,9 @@ Object {
     },
     "_currentValue2": Client {
       "activeOperations": Object {},
+      "createMutation": [Function],
       "createOperationContext": [Function],
+      "createQuery": [Function],
       "createRequestOperation": [Function],
       "dispatchOperation": [Function],
       "exchange": [Function],

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -213,7 +213,7 @@ describe('createQuery', () => {
       variables: { foo: 'bar' },
     });
 
-    await myQuery({ variables: { foo: 'baz' } });
+    await myQuery({ foo: 'baz' });
     // @ts-ignore
     expect(client.executeQuery.mock.calls[0][0].variables.foo).toBe('baz');
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -196,11 +196,9 @@ export class Client {
   createQuery = <ExpectedResult = any>({
     query,
     variables: initialVariables,
-  }: CreateQueryInput) => ({
-    variables: newVariables,
-  }: {
-    variables?: object;
-  } = {}): Promise<OperationResult<ExpectedResult>> =>
+  }: CreateQueryInput) => (
+    newVariables?: object
+  ): Promise<OperationResult<ExpectedResult>> =>
     new Promise(resolve => {
       const variables = newVariables || initialVariables || {};
       const request = createRequest(query, variables);

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,7 +659,7 @@ axios@^0.17.0:
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
-babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
@@ -1012,11 +1012,6 @@ buffer-from@1.x, buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-builtin-modules@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
-
 builtin-modules@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-2.0.0.tgz#60b7ef5ae6546bd7deefa74b08b62a43a232648e"
@@ -1154,7 +1149,7 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1355,7 +1350,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.12.1, commander@^2.14.1, commander@^2.19.0, commander@^2.9.0:
+commander@^2.11.0, commander@^2.14.1, commander@^2.19.0, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -7694,47 +7689,10 @@ ts-jest@^23.10.5:
     semver "^5.5"
     yargs-parser "10.x"
 
-tslib@1.9.3, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@1.9.3, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
-
-tslint-config-prettier@^1.16.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
-  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
-
-tslint-react@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-3.6.0.tgz#7f462c95c4a0afaae82507f06517ff02942196a1"
-  integrity sha512-AIv1QcsSnj7e9pFir6cJ6vIncTqxfqeFF3Lzh8SuuBljueYzEAtByuB6zMaD27BL0xhMEqsZ9s5eHuCONydjBw==
-  dependencies:
-    tsutils "^2.13.1"
-
-tslint@^5.11.0:
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.12.1.tgz#8cec9d454cf8a1de9b0a26d7bdbad6de362e52c1"
-  integrity sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==
-  dependencies:
-    babel-code-frame "^6.22.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^3.2.0"
-    glob "^7.1.1"
-    js-yaml "^3.7.0"
-    minimatch "^3.0.4"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.8.0"
-    tsutils "^2.27.2"
-
-tsutils@^2.13.1, tsutils@^2.27.2:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
-  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  dependencies:
-    tslib "^1.8.1"
 
 tsutils@^3.7.0:
   version "3.10.0"


### PR DESCRIPTION
Addresses #216

This PR adds two methods to the client, `.createQuery` and `.createMutation`. Both of these create - but do not run - queries and mutations that can be used later.

**Todo**

- [ ] - review tests
- [ ] - subscription support

*(WIP documentation, will update)*

### `createQuery`

Accepts an object as its input:

```ts
interface CreateQueryInput {
  query: DocumentNode | string;
  variables?: object;
}
```

Returns a function that can be called with (optional) new variables. This function executes the query when called and returns the results.

Example:

```ts
const MY_QUERY = `
	query { ... }
`

const defaultVariables = {
  x: 'y'
}

const myQuery = client.createQuery({ query: MY_QUERY, variables: defaultVariables })

/** later */

const defaultResults = await myQuery()
const otherResults = await myQuery({ x: 'z' })
```

### `createMutation`

Similar to `createQuery`, except its only argument is a query string.

Example:

```ts
const MY_MUTATION = `
	mutation { ... }
`

const myMutation = client.createMutation(MY_MUTATION)

const result = myMutation({ a: 'b' })
```

-----

Some questions:

 - This is set up to more or less match the signatures of `useQuery` and `useMutation`. But, it might be simpler if these two methods had the same structure. (Is there any reason why `useMutation` does not use `({ query: MY_MUTATION })` instead of just `(MY_MUTATION)`?)
 - Please take a look at my tests -- I'm not too familiar with the internals and unsure if there is anything else that should be covered. The mocks for `executeQuery` and `executeMutation` were just yanked from other tests.

I've tested this in an existing project and it's working. 

