### PR TITLE
fix(README.md): bad route to guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ While GraphQL is an elegant protocol and schema language, client libraries today
 - [Basics](https://formidable.com/open-source/urql/docs/basics/)
 - [Extending & Experimenting](https://formidable.com/open-source/urql/docs/extending-&-experimenting/)
 - [API](https://formidable.com/open-source/urql/docs/api/)
-- [Guides](https://github.com/FormidableLabs/urql/blob/docs/customExchanges/docs/guides.md)
+- [Guides](./docs/guides.md)
 
 _You can find the raw markdown files inside this repository's `docs` folder._
 


### PR DESCRIPTION
Right now it links to not existing page. As I think it's not supposed to be like this, and `./docs/guides` is a right way................