### PR TITLE
Implement server-side rendering support

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,8 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-hooks-testing-library": "^0.5.1",
+    "react-is": "^16.8.6",
+    "react-ssr-prepass": "^1.0.5",
     "react-test-renderer": "^16.8.6",
     "rimraf": "^2.6.2",
     "terser": "^4.0.0",

--- a/src/__snapshots__/client.test.ts.snap
+++ b/src/__snapshots__/client.test.ts.snap
@@ -14,6 +14,7 @@ Client {
   "operations$": [Function],
   "reexecuteOperation": [Function],
   "results$": [Function],
+  "suspense": false,
   "url": "https://hostname.com",
 }
 `;

--- a/src/__snapshots__/context.test.ts.snap
+++ b/src/__snapshots__/context.test.ts.snap
@@ -27,6 +27,7 @@ Object {
       "operations$": [Function],
       "reexecuteOperation": [Function],
       "results$": [Function],
+      "suspense": false,
       "url": "/graphql",
     },
     "_currentValue2": Client {
@@ -42,6 +43,7 @@ Object {
       "operations$": [Function],
       "reexecuteOperation": [Function],
       "results$": [Function],
+      "suspense": false,
       "url": "/graphql",
     },
     "_threadCount": 0,
@@ -76,6 +78,7 @@ Object {
       "operations$": [Function],
       "reexecuteOperation": [Function],
       "results$": [Function],
+      "suspense": false,
       "url": "/graphql",
     },
     "_currentValue2": Client {
@@ -91,6 +94,7 @@ Object {
       "operations$": [Function],
       "reexecuteOperation": [Function],
       "results$": [Function],
+      "suspense": false,
       "url": "/graphql",
     },
     "_threadCount": 0,

--- a/src/client.ts
+++ b/src/client.ts
@@ -147,15 +147,15 @@ export class Client {
         onStart<OperationResult>(() => this.dispatchOperation(operation)),
         take(1)
       );
-    } else if (this.suspense) {
-      operationResults$ = toSuspenseSource(operationResults$);
     }
 
-    return pipe(
+    const result$ = pipe(
       operationResults$,
       onStart<OperationResult>(() => this.onOperationStart(operation)),
       onEnd<OperationResult>(() => this.onOperationEnd(operation))
     );
+
+    return this.suspense ? toSuspenseSource(result$) : result$;
   }
 
   reexecuteOperation = (operation: Operation) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -134,8 +134,7 @@ export class Client {
   /** Executes an Operation by sending it through the exchange pipeline It returns an observable that emits all related exchange results and keeps track of this observable's subscribers. A teardown signal will be emitted when no subscribers are listening anymore. */
   executeRequestOperation(operation: Operation): Source<OperationResult> {
     const { key, operationName } = operation;
-
-    let operationResults$ = pipe(
+    const operationResults$ = pipe(
       this.results$,
       filter(res => res.operation.key === key)
     );

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,8 @@ import {
   OperationType,
 } from './types';
 
+import { toSuspenseSource } from './utils';
+
 /** Options for configuring the URQL [client]{@link Client}. */
 export interface ClientOptions {
   /** Target endpoint URL such as `https://my-target:8080/graphql`. */
