### PR TITLE
(fix) - export `formatDocument`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ export * from './components';
 export * from './exchanges';
 export * from './hooks';
 export * from './types';
-export { CombinedError, createRequest } from './utils';
+export { CombinedError, createRequest, formatDocument } from './utils';


### PR DESCRIPTION
When trying out the graphCache exchange I noticed we were missing the formatDocument helper that is used inside that package.

Relevant line: https://github.com/kitten/urql-exchange-graphcache/blob/master/src/exchange.ts#L3