### PR TITLE
Flag responses with cache hit status

### DIFF
--- a/src/exchanges/cache.test.ts
+++ b/src/exchanges/cache.test.ts
@@ -76,7 +76,7 @@ describe('on query', () => {
   });
 
   describe('cache hit', () => {
-    it('is false when operation is forwarded', () => {
+    it('is miss when operation is forwarded', () => {
       const [ops$, next, complete] = input;
       const exchange = cacheExchange(exchangeArgs)(ops$);
 
@@ -84,7 +84,10 @@ describe('on query', () => {
       next(queryOperation);
       complete();
 
-      expect(forwardedOperations[0].context).toHaveProperty('cacheHit', false);
+      expect(forwardedOperations[0].context).toHaveProperty(
+        'meta.cacheOutcome',
+        'miss'
+      );
     });
 
     it('is true when cached response is returned', async () => {
@@ -103,7 +106,10 @@ describe('on query', () => {
       complete();
 
       const results = await results$;
-      expect(results[1].operation.context).toHaveProperty('cacheHit', true);
+      expect(results[1].operation.context).toHaveProperty(
+        'meta.cacheOutcome',
+        'hit'
+      );
     });
   });
 });

--- a/src/exchanges/cache.ts
+++ b/src/exchanges/cache.ts
@@ -72,9 +72,9 @@ export const cacheExchange: Exchange = ({ forward, client }) => {
         }
 
         return {
-          operation,
           data: undefined,
           error: undefined,
+          operation: addMetadata(operation, { cacheOutcome: 'miss' }),
         };
       })
     );
@@ -158,10 +158,7 @@ const afterQuery = (
     return;
   }
 
-  resultCache.set(operation.key, {
-    ...response,
-    operation,
-  });
+  resultCache.set(operation.key, response);
 
   collectTypesFromResponse(response.data).forEach(typeName => {
     const operations =

--- a/src/hooks/useDevtoolsContext.ts
+++ b/src/hooks/useDevtoolsContext.ts
@@ -18,7 +18,7 @@ const getHookParent = () => {
 const useDevtoolsContextHook = () => {
   const source = useRef(getHookParent());
 
-  return useMemo(() => [{ devtools: { source: source.current } }], []);
+  return useMemo(() => [{ meta: { source: source.current } }], []);
 };
 
 /** Creates additional context values for serving metadata to devtools. */

--- a/src/hooks/useMutation.test.tsx
+++ b/src/hooks/useMutation.test.tsx
@@ -112,7 +112,7 @@ describe('on execute', () => {
     act(() => {
       execute(vars);
     });
-    expect(client.executeMutation.mock.calls[0][1]).toHaveProperty('devtools', {
+    expect(client.executeMutation.mock.calls[0][1]).toHaveProperty('meta', {
       source: 'MutationUser',
     });
   });

--- a/src/hooks/useQuery.test.tsx
+++ b/src/hooks/useQuery.test.tsx
@@ -95,7 +95,7 @@ describe('on initial useEffect', () => {
     expect(client.executeQuery).toBeCalledWith(
       expect.any(Object),
       expect.objectContaining({
-        devtools: {
+        meta: {
           source: 'QueryUser',
         },
       })

--- a/src/hooks/useSubscription.test.tsx
+++ b/src/hooks/useSubscription.test.tsx
@@ -65,7 +65,7 @@ describe('on initial useEffect', () => {
     renderer.create(<SubscriptionUser q={query} />);
     expect(client.executeSubscription).toBeCalledWith(
       expect.any(Object),
-      expect.objectContaining({ devtools: { source: 'SubscriptionUser' } })
+      expect.objectContaining({ meta: { source: 'SubscriptionUser' } })
     );
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,9 @@ export type RequestPolicy =
   | 'network-only'
   | 'cache-and-network';
 
+/** How the operation has */
+export type CacheOutcome = 'miss' | 'partial' | 'hit';
+
 /** A Graphql query, mutation, or subscription. */
 export interface GraphQLRequest {
   /** Unique identifier of the request. */
@@ -32,6 +35,11 @@ export interface OperationContext {
   fetchOptions?: RequestInit | (() => RequestInit);
   requestPolicy: RequestPolicy;
   url: string;
+  meta?: {
+    source?: string;
+    cacheOutcome?: CacheOutcome;
+    networkLatency?: number;
+  };
 }
 
 /** A [query]{@link Query} or [mutation]{@link Mutation} with additional metadata for use during transmission. */

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 import { getKeyForRequest } from './keyForQuery';
-import { GraphQLRequest } from '../types';
+import { GraphQLRequest, Operation, OperationContext } from '../types';
 
 export const createRequest = (
   q: string | DocumentNode,
@@ -15,3 +15,18 @@ export const createRequest = (
     variables: vars || {},
   };
 };
+
+/** Spreads the provided metadata to the source operation's meta property in context.  */
+export const addMetadata = (
+  source: Operation,
+  meta: Exclude<OperationContext['meta'], undefined>
+) => ({
+  ...source,
+  context: {
+    ...source.context,
+    meta: {
+      ...source.context.meta,
+      ...meta,
+    },
+  },
+});


### PR DESCRIPTION
When using the default cache exchange, responses will have an additional property `cacheHit` added to their context.

This property will not be added to the global context type definition as it is specific to this cache. Future cache implementations may use this `cacheHit` property in a different way (i.e. cache hits could be flagged as partial).