### PR TITLE
Move all build tasks to Rollup

### DIFF
--- a/.sail.yml
+++ b/.sail.yml
@@ -2,6 +2,7 @@ workflow:
   - install
   - sail:parallel:
     - build
+    - check
     - lint
     - test
     - e2e
@@ -36,6 +37,12 @@ tasks:
       - yarn
     args:
       - build
+  check:
+    image: node:10
+    command:
+      - yarn
+    args:
+      - check
   e2e:
     image: cypress/browsers:node10.2.1-chrome74
     command:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "jest",
     "coverage": "jest --coverage",
     "lint": "eslint . --ext .ts,.tsx",
-    "prepublishOnly": "run-s clean build",
+    "prepublishOnly": "run-s clean test build",
     "codecov": "codecov"
   },
   "author": "Formidable",

--- a/package.json
+++ b/package.json
@@ -21,17 +21,13 @@
     "exchanges"
   ],
   "scripts": {
-    "prebuild": "rimraf dist",
-    "build": "run-p build:types build:bundle",
-    "build:clean": "rimraf dist",
-    "build:types": "tsc -d --emitDeclarationOnly --outDir dist/types",
-    "build:bundle": "rollup -c rollup.config.js",
-    "build:prune": "rimraf dist/types/**/*.test.d.ts dist/types/test-utils",
+    "clean": "rimraf ./dist ./node_modules/.cache",
+    "build": "rollup -c rollup.config.js",
+    "watch": "rollup -w -c rollup.config.js",
     "test": "jest",
     "coverage": "jest --coverage",
     "lint": "eslint . --ext .ts,.tsx",
-    "check-formatting": "prettier --write src/**/*.{ts,tsx}",
-    "prepublishOnly": "run-s build build:prune",
+    "prepublishOnly": "run-s clean build",
     "codecov": "codecov"
   },
   "author": "Formidable",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clean": "rimraf ./dist ./node_modules/.cache",
     "build": "rollup -c rollup.config.js",
     "watch": "rollup -w -c rollup.config.js",
+    "check": "tsc --noEmit",
     "test": "jest",
     "coverage": "jest --coverage",
     "lint": "eslint . --ext .ts,.tsx",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -69,7 +69,7 @@ const terserMinified = terser({
   }
 });
 
-const plugins = [
+const makePlugins = (isProduction = false) => [
   nodeResolve({
     mainFields: ['module', 'jsnext', 'main'],
     browser: true
@@ -84,14 +84,21 @@ const plugins = [
   typescript({
     typescript: require('typescript'),
     cacheRoot: './node_modules/.cache/.rts2_cache',
+    useTsconfigDeclarationDir: true,
     tsconfigDefaults: {
       compilerOptions: {
-        sourceMap: true,
-        declaration: true
+        sourceMap: true
       },
     },
     tsconfigOverride: {
-      compilerOptions: {
+     exclude: [
+       'src/**/*.test.ts',
+       'src/**/*.test.tsx',
+       'src/**/test-utils/*'
+     ],
+     compilerOptions: {
+        declaration: !isProduction,
+        declarationDir: './dist/types/',
         target: 'es6',
       },
     },
@@ -123,7 +130,8 @@ const plugins = [
         externalHelpers: true
       }]
     ]
-  })
+  }),
+  isProduction ? terserMinified : terserPretty
 ];
 
 const config = {
@@ -137,7 +145,7 @@ const config = {
 export default [
   {
     ...config,
-    plugins: [...plugins, terserPretty],
+    plugins: makePlugins(false),
     output: [
       {
         sourcemap: true,
@@ -158,7 +166,7 @@ export default [
     ]
   }, {
     ...config,
-    plugins: [...plugins, terserMinified],
+    plugins: makePlugins(true),
     output: [
       {
         sourcemap: true,


### PR DESCRIPTION
- Declarations are now generated as part of the Rollup build
- The Rollup build overrides the tsconfig correctly now and no changes to the output were made
- The clean task now runs only before publishing as that's the only time we care about it
- Prune was removed; instead we just exclude test files inside Rollup