### PR TITLE
(fix) - return value of functional components

### DIFF
--- a/src/components/Mutation.ts
+++ b/src/components/Mutation.ts
@@ -1,11 +1,11 @@
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 import { DocumentNode } from 'graphql';
 import { OperationResult } from '../types';
 import { useMutation, UseMutationState } from '../hooks';
 
 export interface MutationProps<T, V> {
   query: DocumentNode | string;
-  children: (arg: MutationState<T, V>) => ReactNode;
+  children: (arg: MutationState<T, V>) => ReactElement<any>;
 }
 
 export interface MutationState<T, V> extends UseMutationState<T> {
@@ -15,7 +15,7 @@ export interface MutationState<T, V> extends UseMutationState<T> {
 export function Mutation<T = any, V = any>({
   children,
   query,
-}: MutationProps<T, V>): ReactNode {
+}: MutationProps<T, V>): ReactElement<any> {
   const [state, executeMutation] = useMutation<T, V>(query);
   return children({ ...state, executeMutation });
 }

--- a/src/components/Query.ts
+++ b/src/components/Query.ts
@@ -1,9 +1,9 @@
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 import { OperationContext } from '../types';
 import { useQuery, UseQueryArgs, UseQueryState } from '../hooks';
 
 export interface QueryProps<T, V> extends UseQueryArgs<V> {
-  children: (arg: QueryState<T>) => ReactNode;
+  children: (arg: QueryState<T>) => ReactElement<any>;
 }
 
 export interface QueryState<T> extends UseQueryState<T> {
@@ -13,7 +13,7 @@ export interface QueryState<T> extends UseQueryState<T> {
 export function Query<T = any, V = any>({
   children,
   ...args
-}: QueryProps<T, V>): ReactNode {
+}: QueryProps<T, V>): ReactElement<any> {
   const [state, executeQuery] = useQuery<T, V>(args);
   return children({ ...state, executeQuery });
 }

--- a/src/components/Subscription.ts
+++ b/src/components/Subscription.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 
 import {
   useSubscription,
@@ -9,14 +9,14 @@ import {
 
 export interface SubscriptionProps<T, R, V> extends UseSubscriptionArgs<V> {
   handler?: SubscriptionHandler<T, R>;
-  children: (arg: UseSubscriptionState<R>) => ReactNode;
+  children: (arg: UseSubscriptionState<R>) => ReactElement<any>;
 }
 
 export function Subscription<T = any, R = T, V = any>({
   children,
   handler,
   ...args
-}: SubscriptionProps<T, R, V>): ReactNode {
+}: SubscriptionProps<T, R, V>): ReactElement<any> {
   const [state] = useSubscription<T, R, V>(args, handler);
   return children(state);
 }


### PR DESCRIPTION
fixes: https://github.com/FormidableLabs/urql/issues/335

Normally one would use the exported type React.FC for these but since this isn't possible with generics I followed this line from the React types to come to this conclusion.

```
type SFC<P> = StatelessComponent<P>;
interface StatelessComponent<P> {
 (props: P & { children?: ReactNode }, context?: any): ReactElement<any>;
}
```