### PR TITLE
Add generics support for Query component.

### DIFF
--- a/src/components/Query.tsx
+++ b/src/components/Query.tsx
@@ -1,28 +1,31 @@
 import { DocumentNode } from 'graphql';
-import React, { Component, FC, ReactNode } from 'react';
+import React, { Component, ReactNode } from 'react';
 import { pipe, subscribe } from 'wonka';
 import { Client } from '../client';
 import { Consumer } from '../context';
 import { Omit, OperationContext, RequestPolicy } from '../types';
 import { CombinedError, createRequest, noop } from '../utils';
 
-interface QueryHandlerProps {
+interface QueryHandlerProps<T> {
   query: string | DocumentNode;
   variables?: object;
   client: Client;
   requestPolicy?: RequestPolicy;
   pause?: boolean;
-  children: (arg: QueryHandlerState) => ReactNode;
+  children: (arg: QueryHandlerState<T>) => ReactNode;
 }
 
-interface QueryHandlerState {
+interface QueryHandlerState<T> {
   fetching: boolean;
-  data?: any;
+  data?: T;
   error?: CombinedError;
   executeQuery: (opts?: Partial<OperationContext>) => void;
 }
 
-class QueryHandler extends Component<QueryHandlerProps, QueryHandlerState> {
+class QueryHandler<T> extends Component<
+  QueryHandlerProps<T>,
+  QueryHandlerState<T>
+> {
   private unsubscribe = noop;
   private request = createRequest(this.props.query, this.props.variables);
 
@@ -84,8 +87,10 @@ class QueryHandler extends Component<QueryHandlerProps, QueryHandlerState> {
   }
 }
 
-export type QueryProps = Omit<QueryHandlerProps, 'client'>;
+export type QueryProps<T> = Omit<QueryHandlerProps<T>, 'client'>;
 
-export const Query: FC<QueryProps> = props => (
-  <Consumer>{client => <QueryHandler {...props} client={client} />}</Consumer>
-);
+export function Query<T = any>(props: QueryProps<T>) {
+  return (
+    <Consumer>{client => <QueryHandler {...props} client={client} />}</Consumer>
+  );
+}


### PR DESCRIPTION
This PR begins to address #213 by adding generics support to the `Query` component. I wanted to keep the diff small and reviewable so we can see how we like this pattern before adopting it in the other components and hooks.

Previously, the `data` returned by `Query`'s render prop was typed as `any`, so users got no type safety around the data returned by their GraphQL API. With these changes, `data` becomes typed by a generic `T` that's supplied to the `Query` component.

For example, let's say our `Query` component returns data of the following shape:

```json
{
   "data": {
      "todos": [
         "id": 1
         "text": "Todo"
         "complete": false
      ]
   }
}
```

We can then use generics to type `data` in our `Query` component.

```typescript
interface Todo {
   id: number,
   text: string,
   complete: boolean;
}

interface Data {
   todos: Todo[];
}

const TodoQuery = gql`
  query {
    todos {
      id
      text
      complete
    }
  }
`;

const Example: FC = () => {
  return (
    <Query<Data> query={TodoQuery}>
      {({ data }) => data.todos.map(todo => <Todo key={todo.id} {...todo} />)}
    </Query>
  );
};
```

If we attempt to access an unknown field (i.e. `data.todo`) or use a property in a non-type safe way, the compiler will alert us 🎉 The generic `T` will default to `any`, so this doesn't affect any existing code using `urql` (it's 100% opt in), so `<Query query={TodoQuery}>` in the above example is still totally valid.