### PR TITLE
(fix) - fetching on initial render

### DIFF
--- a/src/components/Query.tsx
+++ b/src/components/Query.tsx
@@ -60,7 +60,7 @@ class QueryHandler extends Component<QueryHandlerProps, QueryHandlerState> {
     executeQuery: this.executeQuery,
     data: undefined,
     error: undefined,
-    fetching: !this.props.pause,
+    fetching: false,
   };
 
   componentDidMount() {

--- a/src/components/Query.tsx
+++ b/src/components/Query.tsx
@@ -60,7 +60,7 @@ class QueryHandler extends Component<QueryHandlerProps, QueryHandlerState> {
     executeQuery: this.executeQuery,
     data: undefined,
     error: undefined,
-    fetching: false,
+    fetching: this.props.pause !== true,
   };
 
   componentDidMount() {

--- a/src/components/Query.tsx
+++ b/src/components/Query.tsx
@@ -60,7 +60,7 @@ class QueryHandler extends Component<QueryHandlerProps, QueryHandlerState> {
     executeQuery: this.executeQuery,
     data: undefined,
     error: undefined,
-    fetching: false,
+    fetching: !this.props.pause,
   };
 
   componentDidMount() {

--- a/src/components/Query.tsx
+++ b/src/components/Query.tsx
@@ -56,12 +56,15 @@ class QueryHandler extends Component<QueryHandlerProps, QueryHandlerState> {
     this.unsubscribe = teardown;
   };
 
-  state = {
-    executeQuery: this.executeQuery,
-    data: undefined,
-    error: undefined,
-    fetching: this.props.pause !== true,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      executeQuery: this.executeQuery,
+      data: undefined,
+      error: undefined,
+      fetching: props.pause !== true,
+    };
+  }
 
   componentDidMount() {
     this.executeQuery();

--- a/src/components/__snapshots__/Query.test.tsx.snap
+++ b/src/components/__snapshots__/Query.test.tsx.snap
@@ -5,6 +5,6 @@ Object {
   "data": 1234,
   "error": undefined,
   "executeQuery": [Function],
-  "fetching": true,
+  "fetching": false,
 }
 `;

--- a/src/components/__snapshots__/Query.test.tsx.snap
+++ b/src/components/__snapshots__/Query.test.tsx.snap
@@ -5,6 +5,6 @@ Object {
   "data": 1234,
   "error": undefined,
   "executeQuery": [Function],
-  "fetching": false,
+  "fetching": true,
 }
 `;

--- a/src/hooks/__snapshots__/useQuery.test.tsx.snap
+++ b/src/hooks/__snapshots__/useQuery.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`on initial useEffect initialises default state 1`] = `
 Object {
   "data": undefined,
   "error": undefined,
-  "fetching": false,
+  "fetching": true,
 }
 `;

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -35,9 +35,10 @@ export const useQuery = <T = any, V = object>(
 ): UseQueryResponse<T> => {
   const isMounted = useRef(false);
   const unsubscribe = useRef(noop);
-  const initialState = useRef({ fetching: true });
-  const updateState = useRef(update => {
-    initialState.current = update;
+  const initialState = useRef<UseQueryState<T>>({
+    data: undefined,
+    error: undefined,
+    fetching: true,
   });
 
   const client = useContext(Context);
@@ -53,7 +54,7 @@ export const useQuery = <T = any, V = object>(
         requestPolicy: args.requestPolicy,
       }),
       subscribe(({ data, error }) => {
-        updateState.current({ data, error, fetching: false });
+        initialState.current = { data, error, fetching: false };
       })
     );
     unsubscribe.current = teardown;

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -48,7 +48,7 @@ export const useQuery = <T = any, V = object>(
     [args.query, args.variables]
   );
 
-  if (!isMounted.current) {
+  if (!isMounted.current && !args.pause) {
     const [teardown] = pipe(
       client.executeQuery(request, {
         requestPolicy: args.requestPolicy,

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -90,18 +90,18 @@ export const useQuery = <T = any, V = object>(
   );
 
   useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
     if (isMounted.current) {
       executeQuery();
     }
     return unsubscribe.current;
   }, [executeQuery]);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   return [state, executeQuery];
 };

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -42,7 +42,7 @@ export const useQuery = <T = any, V = object>(
   );
 
   const [state, setState] = useState<UseQueryState<T>>({
-    fetching: true,
+    fetching: !args.pause,
     error: undefined,
     data: undefined,
   });

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -40,6 +40,7 @@ export const useQuery = <T = any, V = object>(
     error: undefined,
     fetching: true,
   });
+  const updateRef = useRef(update => (initialState.current = update));
 
   const client = useContext(Context);
 
@@ -54,13 +55,14 @@ export const useQuery = <T = any, V = object>(
         requestPolicy: args.requestPolicy,
       }),
       subscribe(({ data, error }) => {
-        initialState.current = { data, error, fetching: false };
+        updateRef.current({ data, error, fetching: false });
       })
     );
     unsubscribe.current = teardown;
   }
 
   const [state, setState] = useState<UseQueryState<T>>(initialState.current);
+  updateRef.current = setState;
 
   const executeQuery = useCallback(
     (opts?: Partial<OperationContext>) => {

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -53,7 +53,7 @@ export const useQuery = <T = any, V = object>(
         requestPolicy: args.requestPolicy,
       }),
       subscribe(({ data, error }) => {
-        updateState.current({ data, error, isFetching: false });
+        updateState.current({ data, error, fetching: false });
       })
     );
     unsubscribe.current = teardown;

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -42,7 +42,7 @@ export const useQuery = <T = any, V = object>(
   );
 
   const [state, setState] = useState<UseQueryState<T>>({
-    fetching: false,
+    fetching: true,
     error: undefined,
     data: undefined,
   });

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -56,7 +56,7 @@ export const useQuery = <T = any, V = object>(
         updateState.current({ data, error, isFetching: false });
       })
     );
-    teardown();
+    unsubscribe.current = teardown;
   }
 
   const [state, setState] = useState<UseQueryState<T>>(initialState.current);


### PR DESCRIPTION
Fixes: https://github.com/FormidableLabs/urql/issues/245

After the initial render the effect gets executed that sets fetching to `true` 
So when initially rendering we see that fetching is false implying we have data, since after this we'll always see fetching -> data fetching -> data

Only on initial render we see a scenario where: fetching false but no data -> fetching -> data

Made this as a draft because I understand the why but maybe we could resolve it differently with a loaded property or something?

Snapshot:

```

exports[`on initial useEffect initialises default state 1`] = '
Object {
  "data": undefined,
  "error": undefined,
  "fetching": false,
}
';

```

Fails atm due to the initialState change