### PR TITLE
Implement immediate effect and refactor

### DIFF
--- a/src/hooks/__snapshots__/useQuery.test.tsx.snap
+++ b/src/hooks/__snapshots__/useQuery.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`on initial useEffect initialises default state 1`] = `
 Object {
   "data": undefined,
   "error": undefined,
-  "fetching": false,
+  "fetching": true,
 }
 `;

--- a/src/hooks/useImmediateEffect.test.ts
+++ b/src/hooks/useImmediateEffect.test.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+import { renderHook } from 'react-hooks-testing-library';
+import { useImmediateEffect } from './useImmediateEffect';
+
+it('calls effects immediately on mount', () => {
+  const spy = jest.spyOn(React, 'useEffect');
+  const useEffect = jest.fn();
+  const effect = jest.fn();
+
+  spy.mockImplementation(useEffect);
+  renderHook(() => useImmediateEffect(effect, [effect]));
+
+  expect(effect).toHaveBeenCalledTimes(1);
+  expect(effect).toHaveBeenCalledTimes(1);
+
+  expect(useEffect).toHaveBeenCalledWith(expect.any(Function), [
+    expect.any(Function),
+  ]);
+
+  useEffect.mockRestore();
+});

--- a/src/hooks/useImmediateEffect.ts
+++ b/src/hooks/useImmediateEffect.ts
@@ -1,31 +1,34 @@
 import { useRef, useEffect, useCallback } from 'react';
 
