### PR TITLE
Modify use of pause

### DIFF
--- a/src/hooks/useImmediateEffect.ts
+++ b/src/hooks/useImmediateEffect.ts
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { useRef, useEffect } from 'react';
-import { noop } from '../utils';
+import { useRef, useEffect, EffectCallback } from 'react';
 
 enum LifecycleState {
   WillMount = 0,
@@ -9,14 +8,12 @@ enum LifecycleState {
   Update = 2,
 }
 
-type Effect = () => () => void;
-
 /** This is a drop-in replacement for useEffect that will execute the first effect that happens during initial mount synchronously */
 export const useImmediateEffect = (
-  effect: Effect,
+  effect: EffectCallback,
   changes: ReadonlyArray<any>
 ) => {
-  const teardown = useRef(noop);
+  const teardown = useRef<ReturnType<EffectCallback>>(undefined);
   const state = useRef(LifecycleState.WillMount);
 
   // On initial render we just execute the effect


### PR DESCRIPTION
The proposed changes here are aimed to simplify the use-cases associated with the `pause` argument.

Rather than pause preventing requests outright - it will _pause_ the functionality of auto fetching  - whether that be on mount or when the query has changed.

The reasons for this are:
 - It allows users to pause auto fetching while having the ability to manually fetch on demand (currently not an option - see [example problem here](https://www.reddit.com/r/reactjs/comments/bxu4hc/urql_v11_now_with_serverside_rendering_support/eqb3sj0?utm_source=share&utm_medium=web2x))
 - It improves the seperation of concerns. Config options should influence how urql acts, manual operations can be prevented with a conditional inside component logic. 

There's also a small typing fix for _useImmediateEffect_.

<details>
<summary>Example usage</summary>

```tsx
const MySearch = () => {
  const [variables, setVariables] = useState({ searchString: "" });
  const [searchResults, fetchSearchResults] = useQuery({ query, variables, skip: true });

  const throttledFetch = throttle(fetchSearchResults, 200); 

  const handleChange = (e) => {
    setVariables({ searchString: e.target.value });
    throttledFetch();
  };

  return (
    <input value={vars.searchString} onChange={handleChange} />
    <Results values={searchResults} />
  )
}
```

</details>

### Additional notes
The advantages of this approach are pretty clear but it does highlight a bug that we haven't yet addressed - updating variables/query values and immediately executing them in the same render doesnt act as expected.

I've created an [issue about this](https://github.com/FormidableLabs/urql/issues/279) and I believe the best way to go about this is to allow arguments to be overridden when manually fetching.