### PR TITLE
Ensure that state changes are applied immediately on mount

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,12 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/array-type": "off",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "additionalHooks": "useImmediateEffect"
+      }
+    ],
     "react/prop-types": "off",
     "react/no-children-prop": "off",
     "sort-keys": "off",

--- a/src/hooks/useImmediateEffect.test.ts
+++ b/src/hooks/useImmediateEffect.test.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook } from 'react-hooks-testing-library';
+import { renderHook, act } from 'react-hooks-testing-library';
 import { useImmediateEffect } from './useImmediateEffect';
 
 it('calls effects immediately on mount', () => {
@@ -8,14 +8,37 @@ it('calls effects immediately on mount', () => {
   const effect = jest.fn();
 
   spy.mockImplementation(useEffect);
-  renderHook(() => useImmediateEffect(effect, [effect]));
+
+  renderHook(() => {
+    useImmediateEffect(effect, [effect]);
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
 
   expect(effect).toHaveBeenCalledTimes(1);
-  expect(effect).toHaveBeenCalledTimes(1);
-
   expect(useEffect).toHaveBeenCalledWith(expect.any(Function), [
     expect.any(Function),
   ]);
 
-  useEffect.mockRestore();
+  spy.mockRestore();
+});
+
+it('behaves like useEffect otherwise', () => {
+  const spy = jest.spyOn(React, 'useEffect');
+  const effect = jest.fn();
+
+  const { result } = renderHook(() => {
+    const [ref, setState] = React.useState({});
+    useImmediateEffect(effect, [ref]);
+
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalled();
+
+    const forceUpdate = () => setState({});
+    return forceUpdate;
+  });
+
+  act(() => result.current()); // forceUpdate
+  expect(effect).toHaveBeenCalledTimes(2);
+
+  spy.mockRestore();
 });

--- a/src/hooks/useImmediateEffect.ts
+++ b/src/hooks/useImmediateEffect.ts
@@ -9,7 +9,7 @@ enum LifecycleState {
 
 type Effect = () => () => void;
 
-/** This executes an effect immediately on initial render and then treats it as a normal effect */
+/** This is a drop-in replacement for useEffect that will execute the first effect that happens during initial mount synchronously */
 export const useImmediateEffect = (
   effect: Effect,
   changes: ReadonlyArray<any>

--- a/src/hooks/useImmediateEffect.ts
+++ b/src/hooks/useImmediateEffect.ts
@@ -1,4 +1,6 @@
-import { useRef, useEffect, useCallback } from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
+
+import { useRef, useEffect } from 'react';
 import { noop } from '../utils';
 
 enum LifecycleState {
@@ -16,22 +18,21 @@ export const useImmediateEffect = (
 ) => {
   const teardown = useRef(noop);
   const state = useRef(LifecycleState.WillMount);
-  const execute = useCallback(effect, changes);
 
   // On initial render we just execute the effect
   if (state.current === LifecycleState.WillMount) {
     state.current = LifecycleState.DidMount;
-    teardown.current = execute();
+    teardown.current = effect();
   }
 
   useEffect(() => {
     // Initially we skip executing the effect since we've already done so on
     // initial render, then we execute it as usual
     if (state.current === LifecycleState.Update) {
-      return (teardown.current = execute());
+      return (teardown.current = effect());
     } else {
       state.current = LifecycleState.Update;
       return teardown.current;
     }
-  }, [execute]);
+  }, changes);
 };

--- a/src/hooks/useImmediateState.test.ts
+++ b/src/hooks/useImmediateState.test.ts
@@ -1,0 +1,46 @@
+import React from 'react';
+import { renderHook } from 'react-hooks-testing-library';
+import { useImmediateState } from './useImmediateState';
+
+it('updates state immediately during mount', () => {
+  let initialState;
+  let update = 0;
+
+  const setState = jest.fn();
+
+  const spy = jest.spyOn(React, 'useState').mockImplementation(state => {
+    expect(state).toEqual({ x: 'x', test: false });
+    initialState = state;
+    return [state, setState];
+  });
+
+  const { result } = renderHook(() => {
+    const [state, setState] = useImmediateState({ x: 'x', test: false });
+    if (update === 0) setState(s => ({ ...s, test: true }));
+    update++;
+    return state;
+  });
+
+  expect(setState).not.toHaveBeenCalled();
+  expect(result.current).toEqual({ x: 'x', test: true });
+  expect(result.current).toBe(initialState);
+  expect(update).toBe(1);
+
+  spy.mockRestore();
+});
+
+it('behaves like useState otherwise', () => {
+  const setState = jest.fn();
+  const spy = jest
+    .spyOn(React, 'useState')
+    .mockImplementation(state => [state, setState]);
+
+  renderHook(() => {
+    const [state, setState] = useImmediateState({ x: 'x' });
+    React.useEffect(() => setState({ x: 'y' }), [setState]);
+    return state;
+  });
+
+  expect(setState).toHaveBeenCalledTimes(1);
+  spy.mockRestore();
+});

--- a/src/hooks/useImmediateState.ts
+++ b/src/hooks/useImmediateState.ts
@@ -1,0 +1,32 @@
+import { useRef, useEffect, useState, useCallback } from 'react';
+
+type SetStateAction<S> = S | ((prevState: S) => S);
+type SetState<S> = (action: SetStateAction<S>) => void;
+
+export const useImmediateState = <S extends {}>(init: S): [S, SetState<S>] => {
+  const isMounted = useRef(false);
+  const initialState = useRef<S>({ ...init });
+  const [state, setState] = useState<S>(initialState.current);
+
+  const updateState: SetState<S> = useCallback((action: SetStateAction<S>) => {
+    // If the component is currently before its initial mount, update
+    // the state immediately
+    if (isMounted.current) {
+      setState(action);
+    } else if (typeof action === 'function') {
+      const update = (action as any)(initialState.current);
+      Object.assign(initialState.current, update);
+    } else {
+      Object.assign(initialState.current, action as any);
+    }
+  }, []);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return [state, updateState];
+};

--- a/src/hooks/useImmediateState.ts
+++ b/src/hooks/useImmediateState.ts
@@ -3,14 +3,15 @@ import { useRef, useEffect, useState, useCallback } from 'react';
 type SetStateAction<S> = S | ((prevState: S) => S);
 type SetState<S> = (action: SetStateAction<S>) => void;
 
+/** This is a drop-in replacement for useState, limited to object-based state. During initial mount it will mutably update the state, instead of scheduling a React update using setState */
 export const useImmediateState = <S extends {}>(init: S): [S, SetState<S>] => {
   const isMounted = useRef(false);
   const initialState = useRef<S>({ ...init });
   const [state, setState] = useState<S>(initialState.current);
 
+  // This wraps setState and updates the state mutably on initial mount
+  // It also prevents setting the state when the component is unmounted
   const updateState: SetState<S> = useCallback((action: SetStateAction<S>) => {
-    // If the component is currently before its initial mount, update
-    // the state immediately
     if (isMounted.current) {
       setState(action);
     } else if (typeof action === 'function') {

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -1,5 +1,5 @@
 import { DocumentNode } from 'graphql';
-import { useContext } from 'react';
+import { useContext, useCallback } from 'react';
 import { pipe, toPromise } from 'wonka';
 import { Context } from '../context';
 import { OperationResult } from '../types';
@@ -27,20 +27,23 @@ export const useMutation = <T = any, V = object>(
     data: undefined,
   });
 
-  const executeMutation = (variables?: V) => {
-    setState({ fetching: true, error: undefined, data: undefined });
+  const executeMutation = useCallback(
+    (variables?: V) => {
+      setState({ fetching: true, error: undefined, data: undefined });
 
-    const request = createRequest(query, variables as any);
+      const request = createRequest(query, variables as any);
 
-    return pipe(
-      client.executeMutation(request),
-      toPromise
-    ).then(result => {
-      const { data, error } = result;
-      setState({ fetching: false, data, error });
-      return result;
-    });
-  };
+      return pipe(
+        client.executeMutation(request),
+        toPromise
+      ).then(result => {
+        const { data, error } = result;
+        setState({ fetching: false, data, error });
+        return result;
+      });
+    },
+    [client, query, setState]
+  );
 
   return [state, executeMutation];
 };


### PR DESCRIPTION
Fix #245
Fix #209 (See 17feeca)

It seems that in the current version React does
trigger *two* renders in our case.

We call executeQuery immediately which has a couple
of setStates. These are batched, it seems, but
do trigger a second update of the underlying
component, which is a shame.

Instead, we know that the initial executeQuery can
just safely merge its results into the initial
state, if it's during the initial mount.

This is why useImmediateState is added, which does
just that. Not the nicest way to solve this, but
the safest until React ships batched updates by
default.

This is basically a solution that will continue to
ensure that we won't have to add any state-related
stuff outside of `executeQuery`