### PR TITLE
Replace useDevtoolsContext Error.stack with Fiber approach

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -88,7 +88,7 @@ export class Client {
   }
 
   private createOperationContext = (
-    opts?: void | Partial<OperationContext>
+    opts?: Partial<OperationContext>
   ): OperationContext => {
     const { requestPolicy = 'cache-first' } = opts || {};
 
@@ -103,7 +103,7 @@ export class Client {
   createRequestOperation = (
     type: OperationType,
     { key, query, variables }: GraphQLRequest,
-    opts?: void | Partial<OperationContext>
+    opts?: Partial<OperationContext>
   ): Operation => ({
     key,
     query,
@@ -167,7 +167,7 @@ export class Client {
 
   executeQuery = (
     query: GraphQLRequest,
-    opts?: void | Partial<OperationContext>
+    opts?: Partial<OperationContext>
   ): Source<OperationResult> => {
     const operation = this.createRequestOperation('query', query, opts);
     return this.executeRequestOperation(operation);
@@ -175,7 +175,7 @@ export class Client {
 
   executeSubscription = (
     query: GraphQLRequest,
-    opts?: void | Partial<OperationContext>
+    opts?: Partial<OperationContext>
   ): Source<OperationResult> => {
     const operation = this.createRequestOperation('subscription', query, opts);
     return this.executeRequestOperation(operation);
@@ -183,7 +183,7 @@ export class Client {
 
   executeMutation = (
     query: GraphQLRequest,
-    opts?: void | Partial<OperationContext>
+    opts?: Partial<OperationContext>
   ): Source<OperationResult> => {
     const operation = this.createRequestOperation('mutation', query, opts);
     return this.executeRequestOperation(operation);

--- a/src/client.ts
+++ b/src/client.ts
@@ -88,7 +88,7 @@ export class Client {
   }
 
   private createOperationContext = (
-    opts?: Partial<OperationContext>
+    opts?: void | Partial<OperationContext>
   ): OperationContext => {
     const { requestPolicy = 'cache-first' } = opts || {};
 
@@ -103,7 +103,7 @@ export class Client {
   createRequestOperation = (
     type: OperationType,
     { key, query, variables }: GraphQLRequest,
-    opts?: Partial<OperationContext>
+    opts?: void | Partial<OperationContext>
   ): Operation => ({
     key,
     query,
@@ -167,7 +167,7 @@ export class Client {
 
   executeQuery = (
     query: GraphQLRequest,
-    opts?: Partial<OperationContext>
+    opts?: void | Partial<OperationContext>
   ): Source<OperationResult> => {
     const operation = this.createRequestOperation('query', query, opts);
     return this.executeRequestOperation(operation);
@@ -175,7 +175,7 @@ export class Client {
 
   executeSubscription = (
     query: GraphQLRequest,
-    opts?: Partial<OperationContext>
+    opts?: void | Partial<OperationContext>
   ): Source<OperationResult> => {
     const operation = this.createRequestOperation('subscription', query, opts);
     return this.executeRequestOperation(operation);
@@ -183,7 +183,7 @@ export class Client {
 
   executeMutation = (
     query: GraphQLRequest,
-    opts?: Partial<OperationContext>
+    opts?: void | Partial<OperationContext>
   ): Source<OperationResult> => {
     const operation = this.createRequestOperation('mutation', query, opts);
     return this.executeRequestOperation(operation);

--- a/src/hooks/useDevtoolsContext.test.ts
+++ b/src/hooks/useDevtoolsContext.test.ts
@@ -84,7 +84,7 @@ it('retrieves the component name for class components using Query', () => {
   });
 });
 
-it('leaves a default name for unknown fibers', () => {
+it('looks at the parent component, not the parent fiber', () => {
   let hookResult;
 
   // A context consumer/provider has a different Fiber type
@@ -98,6 +98,7 @@ it('leaves a default name for unknown fibers', () => {
 
   class OuterClassComponent extends Component {
     render() {
+      // Basically put one element "in the middle" of OuterClassComponent and Query
       return React.createElement(
         TestContext.Provider,
         { value: 'test' },
@@ -110,7 +111,7 @@ it('leaves a default name for unknown fibers', () => {
 
   expect(hookResult).toEqual({
     meta: {
-      source: 'Query', // the devtool hook didn't walk up the fiber tree
+      source: 'OuterClassComponent',
     },
   });
 });

--- a/src/hooks/useDevtoolsContext.test.ts
+++ b/src/hooks/useDevtoolsContext.test.ts
@@ -1,0 +1,116 @@
+import React, { Component } from 'react';
+import renderer from 'react-test-renderer';
+import { useDevtoolsContext } from './useDevtoolsContext';
+
+it('retrieves the component name for function components', () => {
+  let hookResult;
+
+  const TestFunComponent = () => {
+    hookResult = useDevtoolsContext();
+    return null;
+  };
+
+  renderer.create(React.createElement(TestFunComponent));
+
+  expect(hookResult).toEqual({
+    meta: {
+      source: 'TestFunComponent',
+    },
+  });
+});
+
+it('prefers displayNames', () => {
+  let hookResult;
+
+  const TestFunComponent = () => {
+    hookResult = useDevtoolsContext();
+    return null;
+  };
+
+  TestFunComponent.displayName = 'TestFun';
+
+  renderer.create(React.createElement(TestFunComponent));
+
+  expect(hookResult).toEqual({
+    meta: {
+      source: 'TestFun',
+    },
+  });
+});
+
+it('retrieves the component name for function components using Query', () => {
+  let hookResult;
+
+  // We're not using the actual query component here but one with the _same name_
+  const Query = () => {
+    hookResult = useDevtoolsContext();
+    return null;
+  };
+
+  const OuterFunComponent = () => {
+    return React.createElement(Query);
+  };
+
+  renderer.create(React.createElement(OuterFunComponent));
+
+  expect(hookResult).toEqual({
+    meta: {
+      source: 'OuterFunComponent',
+    },
+  });
+});
+
+it('retrieves the component name for class components using Query', () => {
+  let hookResult;
+
+  // We're not using the actual query component here but one with the _same name_
+  const Query = () => {
+    hookResult = useDevtoolsContext();
+    return null;
+  };
+
+  class OuterClassComponent extends Component {
+    render() {
+      return React.createElement(Query);
+    }
+  }
+
+  renderer.create(React.createElement(OuterClassComponent));
+
+  expect(hookResult).toEqual({
+    meta: {
+      source: 'OuterClassComponent',
+    },
+  });
+});
+
+it('leaves a default name for unknown fibers', () => {
+  let hookResult;
+
+  // A context consumer/provider has a different Fiber type
+  const TestContext = React.createContext('');
+
+  // We're not using the actual query component here but one with the _same name_
+  const Query = () => {
+    hookResult = useDevtoolsContext();
+    return null;
+  };
+
+  class OuterClassComponent extends Component {
+    render() {
+      return React.createElement(
+        TestContext.Provider,
+        { value: 'test' },
+        React.createElement(Query)
+      );
+    }
+  }
+
+  renderer.create(React.createElement(OuterClassComponent));
+
+  expect(hookResult).toEqual({
+    meta: {
+      source: 'Query', // the devtool hook didn't walk up the fiber tree
+    },
+  });
+});

--- a/src/hooks/useDevtoolsContext.ts
+++ b/src/hooks/useDevtoolsContext.ts
@@ -43,7 +43,7 @@ const useDevtoolsContextImpl = (): Partial<OperationContext> => {
 };
 
 /** Creates additional context values for serving metadata to devtools. */
-export const useDevtoolsContext: () => Partial<OperationContext> | void =
+export const useDevtoolsContext: () => Partial<OperationContext> | undefined =
   // NOTE: We check for CurrentOwner in case it'll be unexpectedly changed in React's source
   process.env.NODE_ENV !== 'production' && !!CurrentOwner
     ? useDevtoolsContextImpl

--- a/src/hooks/useDevtoolsContext.ts
+++ b/src/hooks/useDevtoolsContext.ts
@@ -1,28 +1,47 @@
-import { useMemo, useRef } from 'react';
+import * as React from 'react';
+import { OperationContext } from '../types';
 
-/** Find the name of the calling component. */
-const getHookParent = () => {
-  /**
-   * Line values could be:
-   * - named export             " at exports.Home (Home.tsx?9b1b:17)"
-   * - default export / inline  " at Home (Home.tsx?9b1b:17)"
-   */
-  const stackLine = (new Error().stack as string).split('\n')[3];
-  const parsedLine = /.*at (exports\.)?(\w+)/.exec(stackLine);
+const {
+  ReactCurrentOwner: CurrentOwner,
+} = (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
-  return parsedLine === null || typeof parsedLine[2] !== 'string'
-    ? 'Unknown'
-    : parsedLine[2];
-};
+// Is the Fiber a FunctionComponent, ClassComponent, or IndeterminateComponent
+const isComponentFiber = ({ tag }: { tag: number }) =>
+  tag === 0 || tag === 1 || tag === 2;
 
-const useDevtoolsContextHook = () => {
-  const source = useRef(getHookParent());
+// Is the component one of ours (just a heuristic to avoid circular dependencies or flags)
+const isInternalComponent = (Component: { name: string }) =>
+  Component.name === 'Query' ||
+  Component.name === 'Mutation' ||
+  Component.name === 'Subscription';
 
-  return useMemo(() => [{ meta: { source: source.current } }], []);
+const useDevtoolsContextImpl = (): Partial<OperationContext> => {
+  return React.useMemo(() => {
+    let source = 'Component';
+
+    // Check whether the CurrentOwner is set
+    const owner = CurrentOwner.current;
+    if (owner !== null && isComponentFiber(owner)) {
+      let Component = owner.type;
+
+      // If this is one of our own components then check the parent
+      if (isInternalComponent(Component) && isComponentFiber(owner.return)) {
+        Component = owner.return.type;
+      }
+
+      // Get the Component's name if it has one
+      if (typeof Component === 'function') {
+        source = Component.displayName || Component.name || source;
+      }
+    }
+
+    return { meta: { source } };
+  }, []);
 };
 
 /** Creates additional context values for serving metadata to devtools. */
-export const useDevtoolsContext =
-  process.env.NODE_ENV === 'production'
-    ? () => [undefined]
-    : useDevtoolsContextHook;
+export const useDevtoolsContext: () => Partial<OperationContext> | void =
+  // NOTE: We check for CurrentOwner in case it'll be unexpectedly changed in React's source
+  process.env.NODE_ENV !== 'production' && !!CurrentOwner
+    ? useDevtoolsContextImpl
+    : () => undefined;

--- a/src/hooks/useDevtoolsContext.ts
+++ b/src/hooks/useDevtoolsContext.ts
@@ -6,8 +6,8 @@ const {
 } = (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
 // Is the Fiber a FunctionComponent, ClassComponent, or IndeterminateComponent
-const isComponentFiber = ({ tag }: { tag: number }) =>
-  tag === 0 || tag === 1 || tag === 2;
+const isComponentFiber = (fiber: void | { tag: number }) =>
+  fiber && (fiber.tag === 0 || fiber.tag === 1 || fiber.tag === 2);
 
 // Is the component one of ours (just a heuristic to avoid circular dependencies or flags)
 const isInternalComponent = (Component: { name: string }) =>
@@ -25,8 +25,11 @@ const useDevtoolsContextImpl = (): Partial<OperationContext> => {
       let Component = owner.type;
 
       // If this is one of our own components then check the parent
-      if (isInternalComponent(Component) && isComponentFiber(owner.return)) {
-        Component = owner.return.type;
+      if (
+        isInternalComponent(Component) &&
+        isComponentFiber(owner._debugOwner)
+      ) {
+        Component = owner._debugOwner.type;
       }
 
       // Get the Component's name if it has one

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -21,7 +21,7 @@ export type UseMutationResponse<T, V> = [
 export const useMutation = <T = any, V = object>(
   query: DocumentNode | string
 ): UseMutationResponse<T, V> => {
-  const [devtoolsContext] = useDevtoolsContext();
+  const devtoolsContext = useDevtoolsContext();
   const client = useContext(Context);
   const [state, setState] = useImmediateState<UseMutationState<T>>({
     fetching: false,

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -30,7 +30,7 @@ export type UseQueryResponse<T> = [
 export const useQuery = <T = any, V = object>(
   args: UseQueryArgs<V>
 ): UseQueryResponse<T> => {
-  const [devtoolsContext] = useDevtoolsContext();
+  const devtoolsContext = useDevtoolsContext();
   const unsubscribe = useRef(noop);
   const client = useContext(Context);
 

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -26,7 +26,7 @@ export const useSubscription = <T = any, R = T, V = object>(
   args: UseSubscriptionArgs<V>,
   handler?: SubscriptionHandler<T, R>
 ): UseSubscriptionResponse<R> => {
-  const [devtoolsContext] = useDevtoolsContext();
+  const devtoolsContext = useDevtoolsContext();
   const unsubscribe = useRef(noop);
   const client = useContext(Context);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,17 +29,20 @@ export interface GraphQLRequest {
   variables?: object;
 }
 
+/** Metadata that is only available in development for devtools. */
+export interface OperationDebugMeta {
+  source?: string;
+  cacheOutcome?: CacheOutcome;
+  networkLatency?: number;
+}
+
 /** Additional metadata passed to [exchange]{@link Exchange} functions. */
 export interface OperationContext {
   [key: string]: any;
   fetchOptions?: RequestInit | (() => RequestInit);
   requestPolicy: RequestPolicy;
   url: string;
-  meta?: {
-    source?: string;
-    cacheOutcome?: CacheOutcome;
-    networkLatency?: number;
-  };
+  meta?: OperationDebugMeta;
 }
 
 /** A [query]{@link Query} or [mutation]{@link Mutation} with additional metadata for use during transmission. */


### PR DESCRIPTION
(I added some tests for `useDevtoolsContext` first, before I started, just to check that it's still doing the right thing)

This replaces the `Error` stack to determine the current component name with a React Fiber approach, by looking at `ReactCurrentOwner`. This is generally safe and the data structure hasn't changed much since `react-reconciler` was implemented. There's also some guards in the implementation though just in case. But this is just for development after all.

The motivation behind this was that the stack approach can lead to incorrect names at times depending on the browser, minification in the app bundle, testing approach, and other factors, where the stack is unreliable.

So this looks at `ReactCurrentOwner`, which is a ref, checks whether we have a fiber (which we should) and whether it's a component (which it must be since we're checking from a hook). Then it gets the component and will use `displayName` (hooray, display names!) or `name` to determine the current component's name.

If the name is found to be an internal one (`Query`, `Mutation`, `Subscription`) then it'll walk up by one fiber and use the parent instead to get a more useful name. This is currently done using a heuristic as it should be sufficient for a development mode implementation.

I also added some support for class components, since walking one component up via the error stack is pretty tough (if not impossible?)

@andyrichardson: Hope you like it :tada: tl;dr I think it's potentially more stable and allows us to get the `displayName` and find the parent component for our own components :+1: