### PR TITLE
Fix PostUpvoter variables

### DIFF
--- a/examples/3-ssr-with-nextjs/components/PostUpvoter.js
+++ b/examples/3-ssr-with-nextjs/components/PostUpvoter.js
@@ -17,10 +17,8 @@ export default function PostUpvoter({ votes, id }) {
 
   const upvotePost = useCallback(() => {
     executeMutation({
-      variables: {
-        id,
-        votes: votes + 1,
-      },
+      id,
+      votes: votes + 1,
     });
   }, [votes, id, executeMutation]);
 


### PR DESCRIPTION
The upvote buttons in the Next example weren’t working, this fixes it.