### PR TITLE
Add latency info to context

### DIFF
--- a/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`returns error data from fetch 1`] = `
+exports[`on error returns error data 1`] = `
 Object {
   "data": undefined,
   "error": [CombinedError: [Network] ],
@@ -9,6 +9,7 @@ Object {
       "fetchOptions": Object {
         "method": "POST",
       },
+      "latency": 0,
       "requestPolicy": "cache-first",
       "url": "http://localhost:3000/graphql",
     },
@@ -128,7 +129,7 @@ Object {
 }
 `;
 
-exports[`returns response data from fetch 1`] = `
+exports[`on success returns response data 1`] = `
 Object {
   "data": Object {
     "data": Object {
@@ -149,6 +150,7 @@ Object {
           },
         ],
       },
+      "latency": 0,
       "requestPolicy": "cache-first",
       "url": "http://localhost:3000/graphql",
     },

--- a/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -9,7 +9,9 @@ Object {
       "fetchOptions": Object {
         "method": "POST",
       },
-      "latency": 0,
+      "meta": Object {
+        "networkLatency": 100,
+      },
       "requestPolicy": "cache-first",
       "url": "http://localhost:3000/graphql",
     },
@@ -150,7 +152,9 @@ Object {
           },
         ],
       },
-      "latency": 0,
+      "meta": Object {
+        "networkLatency": 100,
+      },
       "requestPolicy": "cache-first",
       "url": "http://localhost:3000/graphql",
     },

--- a/src/exchanges/fetch.test.ts
+++ b/src/exchanges/fetch.test.ts
@@ -40,69 +40,97 @@ const exchangeArgs = {
   client: {} as Client,
 };
 
-it('returns response data from fetch', async () => {
-  fetch.mockResolvedValue({
-    status: 200,
-    json: jest.fn().mockResolvedValue(response),
+describe('on success', () => {
+  beforeEach(() => {
+    fetch.mockResolvedValue({
+      status: 200,
+      json: jest.fn().mockResolvedValue(response),
+    });
   });
 
-  const fetchOptions = jest.fn().mockReturnValue({});
+  it('returns response data', async () => {
+    const fetchOptions = jest.fn().mockReturnValue({});
 
-  const data = await pipe(
-    fromValue({
-      ...queryOperation,
-      context: {
-        ...queryOperation.context,
-        fetchOptions,
-      },
-    }),
-    fetchExchange(exchangeArgs),
-    toPromise
-  );
+    const data = await pipe(
+      fromValue({
+        ...queryOperation,
+        context: {
+          ...queryOperation.context,
+          fetchOptions,
+        },
+      }),
+      fetchExchange(exchangeArgs),
+      toPromise
+    );
 
-  expect(data).toMatchSnapshot();
-  expect(fetchOptions).toHaveBeenCalled();
-});
-
-it('returns error data from fetch', async () => {
-  fetch.mockResolvedValue({
-    status: 400,
-    json: jest.fn().mockResolvedValue(response),
+    expect(data).toMatchSnapshot();
+    expect(fetchOptions).toHaveBeenCalled();
   });
 
-  const data = await pipe(
-    fromValue(queryOperation),
-    fetchExchange(exchangeArgs),
-    toPromise
-  );
+  it('adds latency info to the context', async () => {
+    jest
+      .spyOn(Date, 'now')
+      .mockImplementationOnce(() => 100)
+      .mockImplementationOnce(() => 200);
 
-  expect(data).toMatchSnapshot();
+    const data = await pipe(
+      fromValue({
+        ...queryOperation,
+        context: {
+          ...queryOperation.context,
+        },
+      }),
+      fetchExchange(exchangeArgs),
+      toPromise
+    );
+
+    expect(data.operation.context).toHaveProperty('latency', 100);
+  });
 });
 
-it('calls cancel when the Observable is cancelled', () => {
-  fetch.mockReturnValue(Promise.reject(abortError));
+describe('on error', () => {
+  it('returns error data', async () => {
+    fetch.mockResolvedValue({
+      status: 400,
+      json: jest.fn().mockResolvedValue(response),
+    });
 
-  const [unsubscribe] = pipe(
-    fromValue(queryOperation),
-    fetchExchange(exchangeArgs),
-    subscribe(fail)
-  );
+    const data = await pipe(
+      fromValue(queryOperation),
+      fetchExchange(exchangeArgs),
+      toPromise
+    );
 
-  unsubscribe();
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(abort).toHaveBeenCalledTimes(1);
+    expect(data).toMatchSnapshot();
+  });
 });
 
-it('should not start the operation when teardown gets passed', () => {
-  pipe(
-    fromValue({
-      ...queryOperation,
-      operationName: 'teardown' as OperationType,
-    }),
-    fetchExchange(exchangeArgs),
-    subscribe(fail)
-  );
+describe('on teardown', () => {
+  it('aborts the outgoing request', () => {
+    fetch.mockReturnValue(Promise.reject(abortError));
 
-  expect(fetch).toHaveBeenCalledTimes(0);
-  expect(abort).toHaveBeenCalledTimes(0);
+    const [unsubscribe] = pipe(
+      fromValue(queryOperation),
+      fetchExchange(exchangeArgs),
+      subscribe(fail)
+    );
+
+    unsubscribe();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call the query', () => {
+    pipe(
+      fromValue({
+        ...queryOperation,
+        operationName: 'teardown' as OperationType,
+      }),
+      fetchExchange(exchangeArgs),
+      subscribe(fail)
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(0);
+    expect(abort).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/exchanges/fetch.ts
+++ b/src/exchanges/fetch.ts
@@ -2,7 +2,7 @@
 import { print } from 'graphql';
 import { filter, make, merge, mergeMap, pipe, share, takeUntil } from 'wonka';
 import { Exchange, Operation, OperationResult } from '../types';
-import { CombinedError } from '../utils/error';
+import { addMetadata, CombinedError } from '../utils';
 
 /** A default exchange for fetching GraphQL requests. */
 export const fetchExchange: Exchange = ({ forward }) => {
@@ -80,13 +80,9 @@ const createFetchSource = (operation: Operation) => {
       if (result !== undefined) {
         next({
           ...result,
-          operation: {
-            ...result.operation,
-            context: {
-              ...result.operation.context,
-              latency: Date.now() - startTime,
-            },
-          },
+          operation: addMetadata(result.operation, {
+            networkLatency: Date.now() - startTime,
+          }),
         });
       }
 

--- a/src/exchanges/fetch.ts
+++ b/src/exchanges/fetch.ts
@@ -75,9 +75,19 @@ const createFetchSource = (operation: Operation) => {
         abortController !== undefined ? abortController.signal : undefined,
     };
 
+    const startTime = Date.now();
     executeFetch(operation, fetchOptions).then(result => {
       if (result !== undefined) {
-        next(result);
+        next({
+          ...result,
+          operation: {
+            ...result.operation,
+            context: {
+              ...result.operation.context,
+              latency: Date.now() - startTime,
+            },
+          },
+        });
       }
 
       complete();


### PR DESCRIPTION
Adds a _latency_ property to a returning operation's context. This is the duration in milliseconds that the request took to complete.