### PR TITLE
Fix some British spellings in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-`urql` is a highly customisable and flexible GraphQL client, that
+`urql` is a highly customizable and flexible GraphQL client, that
 happens to come with some default core behavior and some React
 component and hooks APIs.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Documentation
 
 `urql` is a highly customisable and flexible GraphQL client, that
-happens to come with some default core behaviour and some React
+happens to come with some default core behavior and some React
 component and hooks APIs.
 
 You can take `urql` from writing your first GraphQL app, to
@@ -24,7 +24,7 @@ exchange pipeline to your GraphQL API.
 
 ### [Basics](basics.md)
 
-Everything about the basic & default `urql` behaviour
+Everything about the basic & default `urql` behavior
 that comes with explanations of the `fetchExchange`,
 the `cacheExchange`, and how to use _Subscriptions_.
 
@@ -40,7 +40,7 @@ Here's everything you need to know to extend,
 customise and experiment with `urql`. This section
 shows you how to use the `Client` to write new
 APIs (Be it for React or not) and how to write
-new "Exchanges" to customise `urql`'s core behaviour!
+new "Exchanges" to customise `urql`'s core behavior!
 
 ### [Guides](guides.md)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -427,9 +427,15 @@ streams `GraphQLResult`s with `data` and `errors`.
 The `ssrExchange` as [described in the Basics section](basics.md#server-side-rendering).
 It's of type `Options => Exchange`.
 
-It accepts a single input, `{ initialState }`, which is completely
+It accepts two inputs, `initialState` which is completely
 optional and populates the server-side rendered data with
-a rehydrated cache.
+a rehydrated cache, and `isClient` which can be set to
+`true` or `false` to tell the `ssrExchange` whether to
+write to (server-side) or read from (client-side) the cache.
+
+By default `isClient` defaults to `true` when the `Client.suspense`
+mode is disabled and to `false` when the `Client.suspense` mode
+is enabled.
 
 This can be used to extract data that has been queried on
 the server-side, which is also described in the Basics section,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Much of `urql` is about being flexible and customizable.
 To this extent a large chunk of this document is dedicated to
 how `urql` works and how to adapt it to different use cases.
 
-If you wish to use `urql` without any customisations, this
+If you wish to use `urql` without any customizations, this
 document is entirely optional for you. But it's still worth
 the read. Promised.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,7 +101,7 @@ the second argument to `executeQuery`. By default it contains:
 
 - `fetchOptions` for the `fetch` call's options
 - `url` for the `fetch` call's API endpoint
-- `requestPolicy` to determine the cache's behaviour
+- `requestPolicy` to determine the cache's behavior
 
 The `executeQuery` call will return a [Wonka](https://github.com/kitten/wonka)
 stream. This is just an observable (not following the Observable spec)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Much of `urql` is about being flexible and customisable.
+Much of `urql` is about being flexible and customizable.
 To this extent a large chunk of this document is dedicated to
 how `urql` works and how to adapt it to different use cases.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,7 +166,7 @@ same operation / request twice at the same time.
 **Second,** operations are checked against the cache. Depending on the `requestPolicy`
 cached results can be resolved instead and results from network requests are cached.
 
-**Third,** operations are sent to the API and the result is normalised.
+**Third,** operations are sent to the API and the result is normalized.
 
 ## Operation Results
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -67,10 +67,10 @@ operations and sends `POST` requests using `fetch`.
 
 The default caching behavior that `urql` uses is defined by the `cacheExchange`
 unlike Apollo's `Cache` or `InMemoryCache`, caching behavior is handled as
-part of the request pipeline, which makes customisation a lot easier as
+part of the request pipeline, which makes customization a lot easier as
 there's no extra API to learn.
 
-By default however, `urql`'s caching behavior is not that of a _"normalising
+By default however, `urql`'s caching behavior is not that of a _"normalizing
 cache"_ but more of a _"document cache"_.
 
 ### The document cache
@@ -150,7 +150,7 @@ from the API.
 > that data skips the cache, if it's clear to you that the result will
 > need to be up-to-date.
 
-### Customisation
+### Customization
 
 The idea of `urql` is that you can customise the caching behavior amongst
 other things yourself, if needed.

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -230,6 +230,15 @@ The exchange returned by `ssrExchange()` should be added after the `cacheExchang
 (or any other custom cache exchange you've defined), and before any
 asynchronous exchanges like the `fetchExchange`.
 
+If you're also using suspense mode on the client, you can
+additionally set the `isClient` option, which tells the `ssrExchange` manually
+whether it's on the server or client, so that you can enable the `suspense`
+mode on the client-side as well.
+
+```js
+const ssrCache = ssrExchange({ isClient: !!process.browser });
+```
+
 ### Prefetching on the server
 
 In your request handler on the server-side, you'll have to add some

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -1,7 +1,7 @@
 # Basics
 
 As mentioned before, `urql`'s core logic is split into exchanges.
-To that end, `urql`'s behaviour is completely defined by the exchanges
+To that end, `urql`'s behavior is completely defined by the exchanges
 you pass to it or that are the default ones.
 
 This document goes through the exchanges that `urql` adds by default.
@@ -65,12 +65,12 @@ operations and sends `POST` requests using `fetch`.
 
 ## `cacheExchange`
 
-The default caching behaviour that `urql` uses is defined by the `cacheExchange`
-unlike Apollo's `Cache` or `InMemoryCache`, caching behaviour is handled as
+The default caching behavior that `urql` uses is defined by the `cacheExchange`
+unlike Apollo's `Cache` or `InMemoryCache`, caching behavior is handled as
 part of the request pipeline, which makes customisation a lot easier as
 there's no extra API to learn.
 
-By default however, `urql`'s caching behaviour is not that of a _"normalising
+By default however, `urql`'s caching behavior is not that of a _"normalising
 cache"_ but more of a _"document cache"_.
 
 ### The document cache
@@ -123,7 +123,7 @@ The operation context can also contain a `requestPolicy` property
 that alters when and how the cache responds.
 By default this will be set to `'cache-first'`.
 
-When `'cache-first'`, the default behaviour, is used, the cache
+When `'cache-first'`, the default behavior, is used, the cache
 will return all cached results when they're available. When no
 cached result is available it will let the operation through, so
 that the `fetchExchange` can send a request to the API.
@@ -152,7 +152,7 @@ from the API.
 
 ### Customisation
 
-The idea of `urql` is that you can customise the caching behaviour amongst
+The idea of `urql` is that you can customise the caching behavior amongst
 other things yourself, if needed.
 
 [Read more about customising `urql` in the "Extending & Experimenting" section.](extending-and-experimenting.md)

--- a/docs/extending-and-experimenting.md
+++ b/docs/extending-and-experimenting.md
@@ -138,7 +138,7 @@ We have now:
 - Added the second `useEffect` argument to tell it when to rerun
 - Added state to set `fetching: true` and to update the result
 
-In the actual implementation of the hook we also generalise this
+In the actual implementation of the hook we also generalize this
 execution and expose the `executeQuery` function in the returned tuple.
 This is left out here as the implementation can be found in the source code.
 

--- a/docs/extending-and-experimenting.md
+++ b/docs/extending-and-experimenting.md
@@ -5,12 +5,12 @@ and its [Basics](basics.md). This section will introduce you to hacking
 with `urql`.
 
 `urql` comes with some very functional defaults, but its standard component APIs,
-hook APIs, or its core behaviour might not be enough for your complex app. Or
+hook APIs, or its core behavior might not be enough for your complex app. Or
 maybe you're just looking to play around and experiment with GraphQL clients?
 
 This document contains two main sections. The first is about reusing `urql`'s
 core and build new "outward facing APIs". The second is about writing new
-exchanges and hence changing `urql`'s core behaviour.
+exchanges and hence changing `urql`'s core behavior.
 
 ## Writing new APIs for the Client
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,7 +171,7 @@ pass in a fully parsed AST in the form of `DocumentNode` instead.
 For this purpose you can use `graphql-tag`.
 
 This can be extremely helpful, since it enables syntax highlighting
-in some editors. It also can be used to preparse the GraphQL query
+in some editors. It also can be used to pre-parse the GraphQL query
 using `babel-plugin-graphql-tag` or the included Webpack loader.
 
 You only have to make a small adjustment. Install `graphql-tag` and

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -353,9 +353,9 @@ cached completely. When the same query and variables are requested again,
 result is also invalidated when a mutation with similar `__typename`s was
 sent.
 
-[You can find out more about the default caching behaviour in the Basics' `cacheExchange` section.](basics.md#cacheexchange)
+[You can find out more about the default caching behavior in the Basics' `cacheExchange` section.](basics.md#cacheexchange)
 
-Using `urql`'s default behaviour this means we sometimes need a way to refetch
+Using `urql`'s default behavior this means we sometimes need a way to refetch
 data from the GraphQL API and skip the cache, if we need fresh data.
 
 The easiest way to always display up-to-date data is to set the `requestPolicy`

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -18,7 +18,7 @@ your own exchanges by learning how we write ours.
 ## Introduction
 
 All exchanges are written with [Wonka](https://wonka.kitten.sh/), a ligtweight iterable and
-observable streaming library. Wonka is used `urql` because its behaviour
+observable streaming library. Wonka is used `urql` because its behavior
 is extremely predictable and built to be treeshakeable.
 
 [You can read more about how to use it on the Wonka site.](https://wonka.kitten.sh/basics/)
@@ -31,7 +31,7 @@ and with utilities like `map` and `filter` that transform their output,
 but they work with values that come in asynchronously over time.
 
 These utilities are called "operators" and there's a lot of them to
-enable you to express any asynchronous or iterable behaviour that
+enable you to express any asynchronous or iterable behavior that
 you need.
 
 For instance you can convert an array into a Wonka source,
@@ -215,7 +215,7 @@ When you write exchanges, some will inevitably be asynchronous, if
 they're fetching results, performing authentication, or other tasks
 that you have to wait for.
 
-This can cause problems, because the behaviour in `urql` is built
+This can cause problems, because the behavior in `urql` is built
 to be _synchronous_ first. This helps us build our suspense mode,
 and it helps your components receive cached data on their initial
 mount without rerendering.
@@ -241,7 +241,7 @@ to put them in a specific order. For instance, an authentication exchange
 needs to go before the `fetchExchange`. And a secondary cache would
 maybe go in front of the default cache exchange.
 
-But to ensure the correct behaviour of suspense mode and
+But to ensure the correct behavior of suspense mode and
 the initialization of our hooks, it's vital to order your exchanges
 so that synchronous exchanges come first and asynchronous ones
 come last.

--- a/src/exchanges/ssr.ts
+++ b/src/exchanges/ssr.ts
@@ -15,6 +15,7 @@ export interface SSRData {
 }
 
 export interface SSRExchangeParams {
+  isClient?: boolean;
   initialState?: SSRData;
 }
 
@@ -77,6 +78,13 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
   // The SSR Exchange is a temporary cache that can populate results into data for suspense
   // On the client it can be used to retrieve these temporary results from a rehydrated cache
   const ssr: SSRExchange = ({ client, forward }) => ops$ => {
+    // params.isClient tells us whether we're on the client-side
+    // By default we assume that we're on the client if suspense-mode is disabled
+    const isClient =
+      params && typeof params.isClient === 'boolean'
+        ? !!params.isClient
+        : !client.suspense;
+
     const sharedOps$ = share(ops$);
 
     let forwardedOps$ = pipe(
@@ -96,8 +104,8 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
       })
     );
 
-    if (client.suspense) {
-      // Inside suspense-mode we cache results in the cache as they're resolved
+    if (!isClient) {
+      // On the server we cache results in the cache as they're resolved
       forwardedOps$ = pipe(
         forwardedOps$,
         tap((result: OperationResult) => {
@@ -109,7 +117,7 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
         })
       );
     } else {
-      // Outside of suspense-mode we delete results from the cache as they're resolved
+      // On the client we delete results from the cache as they're resolved
       cachedOps$ = pipe(
         cachedOps$,
         tap((result: OperationResult) => {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -54,16 +54,16 @@ export class CombinedError extends Error {
     graphQLErrors?: Array<string | GraphQLError | Error>;
     response?: any;
   }) {
-    const normalisedGraphQLErrors = (graphQLErrors || []).map(
+    const normalizedGraphQLErrors = (graphQLErrors || []).map(
       rehydrateGraphQlError
     );
-    const message = generateErrorMessage(networkError, normalisedGraphQLErrors);
+    const message = generateErrorMessage(networkError, normalizedGraphQLErrors);
 
     super(message);
 
     this.name = 'CombinedError';
     this.message = message;
-    this.graphQLErrors = normalisedGraphQLErrors;
+    this.graphQLErrors = normalizedGraphQLErrors;
     this.networkError = networkError;
     this.response = response;
   }


### PR DESCRIPTION
These changes were already applied to `urql-docs`, but never backported