### PR TITLE
Add a higher-order function a fetch exchange

### DIFF
--- a/src/exchanges/fetch.test.ts
+++ b/src/exchanges/fetch.test.ts
@@ -2,7 +2,7 @@ import { empty, fromValue, pipe, Source, subscribe, toPromise } from 'wonka';
 import { Client } from '../client';
 import { queryOperation } from '../test-utils';
 import { OperationResult, OperationType } from '../types';
-import { fetchExchange } from './fetch';
+import { fetchExchange, createFetchExchange } from './fetch';
 
 const fetch = (global as any).fetch as jest.Mock;
 const abort = jest.fn();
@@ -167,5 +167,27 @@ describe('on teardown', () => {
 
     expect(fetch).toHaveBeenCalledTimes(0);
     expect(abort).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('createFetchExchange', () => {
+  it('creates a new exchange', async () => {
+    const headers = { foo: 'bar' };
+    const buildRequest = jest.fn(() => ({ headers }));
+    const customExchange = createFetchExchange(buildRequest);
+
+    fetch.mockResolvedValue({});
+
+    await pipe(
+      fromValue(queryOperation),
+      customExchange(exchangeArgs),
+      toPromise
+    );
+
+    expect(buildRequest).toHaveBeenCalledWith(queryOperation);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers })
+    );
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,3 +74,6 @@ export type Exchange = (input: ExchangeInput) => ExchangeIO;
 
 /** Function responsible for receiving an observable [operation]{@link Operation} and returning a [result]{@link OperationResult}. */
 export type ExchangeIO = (ops$: Source<Operation>) => Source<OperationResult>;
+
+/** Function responsible for reciving an operation and returning configuration for fetch */
+export type RequestBuilder = (operation: Operation) => RequestInit;


### PR DESCRIPTION
Some features, such as file uploads, will require defining a new exchange to send a request. The `createFetchExchange` function will allow developers to customize requests at a low level, without
reimplementing the entire fetch exchange.

With this HOC, it should be relatively simple to build an exchange that handles file uploads.