### PR TITLE
Fix ssrExchange's client-mode defaulting based on suspense-mode

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -427,9 +427,15 @@ streams `GraphQLResult`s with `data` and `errors`.
 The `ssrExchange` as [described in the Basics section](basics.md#server-side-rendering).
 It's of type `Options => Exchange`.
 
-It accepts a single input, `{ initialState }`, which is completely
+It accepts two inputs, `initialState` which is completely
 optional and populates the server-side rendered data with
-a rehydrated cache.
+a rehydrated cache, and `isClient` which can be set to
+`true` or `false` to tell the `ssrExchange` whether to
+write to (server-side) or read from (client-side) the cache.
+
+By default `isClient` defaults to `true` when the `Client.suspense`
+mode is disabled and to `false` when the `Client.suspense` mode
+is enabled.
 
 This can be used to extract data that has been queried on
 the server-side, which is also described in the Basics section,

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -230,6 +230,15 @@ The exchange returned by `ssrExchange()` should be added after the `cacheExchang
 (or any other custom cache exchange you've defined), and before any
 asynchronous exchanges like the `fetchExchange`.
 
+If you're also using suspense mode on the client, you can
+additionally set the `isClient` option, which tells the `ssrExchange` manually
+whether it's on the server or client, so that you can enable the `suspense`
+mode on the client-side as well.
+
+```js
+const ssrCache = ssrExchange({ isClient: !!process.browser });
+```
+
 ### Prefetching on the server
 
 In your request handler on the server-side, you'll have to add some

--- a/src/exchanges/ssr.ts
+++ b/src/exchanges/ssr.ts
@@ -15,6 +15,7 @@ export interface SSRData {
 }
 
 export interface SSRExchangeParams {
+  isClient?: boolean;
   initialState?: SSRData;
 }
 
@@ -77,6 +78,13 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
   // The SSR Exchange is a temporary cache that can populate results into data for suspense
   // On the client it can be used to retrieve these temporary results from a rehydrated cache
   const ssr: SSRExchange = ({ client, forward }) => ops$ => {
+    // params.isClient tells us whether we're on the client-side
+    // By default we assume that we're on the client if suspense-mode is disabled
+    const isClient =
+      params && typeof params.isClient === 'boolean'
+        ? !!params.isClient
+        : !client.suspense;
+
     const sharedOps$ = share(ops$);
 
     let forwardedOps$ = pipe(
@@ -96,8 +104,8 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
       })
     );
 
-    if (client.suspense) {
-      // Inside suspense-mode we cache results in the cache as they're resolved
+    if (!isClient) {
+      // On the server we cache results in the cache as they're resolved
       forwardedOps$ = pipe(
         forwardedOps$,
         tap((result: OperationResult) => {
@@ -109,7 +117,7 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
         })
       );
     } else {
-      // Outside of suspense-mode we delete results from the cache as they're resolved
+      // On the client we delete results from the cache as they're resolved
       cachedOps$ = pipe(
         cachedOps$,
         tap((result: OperationResult) => {


### PR DESCRIPTION
Previously it was impossible to use the `ssrExchange` together with `suspense` mode on the client-side, since the `ssrExchange` assumes that it's on the server, when the `suspense` mode is turned on.

This PR adds a separate `isClient` option to `ssrExchange`, so it can be told whether it's running on the client-side manually.