-enum EffectState {
-  BeforeMount = 0,
-  AfterMount = 1,
-  Render = 2,
+enum LifecycleState {
+  WillMount = 0,
+  DidMount = 1,
+  Update = 2,
 }
 
 type Effect = () => void | (() => void);
 
 /** This executes an effect immediately on initial render and then treats it as a normal effect */
-export const useImmediateEffect = (effect: Effect, changes?: any[]) => {
-  const state = useRef(EffectState.BeforeMount);
+export const useImmediateEffect = (
+  effect: Effect,
+  changes: ReadonlyArray<any>
+) => {
+  const state = useRef(LifecycleState.WillMount);
   const execute = useCallback(effect, changes);
 
   useEffect(() => {
     // Initially we skip executing the effect since we've already done so on
     // initial render, then we execute it as usual
-    if (state.current === EffectState.Render) {
+    if (state.current === LifecycleState.Update) {
       return execute();
     } else {
-      state.current = EffectState.Render;
+      state.current = LifecycleState.Update;
     }
   }, [execute]);
 
   // On initial render we just execute the effect
-  if (state.current === EffectState.BeforeMount) {
-    state.current = EffectState.AfterMount;
+  if (state.current === LifecycleState.WillMount) {
+    state.current = LifecycleState.DidMount;
     execute();
   }
 };

--- a/src/hooks/useImmediateEffect.ts
+++ b/src/hooks/useImmediateEffect.ts
@@ -1,0 +1,30 @@
+import { useRef, useEffect } from 'react';
+
+enum EffectState {
+  BeforeMount = 0,
+  AfterMount = 1,
+  Render = 2,
+}
+
+type Effect = () => void | (() => void);
+
+/** This executes an effect immediately on initial render and then treats it as a normal effect */
+export const useImmediateEffect = (effect: Effect) => {
+  const state = useRef(EffectState.BeforeMount);
+
+  useEffect(() => {
+    // Initially we skip executing the effect since we've already done so on
+    // initial render, then we execute it as usual
+    if (state.current === EffectState.Render) {
+      return effect();
+    } else {
+      state.current = EffectState.Render;
+    }
+  }, [effect]);
+
+  // On initial render we just execute the effect
+  if (state.current === EffectState.BeforeMount) {
+    state.current = EffectState.AfterMount;
+    effect();
+  }
+};

--- a/src/hooks/useImmediateEffect.ts
+++ b/src/hooks/useImmediateEffect.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 
 enum EffectState {
   BeforeMount = 0,
@@ -9,22 +9,23 @@ enum EffectState {
 type Effect = () => void | (() => void);
 
 /** This executes an effect immediately on initial render and then treats it as a normal effect */
-export const useImmediateEffect = (effect: Effect) => {
+export const useImmediateEffect = (effect: Effect, changes?: any[]) => {
   const state = useRef(EffectState.BeforeMount);
+  const execute = useCallback(effect, changes);
 
   useEffect(() => {
     // Initially we skip executing the effect since we've already done so on
     // initial render, then we execute it as usual
     if (state.current === EffectState.Render) {
-      return effect();
+      return execute();
     } else {
       state.current = EffectState.Render;
     }
-  }, [effect]);
+  }, [execute]);
 
   // On initial render we just execute the effect
   if (state.current === EffectState.BeforeMount) {
     state.current = EffectState.AfterMount;
-    effect();
+    execute();
   }
 };

--- a/src/hooks/useQuery.test.tsx
+++ b/src/hooks/useQuery.test.tsx
@@ -20,7 +20,7 @@ jest.mock('../client', () => {
 
 import React, { FC } from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { pipe, onEnd, interval } from 'wonka';
+import { pipe, onStart, onEnd, interval } from 'wonka';
 import { createClient } from '../client';
 import { OperationContext } from '../types';
 import { useQuery, UseQueryArgs, UseQueryState } from './useQuery';
@@ -164,21 +164,23 @@ describe('on change', () => {
 });
 
 describe('on unmount', () => {
+  const start = jest.fn();
   const unsubscribe = jest.fn();
 
   beforeEach(() => {
-    client.executeQuery.mockReturnValueOnce(
+    client.executeQuery.mockReturnValue(
       pipe(
         interval(400),
+        onStart(start),
         onEnd(unsubscribe)
       )
     );
   });
 
-  it('unsubscribe is called', () => {
+  it.only('unsubscribe is called', () => {
     const wrapper = renderer.create(<QueryUser {...props} />);
     wrapper.unmount();
-
+    expect(start).toBeCalledTimes(1);
     expect(unsubscribe).toBeCalledTimes(1);
   });
 });

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -73,6 +73,7 @@ export const useQuery = <T = any, V = object>(
   // Calls executeQuery on initial render immediately, then
   // treats it as a normal effect
   useImmediateEffect(() => {
+    isMounted.current = true;
     executeQuery();
 
     return () => {

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -77,7 +77,10 @@ export const useQuery = <T = any, V = object>(
 
   // Calls executeQuery on initial render immediately, then
   // treats it as a normal effect
-  useImmediateEffect(executeQuery);
+  useImmediateEffect(() => {
+    executeQuery();
+    return () => unsubscribe.current();
+  }, [executeQuery]);
 
   return [state, executeQuery];
 };

--- a/src/hooks/useRequest.test.ts
+++ b/src/hooks/useRequest.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from 'react-hooks-testing-library';
+import { queryGql } from '../test-utils';
+import { useRequest } from './useRequest';
+
+it('preserves instance of request when key has not changed', () => {
+  let { query, variables } = queryGql;
+
+  const { result, rerender } = renderHook(
+    ({ query, variables }) => useRequest(query, variables),
+    { initialProps: { query, variables } }
+  );
+
+  const resultA = result.current;
+  expect(resultA).toEqual({
+    key: expect.any(Number),
+    query: expect.anything(),
+    variables: variables,
+  });
+
+  variables = { ...variables }; // Change reference
+  rerender({ query, variables });
+
+  const resultB = result.current;
+  expect(resultA).toBe(resultB);
+
+  variables = { ...variables, test: true }; // Change values
+  rerender({ query, variables });
+
+  const resultC = result.current;
+  expect(resultA).not.toBe(resultC);
+});

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -1,0 +1,23 @@
+import { DocumentNode } from 'graphql';
+import { useRef, useMemo } from 'react';
+import { GraphQLRequest } from '../types';
+import { createRequest } from '../utils';
+
+/** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
+export const useRequest = (
+  query: string | DocumentNode,
+  variables?: any
+): GraphQLRequest => {
+  const prev = useRef<void | GraphQLRequest>(undefined);
+
+  return useMemo(() => {
+    const request = createRequest(query, variables);
+    // We manually ensure reference equality if the key hasn't changed
+    if (prev.current !== undefined && prev.current.key === request.key) {
+      return prev.current;
+    } else {
+      prev.current = request;
+      return request;
+    }
+  }, [query, variables]);
+};

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -36,13 +36,6 @@ export const useSubscription = <T = any, R = T, V = object>(
     data: undefined,
   });
 
-  useEffect(
-    () => () => {
-      isMounted.current = false;
-    },
-    []
-  );
-
   const executeSubscription = useCallback(() => {
     unsubscribe.current();
 
@@ -63,8 +56,13 @@ export const useSubscription = <T = any, R = T, V = object>(
 
   // Trigger subscription on query change
   useEffect(() => {
+    isMounted.current = true;
     executeSubscription();
-    return () => unsubscribe.current();
+
+    return () => {
+      isMounted.current = false;
+      unsubscribe.current();
+    };
   }, [executeSubscription]);
 
   return [state];

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,15 +1,9 @@
 import { DocumentNode } from 'graphql';
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-  useMemo,
-} from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { pipe, subscribe } from 'wonka';
 import { Context } from '../context';
-import { CombinedError, createRequest, noop } from '../utils';
+import { CombinedError, noop } from '../utils';
+import { useRequest } from './useRequest';
 
 export interface UseSubscriptionArgs<V> {
   query: DocumentNode | string;
@@ -31,19 +25,17 @@ export const useSubscription = <T = any, R = T, V = object>(
 ): UseSubscriptionResponse<R> => {
   const isMounted = useRef(true);
   const unsubscribe = useRef(noop);
-
   const client = useContext(Context);
-  const request = useMemo(
-    () => createRequest(args.query, args.variables as any),
-    [args.query, args.variables]
-  );
+
+  // This creates a request which will keep a stable reference
+  // if request.key doesn't change
+  const request = useRequest(args.query, args.variables);
 
   const [state, setState] = useState<UseSubscriptionState<R>>({
     error: undefined,
     data: undefined,
   });
 
-  /** Unmount handler */
   useEffect(
     () => () => {
       isMounted.current = false;
@@ -69,11 +61,10 @@ export const useSubscription = <T = any, R = T, V = object>(
     unsubscribe.current = teardown;
   }, [client, handler, request]);
 
-  /** Trigger subscription on query change. */
+  // Trigger subscription on query change
   useEffect(() => {
     executeSubscription();
-
-    return unsubscribe.current;
+    return () => unsubscribe.current();
   }, [executeSubscription]);
 
   return [state];

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,8 +1,12 @@
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import { getKeyForRequest } from './keyForQuery';
+import { GraphQLRequest } from '../types';
 
-export const createRequest = (q: string | DocumentNode, vars?: object) => {
+export const createRequest = (
+  q: string | DocumentNode,
+  vars?: object
+): GraphQLRequest => {
   const query = typeof q === 'string' ? gql([q]) : q;
 
   return {


### PR DESCRIPTION
Fix #245 

Initial stuff that will become necessary for #218

This implements two hooks:

- `useRequest` to simplify the creation of requests while keeping a stable reference, so we don't have to check for `request.key`
- `useImmediateEffect` to simplify running an effect immediately outside of `useEffect` for SSR/suspense, which then otherwise behaves like a normal `useEffect`.

