### PR TITLE
Remove enum in useImmediateEffect

### DIFF
--- a/src/hooks/useImmediateEffect.ts
+++ b/src/hooks/useImmediateEffect.ts
@@ -2,11 +2,11 @@
 
 import { useRef, useEffect, EffectCallback } from 'react';
 
-enum LifecycleState {
-  WillMount = 0,
-  DidMount = 1,
-  Update = 2,
-}
+type LifecycleState = 0 | 1 | 2;
+
+const WILL_MOUNT = 0;
+const DID_MOUNT = 1;
+const UPDATE = 2;
 
 /** This is a drop-in replacement for useEffect that will execute the first effect that happens during initial mount synchronously */
 export const useImmediateEffect = (
@@ -14,21 +14,21 @@ export const useImmediateEffect = (
   changes: ReadonlyArray<any>
 ) => {
   const teardown = useRef<ReturnType<EffectCallback>>(undefined);
-  const state = useRef(LifecycleState.WillMount);
+  const state = useRef<LifecycleState>(WILL_MOUNT);
 
   // On initial render we just execute the effect
-  if (state.current === LifecycleState.WillMount) {
-    state.current = LifecycleState.DidMount;
+  if (state.current === WILL_MOUNT) {
+    state.current = DID_MOUNT;
     teardown.current = effect();
   }
 
   useEffect(() => {
     // Initially we skip executing the effect since we've already done so on
     // initial render, then we execute it as usual
-    if (state.current === LifecycleState.Update) {
+    if (state.current === UPDATE) {
       return (teardown.current = effect());
     } else {
-      state.current = LifecycleState.Update;
+      state.current = UPDATE;
       return teardown.current;
     }
   }, changes);


### PR DESCRIPTION
I forgot to PR this (shame) 😆 

We can do the same with constants, which compile away
thanks to Terser. This saves a lot and since we're
not exposing the enum, it's 100% fine.

urql.min.js: 4.62 kB -> 4.55 kB