### PR TITLE
Add link to additional egghead screen casts

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -198,6 +198,9 @@ Once you've set up the `subscriptionExchange` and your
 `forwardSubscription` function, you can start using
 the `<Subscription>` component and/or the `useSubscription()` hook.
 
+> A tutorial on setting up the `subscriptionExchange` is also available as a
+> [screencast on egghead](https://egghead.io/lessons/graphql-set-up-graphql-subscriptions-with-urql?pl=introduction-to-urql-a-react-graphql-client-faaa2bf5).
+
 ### Usage with components
 
 The `<Subscription>` component is extremely similar to the `<Query>`
@@ -286,3 +289,6 @@ As we can see, the `result.data` is being updated and transformed by
 the `handleSubscription` function. This works over time, so as
 new messages come in, we will append them to the list of previous
 messages.
+
+> A tutorial on the `useSubscription` hook is also available as a
+> [screencast on egghead](https://egghead.io/lessons/graphql-write-a-graphql-subscription-with-react-hooks-using-urql?pl=introduction-to-urql-a-react-graphql-client-faaa2bf5).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,9 @@ const YourApp = () => (
 );
 ```
 
+> A tutorial on how to set up a `client` and `Provider`
+> is [available as screencast on egghead](https://egghead.io/lessons/graphql-set-up-an-urql-graphql-provider-in-react?pl=introduction-to-urql-a-react-graphql-client-faaa2bf5).
+
 Every component and query underneath the `<Provider>` in the tree now has access
 to the client and will call the client when it needs to execute GraphQL requests.
 
@@ -156,7 +159,7 @@ Similarly to the `<Query>` component, `useQuery` will start the request
 as soon as it's mounted and will rerun it when the query or variables change.
 
 > A tutorial on the `useQuery` hook is also available as a
-> [screencast on egghead](https://egghead.io/lessons/graphql-query-graphql-data-with-urql-using-react-hooks).
+> [screencast on egghead](https://egghead.io/lessons/graphql-query-graphql-data-with-urql-using-react-hooks?pl=introduction-to-urql-a-react-graphql-client-faaa2bf5).
 
 [Read more about the result's API in the Architecture's Results section.](architecture.md#operation-results)
 
@@ -337,6 +340,9 @@ const TodoForm = () => {
 This is functionally the same as the second example, but `executeMutation`
 also returns a promise with `useMutation` as it does with `<Mutation>` so
 the first example could also be written using hooks.
+
+> A tutorial on the `useMutation` hook is also available as a
+> [screencast on egghead](https://egghead.io/lessons/graphql-write-a-graphql-mutation-using-react-hooks-with-urql?pl=introduction-to-urql-a-react-graphql-client-faaa2bf5).
 
 ## Refetching data
 


### PR DESCRIPTION
This adds tutorials on:
- setting up a client and provider
- adding the subscription exchange
- using `useSubscription`

This also adds a `pl` param to each lesson url so that the user clicking the link will see all the other urql lessons.

![](https://media0.giphy.com/media/3oz8xH4lNUNgTKBMwE/giphy.gif?cid=5a38a5a25cf6857c344b4f5877955d47&rid=giphy.gif)