### PR TITLE
Fix dedup ignoring torn down query operations

### DIFF
--- a/src/exchanges/dedup.test.ts
+++ b/src/exchanges/dedup.test.ts
@@ -75,6 +75,19 @@ it('forwards duplicate query operations as usual after they respond', async () =
   expect(forwardedOperations.length).toBe(2);
 });
 
+it('forwards duplicate query operations after one was torn down', async () => {
+  shouldRespond = false; // We filter out our mock responses
+  const [ops$, next, complete] = input;
+  const exchange = dedupExchange(exchangeArgs)(ops$);
+
+  publish(exchange);
+  next(queryOperation);
+  next({ ...queryOperation, operationName: 'teardown' });
+  next(queryOperation);
+  complete();
+  expect(forwardedOperations.length).toBe(3);
+});
+
 it('always forwards mutation operations without deduplicating them', async () => {
   shouldRespond = false; // We filter out our mock responses
   const [ops$, next, complete] = input;


### PR DESCRIPTION
Fix #280 

When a query was torn down, the dedup exchange wasn't
removing its key from the inFlight keys.

This was causing us to ignore torn down queries forever.