@@ -33,6 +35,8 @@ export interface ClientOptions {
   fetchOptions?: RequestInit | (() => RequestInit);
   /** An ordered array of Exchanges. */
   exchanges?: Exchange[];
+  /** Activates support for Suspense. */
+  suspense?: boolean;
 }
 
 interface ActiveOperations {
@@ -47,6 +51,7 @@ export class Client {
   url: string;
   fetchOptions?: RequestInit | (() => RequestInit);
   exchange: Exchange;
+  suspense: boolean;
 
   // These are internals to be used to keep track of operations
   dispatchOperation: (operation: Operation) => void;
@@ -57,6 +62,7 @@ export class Client {
   constructor(opts: ClientOptions) {
     this.url = opts.url;
     this.fetchOptions = opts.fetchOptions;
+    this.suspense = !!opts.suspense;
 
     // This subject forms the input of operations; executeOperation may be
     // called to dispatch a new operation on the subject
@@ -129,7 +135,7 @@ export class Client {
   executeRequestOperation(operation: Operation): Source<OperationResult> {
     const { key, operationName } = operation;
 
-    const operationResults$ = pipe(
+    let operationResults$ = pipe(
       this.results$,
       filter(res => res.operation.key === key)
     );
@@ -141,6 +147,8 @@ export class Client {
         onStart<OperationResult>(() => this.dispatchOperation(operation)),
         take(1)
       );
+    } else if (this.suspense) {
+      operationResults$ = toSuspenseSource(operationResults$);
     }
 
     return pipe(

--- a/src/exchanges/cache.ts
+++ b/src/exchanges/cache.ts
@@ -11,6 +11,9 @@ interface OperationCache {
   [key: string]: Set<number>;
 }
 
+const shouldSkip = ({ operationName }: Operation) =>
+  operationName !== 'mutation' && operationName !== 'query';
+
 export const cacheExchange: Exchange = ({ forward, client }) => {
   const resultCache = new Map() as ResultCache;
   const operationCache = Object.create(null) as OperationCache;
@@ -41,10 +44,6 @@ export const cacheExchange: Exchange = ({ forward, client }) => {
       (requestPolicy === 'cache-only' || resultCache.has(key))
     );
   };
-
-  const shouldSkip = (operation: Operation) =>
-    operation.operationName !== 'mutation' &&
-    operation.operationName !== 'query';
 
   return ops$ => {
     const sharedOps$ = share(ops$);

--- a/src/exchanges/index.ts
+++ b/src/exchanges/index.ts
@@ -1,3 +1,4 @@
+export { ssrExchange } from './ssr';
 export { cacheExchange } from './cache';
 export { subscriptionExchange } from './subscription';
 export { debugExchange } from './debug';

--- a/src/exchanges/ssr.test.ts
+++ b/src/exchanges/ssr.test.ts
@@ -35,14 +35,20 @@ it('caches query results correctly', () => {
 
   const data = ssr.extractData();
   expect(Object.keys(data)).toEqual(['' + queryOperation.key]);
-  expect(data).toEqual({ [queryOperation.key]: queryResponse });
+
+  expect(data).toEqual({
+    [queryOperation.key]: {
+      data: queryResponse.data,
+      error: undefined,
+    },
+  });
 });
 
 it('resolves cached query results correctly', () => {
   const onPush = jest.fn();
 
   const ssr = ssrExchange({
-    initialState: { [queryOperation.key]: queryResponse },
+    initialState: { [queryOperation.key]: queryResponse as any },
   });
 
   const [ops$, next] = input;
@@ -65,7 +71,7 @@ it('deletes cached results in non-suspense environments', () => {
   const onPush = jest.fn();
   const ssr = ssrExchange();
 
-  ssr.restoreData({ [queryOperation.key]: queryResponse });
+  ssr.restoreData({ [queryOperation.key]: queryResponse as any });
   expect(Object.keys(ssr.extractData()).length).toBe(1);
 
   const [ops$, next] = input;

--- a/src/exchanges/ssr.test.ts
+++ b/src/exchanges/ssr.test.ts
@@ -85,4 +85,7 @@ it('deletes cached results in non-suspense environments', () => {
 
   expect(Object.keys(ssr.extractData()).length).toBe(0);
   expect(onPush).toHaveBeenCalledWith(queryResponse);
+
+  // NOTE: The operation should not be duplicated
+  expect(output).not.toHaveBeenCalled();
 });

--- a/src/exchanges/ssr.test.ts
+++ b/src/exchanges/ssr.test.ts
@@ -1,0 +1,82 @@
+import { makeSubject, pipe, map, publish, forEach, Subject } from 'wonka';
+
+import { Client } from '../client';
+import { queryOperation, queryResponse } from '../test-utils';
+import { ExchangeIO, Operation } from '../types';
+import { ssrExchange } from './ssr';
+
+let forward: ExchangeIO;
+let exchangeInput;
+let client: Client;
+let input: Subject<Operation>;
+let output;
+
+beforeEach(() => {
+  input = makeSubject<Operation>();
+  output = jest.fn();
+  forward = ops$ =>
+    pipe(
+      ops$,
+      map(output)
+    );
+  client = { suspense: true } as any;
+  exchangeInput = { forward, client };
+});
+
+it('caches query results correctly', () => {
+  output.mockReturnValueOnce(queryResponse);
+
+  const ssr = ssrExchange();
+  const [ops$, next] = input;
+  const exchange = ssr(exchangeInput)(ops$);
+
+  publish(exchange);
+  next(queryOperation);
+
+  const data = ssr.extractData();
+  expect(Object.keys(data)).toEqual(['' + queryOperation.key]);
+  expect(data).toEqual({ [queryOperation.key]: queryResponse });
+});
+
+it('resolves cached query results correctly', () => {
+  const onPush = jest.fn();
+
+  const ssr = ssrExchange({
+    initialState: { [queryOperation.key]: queryResponse },
+  });
+
+  const [ops$, next] = input;
+  const exchange = ssr(exchangeInput)(ops$);
+
+  pipe(
+    exchange,
+    forEach(onPush)
+  );
+  next(queryOperation);
+
+  const data = ssr.extractData();
+  expect(Object.keys(data).length).toBe(1);
+  expect(output).not.toHaveBeenCalled();
+  expect(onPush).toHaveBeenCalledWith(queryResponse);
+});
+
+it('deletes cached results in non-suspense environments', () => {
+  client.suspense = false;
+  const onPush = jest.fn();
+  const ssr = ssrExchange();
+
+  ssr.restoreData({ [queryOperation.key]: queryResponse });
+  expect(Object.keys(ssr.extractData()).length).toBe(1);
+
+  const [ops$, next] = input;
+  const exchange = ssr(exchangeInput)(ops$);
+
+  pipe(
+    exchange,
+    forEach(onPush)
+  );
+  next(queryOperation);
+
+  expect(Object.keys(ssr.extractData()).length).toBe(0);
+  expect(onPush).toHaveBeenCalledWith(queryResponse);
+});

--- a/src/exchanges/ssr.ts
+++ b/src/exchanges/ssr.ts
@@ -1,0 +1,79 @@
+import { pipe, share, filter, merge, map, tap } from 'wonka';
+import { Exchange, OperationResult, Operation } from '../types';
+
+export interface SSRData {
+  [key: string]: OperationResult;
+}
+
+export interface SSRExchangeParams {
+  initialState?: SSRData;
+}
+
+export interface SSRExchange extends Exchange {
+  /** Rehydrates cached data */
+  restoreData(data: SSRData): void;
+  /** Extracts cached data */
+  extractData(): SSRData;
+}
+
+const shouldSkip = ({ operationName }: Operation) =>
+  operationName !== 'subscription' && operationName !== 'query';
+
+/** The ssrExchange can be created to capture data during SSR and also to rehydrate it on the client */
+export const ssrExchange = (params: SSRExchangeParams): SSRExchange => {
+  const data: SSRData = {};
+
+  const isCached = (operation: Operation) => {
+    return !shouldSkip(operation) && data[operation.key] !== undefined;
+  };
+
+  // The SSR Exchange is a temporary cache that can populate results into data for suspense
+  // On the client it can be used to retrieve these temporary results from a rehydrated cache
+  const ssr: SSRExchange = ({ client, forward }) => ops$ => {
+    const sharedOps$ = share(ops$);
+
+    let cachedOps$ = pipe(
+      sharedOps$,
+      filter(op => isCached(op)),
+      map(op => data[op.key])
+    );
+
+    let forwardedOps$ = pipe(
+      sharedOps$,
+      filter(op => !isCached(op)),
+      forward
+    );
+
+    if (!client.suspense) {
+      // Outside of suspense-mode we delete results from the cache as they're resolved
+      cachedOps$ = pipe(
+        cachedOps$,
+        tap((result: OperationResult) => {
+          delete data[result.operation.key];
+        })
+      );
+    } else {
+      // Inside suspense-mode we cache results in the cache as they're resolved
+      forwardedOps$ = pipe(
+        forwardedOps$,
+        tap((result: OperationResult) => {
+          const { operation } = result;
+          if (!shouldSkip(operation)) {
+            data[operation.key] = result;
+          }
+        })
+      );
+    }
+
+    return merge([cachedOps$, forwardedOps$]);
+  };
+
+  ssr.restoreData = (restore: SSRData) => Object.assign(data, restore);
+  ssr.extractData = () => Object.assign({}, data);
+
+  if (params.initialState !== undefined) {
+    ssr.restoreData(params.initialState);
+  }
+
+  return ssr;
+};

--- a/src/exchanges/ssr.ts
+++ b/src/exchanges/ssr.ts
@@ -20,7 +20,7 @@ const shouldSkip = ({ operationName }: Operation) =>
   operationName !== 'subscription' && operationName !== 'query';
 
 /** The ssrExchange can be created to capture data during SSR and also to rehydrate it on the client */
-export const ssrExchange = (params: SSRExchangeParams): SSRExchange => {
+export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
   const data: SSRData = {};
 
   const isCached = (operation: Operation) => {
@@ -71,7 +71,7 @@ export const ssrExchange = (params: SSRExchangeParams): SSRExchange => {
   ssr.restoreData = (restore: SSRData) => Object.assign(data, restore);
   ssr.extractData = () => Object.assign({}, data);
 
-  if (params.initialState !== undefined) {
+  if (params && params.initialState) {
     ssr.restoreData(params.initialState);
   }
 

--- a/src/test-utils/ssr.test.tsx
+++ b/src/test-utils/ssr.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import prepass from 'react-ssr-prepass';
-import { publish, filter, delay, pipe, map } from 'wonka';
+import { never, publish, filter, delay, pipe, map } from 'wonka';
 
 import { createClient } from '../client';
 import { Provider } from '../context';
@@ -11,66 +11,99 @@ import { queryOperation, queryResponse } from './index';
 
 const url = 'https://hostname.com';
 
-let ssr;
-let client;
+describe('server-side rendering', () => {
+  let ssr;
+  let client;
 
-beforeEach(() => {
-  const fetchExchange: Exchange = () => ops$ => {
-    return pipe(
-      ops$,
-      filter(x => x.operationName === 'query'),
-      delay(100),
-      map(operation => ({ ...queryResponse, operation }))
+  beforeEach(() => {
+    const fetchExchange: Exchange = () => ops$ => {
+      return pipe(
+        ops$,
+        filter(x => x.operationName === 'query'),
+        delay(100),
+        map(operation => ({ ...queryResponse, operation }))
+      );
+    };
+
+    ssr = ssrExchange();
+    client = createClient({
+      url,
+      // We include the SSR exchange after the cache
+      exchanges: [dedupExchange, cacheExchange, ssr, fetchExchange],
+      suspense: true,
+    });
+  });
+
+  it('correctly executes suspense and populates the SSR cache', async () => {
+    let promise;
+
+    try {
+      pipe(
+        client.executeRequestOperation(queryOperation),
+        publish
+      );
+    } catch (error) {
+      promise = error;
+    }
+
+    expect(promise).toBeInstanceOf(Promise);
+    const result = await promise;
+    expect(result.data).not.toBe(undefined);
+
+    const data = ssr.extractData();
+    expect(Object.keys(data).length).toBe(1);
+  });
+
+  it('works for an actual component tree', async () => {
+    const Query = () => {
+      useQuery({
+        query: queryOperation.query,
+        variables: queryOperation.variables,
+      });
+
+      return null;
+    };
+
+    const App = () => (
+      <Provider value={client}>
+        <Query />
+      </Provider>
     );
-  };
 
-  ssr = ssrExchange();
-  client = createClient({
-    url,
-    // We include the SSR exchange after the cache
-    exchanges: [dedupExchange, cacheExchange, ssr, fetchExchange],
-    suspense: true,
+    await prepass(<App />);
+
+    const data = ssr.extractData();
+    expect(Object.keys(data).length).toBe(1);
   });
 });
 
-it('correctly executes suspense and populates the SSR cache', async () => {
-  let promise;
+describe('client-side rehydration', () => {
+  let ssr;
+  let client;
 
-  try {
-    pipe(
-      client.executeRequestOperation(queryOperation),
-      publish
-    );
-  } catch (error) {
-    promise = error;
-  }
+  beforeEach(() => {
+    const fetchExchange: Exchange = () => () => never as any;
 
-  expect(promise).toBeInstanceOf(Promise);
-  const result = await promise;
-  expect(result.data).not.toBe(undefined);
-
-  const data = ssr.extractData();
-  expect(Object.keys(data).length).toBe(1);
-});
-
-it('works for an actual component tree', async () => {
-  const Query = () => {
-    useQuery({
-      query: queryOperation.query,
-      variables: queryOperation.variables,
+    ssr = ssrExchange();
+    client = createClient({
+      url,
+      // We include the SSR exchange after the cache
+      exchanges: [dedupExchange, cacheExchange, ssr, fetchExchange],
+      suspense: false,
     });
+  });
 
-    return null;
-  };
+  it('can rehydrate results on the client', () => {
+    ssr.restoreData({ [queryOperation.key]: queryResponse });
 
-  const App = () => (
-    <Provider value={client}>
-      <Query />
-    </Provider>
-  );
+    expect(() => {
+      pipe(
+        client.executeRequestOperation(queryOperation),
+        publish
+      );
+    }).not.toThrow();
 
-  await prepass(<App />);
-
-  const data = ssr.extractData();
-  expect(Object.keys(data).length).toBe(1);
+    const data = ssr.extractData();
+    expect(Object.keys(data).length).toBe(0);
+  });
 });

--- a/src/test-utils/ssr.test.tsx
+++ b/src/test-utils/ssr.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import prepass from 'react-ssr-prepass';
+import { publish, filter, delay, pipe, map } from 'wonka';
+
+import { createClient } from '../client';
+import { Provider } from '../context';
+import { useQuery } from '../hooks';
+import { dedupExchange, cacheExchange, ssrExchange } from '../exchanges';
+import { Exchange } from '../types';
+import { queryOperation, queryResponse } from './index';
+
+const url = 'https://hostname.com';
+
+let ssr;
+let client;
+
+beforeEach(() => {
+  const fetchExchange: Exchange = () => ops$ => {
+    return pipe(
+      ops$,
+      filter(x => x.operationName === 'query'),
+      delay(100),
+      map(operation => ({ ...queryResponse, operation }))
+    );
+  };
+
+  ssr = ssrExchange();
+  client = createClient({
+    url,
+    // We include the SSR exchange after the cache
+    exchanges: [dedupExchange, cacheExchange, ssr, fetchExchange],
+    suspense: true,
+  });
+});
+
+it('correctly executes suspense and populates the SSR cache', async () => {
+  let promise;
+
+  try {
+    pipe(
+      client.executeRequestOperation(queryOperation),
+      publish
+    );
+  } catch (error) {
+    promise = error;
+  }
+
+  expect(promise).toBeInstanceOf(Promise);
+  const result = await promise;
+  expect(result.data).not.toBe(undefined);
+
+  const data = ssr.extractData();
+  expect(Object.keys(data).length).toBe(1);
+});
+
+it('works for an actual component tree', async () => {
+  const Query = () => {
+    useQuery({
+      query: queryOperation.query,
+      variables: queryOperation.variables,
+    });
+
+    return null;
+  };
+
+  const App = () => (
+    <Provider value={client}>
+      <Query />
+    </Provider>
+  );
+
+  await prepass(<App />);
+
+  const data = ssr.extractData();
+  expect(Object.keys(data).length).toBe(1);
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ export { CombinedError } from './error';
 export { getKeyForRequest } from './keyForQuery';
 export { createRequest } from './request';
 export { formatDocument, collectTypesFromResponse } from './typenames';
+export { toSuspenseSource } from './toSuspenseSource';
 
 export const noop = () => {
   /* noop */

--- a/src/utils/toSuspenseSource.test.ts
+++ b/src/utils/toSuspenseSource.test.ts
@@ -1,0 +1,102 @@
+import {
+  pipe,
+  onStart,
+  onPush,
+  onEnd,
+  fromValue,
+  fromArray,
+  makeSubject,
+  never,
+  subscribe,
+} from 'wonka';
+
+import { toSuspenseSource } from './toSuspenseSource';
+
+it('does nothing when not subscribed to', () => {
+  const start = jest.fn();
+
+  pipe(
+    fromValue('test'),
+    onStart(start),
+    toSuspenseSource
+  );
+
+  expect(start).not.toHaveBeenCalled();
+});
+
+it('resolves synchronously when the source resolves synchronously', () => {
+  const start = jest.fn();
+  const push = jest.fn();
+  let result;
+
+  pipe(
+    fromValue('test'),
+    onStart(start),
+    onPush(push),
+    toSuspenseSource,
+    subscribe(value => {
+      result = value;
+    })
+  );
+
+  expect(result).toBe('test');
+  expect(start).toHaveBeenCalledTimes(1);
+  expect(push).toHaveBeenCalledTimes(1);
+});
+
+it('throws a promise when the source is not resolving immediately', () => {
+  expect(() => {
+    pipe(
+      never,
+      toSuspenseSource,
+      subscribe(() => {})
+    );
+  }).toThrow(expect.any(Promise));
+});
+
+it('throws a promise that resolves when the source emits a value', () => {
+  const [source, push] = makeSubject();
+  const end = jest.fn();
+
+  let promise;
+  let result;
+
+  try {
+    pipe(
+      source,
+      toSuspenseSource,
+      onEnd(end),
+      subscribe(value => {
+        expect(value).toBe('test');
+        result = value;
+      })
+    );
+  } catch (error) {
+    promise = error;
+  }
+
+  // Expect it to have thrown
+  expect(promise).toBeInstanceOf(Promise);
+
+  push('test');
+  expect(result).toBe('test');
+
+  return promise.then(resolved => {
+    expect(resolved).toBe('test');
+    expect(end).toHaveBeenCalled();
+  });
+});
+
+it('behaves like a normal source when the first result was synchronous', async () => {
+  const push = jest.fn();
+  await new Promise(resolve => {
+    pipe(
+      fromArray([1, 2]),
+      toSuspenseSource,
+      onEnd(resolve),
+      subscribe(push)
+    );
+  });
+
+  expect(push).toHaveBeenCalledTimes(2);
+});

--- a/src/utils/toSuspenseSource.ts
+++ b/src/utils/toSuspenseSource.ts
@@ -1,0 +1,45 @@
+import { pipe, make, onPush, onEnd, subscribe, Source } from 'wonka';
+
+/** This converts a Source to a suspense Source; It will forward the first result synchronously or throw a promise that resolves when the result becomes available */
+export const toSuspenseSource = <T>(source: Source<T>): Source<T> => {
+  // Create a new Source from scratch so we have full control over the Source's lifecycle
+  return make(([push, end]) => {
+    let isCancelled = false;
+    let resolveSuspense;
+    let synchronousResult;
+
+    // Subscribe to the source and wait for the first result only
+    const [teardown] = pipe(
+      source,
+      onPush(push),
+      onEnd(end),
+      subscribe(value => {
+        // When this operation resolved synchronously assign the result to
+        // synchronousResult which will be picked up below
+        if (resolveSuspense === undefined) {
+          synchronousResult = value;
+        } else if (!isCancelled) {
+          // Otherwise we resolve this source and the thrown promise
+          resolveSuspense(value);
+          end();
+          teardown();
+        }
+      })
+    );
+
+    // If we have a synchronous result, push it onto this source, which is synchronous
+    // otherwise throw a new promise which will resolve later
+    if (synchronousResult === undefined) {
+      throw new Promise(resolve => {
+        resolveSuspense = resolve;
+      });
+    }
+
+    // Since promises aren't cancellable we have a flag that prevents
+    // the thrown promise from resolving if this source is cancelled
+    return () => {
+      isCancelled = true;
+      teardown();
+    };
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6252,15 +6252,17 @@ react-hooks-testing-library@^0.5.1:
   dependencies:
     "@babel/runtime" "^7.4.2"
 
-react-is@^16.8.1:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.1.tgz#a80141e246eb894824fb4f2901c0c50ef31d4cdb"
-  integrity sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA==
-
-react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-ssr-prepass@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.0.5.tgz#63ce763b2deb81949b20ccb2c64503ca53c562ba"
+  integrity sha512-A8QXXIHBpzr5/bnG3rwFgJWU6gLo7/dcW1bBIluoBI2hMyC+uuMRO+rXEtUpX6AVDhWfdFVi2I7kvWUDIRgDtA==
+  dependencies:
+    object-is "^1.0.1"
 
 react-test-renderer@^16.0.0-0:
   version "16.8.1"


### PR DESCRIPTION
Fix #218

Server-side rendering can now be achieved; an app using `urql` can do this with just minor modifications. Instead of using `getDataFromTree` like `react-apollo` does we're using our more generic [`react-ssr-prepass` library.](https://github.com/FormidableLabs/react-ssr-prepass)

This still needs to be documented but essentially on the server the client used like so:

```js
import ssrPrepass from 'react-ssr-prepass';

import {
  createClient,
  dedupExchange,
  cacheExchange,
  ssrExchange,
  fetchExchange
} from 'urql';

// We create an ssrExchange, which is an additional cache for client-side rehydration
const ssr = ssrExchange();

// The client can also be shared, but `suspense` needs to be set to
// false on the client-side
const client = createClient({
  url,
  exchanges: [dedupExchange, cacheExchange, ssr, fetchExchange],
  suspense: true
});

// The user has their app somewhere
const App = () => {/* ... */};
// We execute the SSR prepass
await ssrPrepass(<App />);

// Now we can extract the data:
const data = ssr.extractData();

// ...
// This is where renderToString or something goes
// We then need to send down the urql ssr data in the HTML as well
const html = `<script>window.DATA = (${JSON.stringify(data)});</script>`
```

And on the client we also use the SSR exchange to rehydrate the data:

```js
import {
  createClient,
  dedupExchange,
  cacheExchange,
  ssrExchange,
  fetchExchange
} from 'urql';

// We create an ssrExchange, which is an additional cache for client-side rehydration
const ssr = ssrExchange({ initialState: window.DATA });

// The above can also be used as:
// ssr.restoreData(window.DATA);

const client = createClient({
  url,
  exchanges: [dedupExchange, cacheExchange, ssr, fetchExchange],
  suspense: false // NOTE this is false on the client
});

// ...
// ReactDOM.rehydrate or otherwise
```