### PR TITLE
Fix useImmediateState for React Native

### DIFF
--- a/src/hooks/useImmediateState.ts
+++ b/src/hooks/useImmediateState.ts
@@ -20,22 +20,22 @@ const useIsomorphicLayoutEffect =
  */
 export const useImmediateState = <S extends {}>(init: S): [S, SetState<S>] => {
   const isMounted = useRef(false);
-  const initialState = useRef<S>({ ...init });
-  const [state, setState] = useState<S>(initialState.current);
+  const [state, setState] = useState<S>(init);
 
   // This wraps setState and updates the state mutably on initial mount
   const updateState: SetState<S> = useCallback(
     (action: SetStateAction<S>): void => {
       if (!isMounted.current) {
-        const newValue =
+        const newState =
           typeof action === 'function'
-            ? (action as (arg: S) => S)(initialState.current)
+            ? (action as (arg: S) => S)(state)
             : action;
-        Object.assign(initialState.current, newValue);
+        Object.assign(state, newState);
       } else {
         setState(action);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
 

--- a/src/hooks/useImmediateState.ts
+++ b/src/hooks/useImmediateState.ts
@@ -1,8 +1,17 @@
-import { useRef, useState, useCallback, useLayoutEffect } from 'react';
-import { isSSR } from '../utils';
+import {
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+} from 'react';
 
 type SetStateAction<S> = S | ((prevState: S) => S);
 type SetState<S> = (action: SetStateAction<S>) => void;
+
+// See https://github.com/reduxjs/react-redux/blob/316467a/src/hooks/useSelector.js#L6-L15
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * This is a drop-in replacement for useState, limited to object-based state.
@@ -30,13 +39,12 @@ export const useImmediateState = <S extends {}>(init: S): [S, SetState<S>] => {
     []
   );
 
-  !isSSR && // eslint-disable-next-line react-hooks/rules-of-hooks
-    useLayoutEffect(() => {
-      isMounted.current = true;
-      return () => {
-        isMounted.current = false;
-      };
-    }, []);
+  useIsomorphicLayoutEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   return [state, updateState];
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,6 @@
 export * from './error';
 export * from './keyForQuery';
 export * from './request';
-export * from './ssr';
 export * from './typenames';
 export * from './toSuspenseSource';
 

--- a/src/utils/ssr.ts
+++ b/src/utils/ssr.ts
@@ -1,2 +1,0 @@
-export const isSSR =
-  typeof window === 'undefined' || !('HTMLElement' in window);


### PR DESCRIPTION
The `ssr` check was failing on React Native since it was kind of aggressive. I don't really want to even have it or `useLayoutEffect` in place, but multiple React threads didn't really resolve concerns that have been raised with it. Even `react-redux` uses it in this way.

I tried to find an alternative solution, but it turns out that `useState(s => s)` which would be firing at a similar time still triggers an update.

I've left a link to react-redux's repo since they're likely also be looking out for a solution to this problem.