### PR TITLE
add typename existence check

### DIFF
--- a/src/utils/typenames.test.ts
+++ b/src/utils/typenames.test.ts
@@ -7,15 +7,37 @@ const formatTypeNames = (query: string) => {
 };
 
 describe('formatTypeNames', () => {
-  it('should add typenames to a query string', () => {
-    expect(formatTypeNames(`{ todos { id } }`)).toBe(`{
-  todos {
-    id
-    __typename
-  }
-  __typename
-}
-`);
+  it('adds typenames to a query string', () => {
+    expect(formatTypeNames(`{ todos { id } }`)).toMatchInlineSnapshot(`
+      "{
+        todos {
+          id
+          __typename
+        }
+        __typename
+      }
+      "
+    `);
+  });
+
+  it('does not duplicate typenames', () => {
+    expect(
+      formatTypeNames(`{ 
+      todos { 
+        id
+      }
+      __typename
+    }`)
+    ).toMatchInlineSnapshot(`
+            "{
+              todos {
+                id
+                __typename
+              }
+              __typename
+            }
+            "
+        `);
   });
 });
 

--- a/src/utils/typenames.ts
+++ b/src/utils/typenames.ts
@@ -36,13 +36,16 @@ export const collectTypesFromResponse = (response: object) =>
 const formatNode = (
   n: FieldNode | InlineFragmentNode | OperationDefinitionNode
 ) => {
+  if (n.selectionSet === undefined) {
+    return false;
+  }
+
   if (
-    n.selectionSet === undefined ||
     n.selectionSet.selections.some(
       s => s.kind === 'Field' && s.name.value === '__typename'
     )
   ) {
-    return false;
+    return n;
   }
 
   return {

--- a/src/utils/typenames.ts
+++ b/src/utils/typenames.ts
@@ -35,25 +35,33 @@ export const collectTypesFromResponse = (response: object) =>
 
 const formatNode = (
   n: FieldNode | InlineFragmentNode | OperationDefinitionNode
-) =>
-  n.selectionSet !== undefined && n.selectionSet.selections !== undefined
-    ? {
-        ...n,
-        selectionSet: {
-          ...n.selectionSet,
-          selections: [
-            ...n.selectionSet.selections,
-            {
-              kind: 'Field',
-              name: {
-                kind: 'Name',
-                value: '__typename',
-              },
-            },
-          ],
+) => {
+  if (
+    n.selectionSet === undefined ||
+    n.selectionSet.selections.some(
+      s => s.kind === 'Field' && s.name.value === '__typename'
+    )
+  ) {
+    return false;
+  }
+
+  return {
+    ...n,
+    selectionSet: {
+      ...n.selectionSet,
+      selections: [
+        ...n.selectionSet.selections,
+        {
+          kind: 'Field',
+          name: {
+            kind: 'Name',
+            value: '__typename',
+          },
         },
-      }
-    : false;
+      ],
+    },
+  };
+};
 
 export const formatDocument = (astNode: DocumentNode) =>
   visit(astNode, {


### PR DESCRIPTION
Fix #320 

**Note: ** The [check for a selections array](https://github.com/FormidableLabs/urql/compare/320-fix-typename-additions?expand=1#diff-f56409a2c09e8916f77be7385bb12343L39) inside of the selectionSet has been removed. According to _@types/graphql_ the [selections property is required](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/graphql/language/ast.d.ts#L226).