### PR TITLE
Make further bundle size optimisations

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "rollup-plugin-buble": "^0.19.8",
     "rollup-plugin-commonjs": "^10.0.1",
     "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-typescript2": "^0.22.0",
     "terser": "^4.1.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import nodeResolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 import buble from 'rollup-plugin-buble';
 import babel from 'rollup-plugin-babel';
+import replace from 'rollup-plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 
 const pkgInfo = require('./package.json');
@@ -131,8 +132,11 @@ const makePlugins = (isProduction = false) => [
       }]
     ]
   }),
+  isProduction && replace({
+    'process.env.NODE_ENV': JSON.stringify('production')
+  }),
   isProduction ? terserMinified : terserPretty
-];
+].filter(Boolean);
 
 const config = {
   input: './src/index.ts',
@@ -167,16 +171,17 @@ export default [
   }, {
     ...config,
     plugins: makePlugins(true),
+    onwarn: () => {},
     output: [
       {
-        sourcemap: true,
+        sourcemap: false,
         legacy: true,
         freeze: false,
         file: './dist/urql.min.js',
         format: 'cjs'
       },
       {
-        sourcemap: true,
+        sourcemap: false,
         legacy: true,
         freeze: false,
         file: './dist/urql.es.min.js',

--- a/src/components/Query.ts
+++ b/src/components/Query.ts
@@ -10,10 +10,9 @@ export interface QueryState<T> extends UseQueryState<T> {
   executeQuery: (opts?: Partial<OperationContext>) => void;
 }
 
-export function Query<T = any, V = any>({
-  children,
-  ...args
-}: QueryProps<T, V>): ReactElement<any> {
-  const [state, executeQuery] = useQuery<T, V>(args);
-  return children({ ...state, executeQuery });
+export function Query<T = any, V = any>(
+  props: QueryProps<T, V>
+): ReactElement<any> {
+  const [state, executeQuery] = useQuery<T, V>(props);
+  return props.children({ ...state, executeQuery });
 }

--- a/src/components/Subscription.ts
+++ b/src/components/Subscription.ts
@@ -12,11 +12,9 @@ export interface SubscriptionProps<T, R, V> extends UseSubscriptionArgs<V> {
   children: (arg: UseSubscriptionState<R>) => ReactElement<any>;
 }
 
-export function Subscription<T = any, R = T, V = any>({
-  children,
-  handler,
-  ...args
-}: SubscriptionProps<T, R, V>): ReactElement<any> {
-  const [state] = useSubscription<T, R, V>(args, handler);
-  return children(state);
+export function Subscription<T = any, R = T, V = any>(
+  props: SubscriptionProps<T, R, V>
+): ReactElement<any> {
+  const [state] = useSubscription<T, R, V>(props, props.handler);
+  return props.children(state);
 }

--- a/src/exchanges/cache.ts
+++ b/src/exchanges/cache.ts
@@ -135,7 +135,9 @@ export const afterMutation = (
   collectTypesFromResponse(response.data).forEach(typeName => {
     const operations =
       operationCache[typeName] || (operationCache[typeName] = new Set());
-    operations.forEach(key => pendingOperations.add(key));
+    operations.forEach(key => {
+      pendingOperations.add(key);
+    });
     operations.clear();
   });
 

--- a/src/exchanges/cache.ts
+++ b/src/exchanges/cache.ts
@@ -56,9 +56,8 @@ export const cacheExchange: Exchange = ({ forward, client }) => {
       sharedOps$,
       filter(op => !shouldSkip(op) && isOperationCached(op)),
       map(operation => {
-        const { key, context } = operation;
-        const cachedResult = resultCache.get(key);
-        if (context.requestPolicy === 'cache-and-network') {
+        const cachedResult = resultCache.get(operation.key);
+        if (operation.context.requestPolicy === 'cache-and-network') {
           reexecuteOperation(client, operation);
         }
 

--- a/src/exchanges/debug.ts
+++ b/src/exchanges/debug.ts
@@ -2,15 +2,19 @@ import { pipe, tap } from 'wonka';
 import { Exchange } from '../types';
 
 export const debugExchange: Exchange = ({ forward }) => {
-  return ops$ =>
-    pipe(
-      ops$,
-      // eslint-disable-next-line no-console
-      tap(op => console.log('[Exchange debug]: Incoming operation: ', op)),
-      forward,
-      tap(result =>
+  if (process.env.NODE_ENV === 'production') {
+    return ops$ => forward(ops$);
+  } else {
+    return ops$ =>
+      pipe(
+        ops$,
         // eslint-disable-next-line no-console
-        console.log('[Exchange debug]: Completed operation: ', result)
-      )
-    );
+        tap(op => console.log('[Exchange debug]: Incoming operation: ', op)),
+        forward,
+        tap(result =>
+          // eslint-disable-next-line no-console
+          console.log('[Exchange debug]: Completed operation: ', result)
+        )
+      );
+  }
 };

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -6,8 +6,7 @@ const generateErrorMessage = (
 ) => {
   let error = '';
   if (networkErr !== undefined) {
-    error = `[Network] ${networkErr.message}`;
-    return error;
+    return (error = `[Network] ${networkErr.message}`);
   }
 
   if (graphQlErrs !== undefined) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './error';
 export * from './keyForQuery';
 export * from './request';
+export * from './result';
 export * from './typenames';
 export * from './toSuspenseSource';
 

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -1,0 +1,35 @@
+import { Operation, OperationResult } from '../types';
+import { CombinedError } from './error';
+
+export const makeResult = (
+  operation: Operation,
+  result: any,
+  response?: any
+): OperationResult => ({
+  operation,
+  data: result.data,
+  error: Array.isArray(result.errors)
+    ? new CombinedError({
+        graphQLErrors: result.errors,
+        response,
+      })
+    : undefined,
+  extensions:
+    typeof result.extensions === 'object' && result.extensions !== null
+      ? result.extensions
+      : undefined,
+});
+
+export const makeErrorResult = (
+  operation: Operation,
+  error: Error,
+  response?: any
+): OperationResult => ({
+  operation,
+  data: undefined,
+  error: new CombinedError({
+    networkError: error,
+    response,
+  }),
+  extensions: undefined,
+});

--- a/src/utils/typenames.ts
+++ b/src/utils/typenames.ts
@@ -13,7 +13,9 @@ interface EntityLike {
 
 const collectTypes = (obj: EntityLike | EntityLike[], types: string[] = []) => {
   if (Array.isArray(obj)) {
-    obj.forEach(inner => collectTypes(inner, types));
+    obj.forEach(inner => {
+      collectTypes(inner, types);
+    });
   } else if (typeof obj === 'object' && obj !== null) {
     for (const key in obj) {
       if (Object.prototype.hasOwnProperty.call(obj, key)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5279,6 +5279,14 @@ rollup-plugin-node-resolve@^5.2.0:
     resolve "^1.11.1"
     rollup-pluginutils "^2.8.1"
 
+rollup-plugin-replace@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
+  integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
+  dependencies:
+    magic-string "^0.25.2"
+    rollup-pluginutils "^2.6.0"
+
 rollup-plugin-terser@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.1.1.tgz#e9d2545ec8d467f96ba99b9216d2285aad8d5b66"
@@ -5300,7 +5308,7 @@ rollup-plugin-typescript2@^0.22.0:
     rollup-pluginutils "2.8.1"
     tslib "1.10.0"
 
-rollup-pluginutils@2.8.1, rollup-pluginutils@^2.8.1:
+rollup-pluginutils@2.8.1, rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
   integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==


### PR DESCRIPTION
This accomplishes a couple of things.

Firstly it sets up Rollup to compile `process.env.NODE_ENV` to be `"production"` for our minified bundles so those accurately reflect what `urql` would compile to in a production environment.

Then it adds some initial bundle size optimisations:

- Remove rest spread from Query/Subscription components as it's not needed
- Replace `debugExchange` with a noop in production
- Remove usage of `addMetadata` with latency times from `fetchExchange` in production
- Remove fallback and fetch error for unknown operations in production
- Extract response/error parsing from `fetchExchange` and `subscriptionExchange` into a common file

This appears to currently save us about `0.3kB (4.62 kB => 4.32kB) min+gzip`