### PR TITLE
Fix error in collectTypes method

### DIFF
--- a/src/utils/typenames.ts
+++ b/src/utils/typenames.ts
@@ -16,7 +16,7 @@ const collectTypes = (obj: EntityLike | EntityLike[], types: string[] = []) => {
     obj.forEach(inner => collectTypes(inner, types));
   } else if (typeof obj === 'object' && obj !== null) {
     for (const key in obj) {
-      if (obj.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
         const val = obj[key];
         if (key === '__typename' && typeof val === 'string') {
           types.push(val);


### PR DESCRIPTION
`obj.hasOwnProperty` can sometimes be undefined even though `obj` is an actual object, see this conversation over in another repo for reference: https://github.com/domchristie/humps/issues/35

I am (somehow through a million hoops) running into this in my project, and their suggested fix of using `Object.prototype.hasOwnProperty.call(obj, key)` works beautifully and fixes my issue.