### PR TITLE
(fix) - should reexecute operation on cache-and-network

### DIFF
--- a/src/exchanges/cache.test.ts
+++ b/src/exchanges/cache.test.ts
@@ -18,7 +18,7 @@ import {
   subscriptionResult,
   undefinedQueryResponse,
 } from '../test-utils';
-import { Operation, OperationResult } from '../types';
+import { Operation, OperationResult, RequestPolicy } from '../types';
 import { afterMutation, cacheExchange } from './cache';
 
 let response;
@@ -73,6 +73,23 @@ describe('on query', () => {
     complete();
     expect(forwardedOperations.length).toBe(1);
     expect(reexecuteOperation).not.toBeCalled();
+  });
+
+  it('should reexecute with cache-and-network policy', () => {
+    const [ops$, next, complete] = input;
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+    const cacheAndNetworkQueryOperation = {
+      ...queryOperation,
+      context: {
+        ...queryOperation.context,
+        requestPolicy: 'cache-and-network' as RequestPolicy,
+      },
+    };
+    publish(exchange);
+    next(queryOperation);
+    next(cacheAndNetworkQueryOperation);
+    complete();
+    expect(forwardedOperations.length).toBe(2);
   });
 
   describe('cache hit', () => {

--- a/src/exchanges/cache.ts
+++ b/src/exchanges/cache.ts
@@ -45,6 +45,7 @@ export const cacheExchange: Exchange = ({ forward, client }) => {
     return (
       operationName === 'query' &&
       requestPolicy !== 'network-only' &&
+      requestPolicy !== 'cache-and-network' &&
       (requestPolicy === 'cache-only' || resultCache.has(key))
     );
   };


### PR DESCRIPTION
This doesn't feel entirely right yet since cache-and-network should return AND dispatch a new request. This isn't the case yet was just making this PR to see if I'm on the correct path for this.