### PR TITLE
(chore) - continue without graphql-tag

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ Accepts a single options object as input:
 
 ```js
 interface UseQueryArgs {
-  query: string;
+  query: DocumentNode;
   variables?: any;
   requestPolicy?: RequestPolicy;
   pause?: boolean;
@@ -37,7 +37,7 @@ accepts a partial `OperationContext`.
 
 ### `useMutation` (hook)
 
-Accepts a single `query` argument of type `string`. And returns the
+Accepts a single `query` argument of type `DocumentNode`. And returns the
 current mutation's state and an `executeMutation` function in a tuple. The
 mutation is not started unless `executeMutation` has been called.
 
@@ -69,7 +69,7 @@ The options argument shape is:
 
 ```js
 interface UseSubscriptionArgs {
-  query: string;
+  query: DocumentNode;
   variables?: any;
   context?: Partial<OperationContext>;
 }
@@ -104,7 +104,7 @@ interface UseSubscriptionState<T> {
 
 | Prop          | Type                       | Description                                                                                           |
 | ------------- | -------------------------- | ----------------------------------------------------------------------------------------------------- |
-| query         | `string`                   | The GraphQL request's query                                                                           |
+| query         | `DocumentNode`             | The GraphQL request's query                                                                           |
 | variables     | `object`                   | The GraphQL request's variables                                                                       |
 | context       | `?object`                  | The GraphQL request's context                                                                         |
 | requestPolicy | `?RequestPolicy`           | An optional request policy that should be used                                                        |
@@ -129,7 +129,7 @@ interface UseSubscriptionState<T> {
 
 | Prop     | Type                       | Description                                                                                           |
 | -------- | -------------------------- | ----------------------------------------------------------------------------------------------------- |
-| query    | `string`                   | The GraphQL request's query                                                                           |
+| query    | `DocumentNode`             | The GraphQL request's query                                                                           |
 | children | `RenderProps => ReactNode` | A function that follows the typical render props pattern. The shape of the render props is as follows |
 
 #### Render Props
@@ -150,7 +150,7 @@ interface UseSubscriptionState<T> {
 
 | Prop      | Type                                                | Description                                                                                           |
 | --------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| query     | `string`                                            | The GraphQL subscription's query                                                                      |
+| query     | `DocumentNode`                                      | The GraphQL subscription's query                                                                      |
 | variables | `object`                                            | The GraphQL subscriptions' variables                                                                  |
 | context   | `?Partial<OperationContext>`                        | The GraphQL subscriptions' context                                                                    |
 | handler   | `undefined \| (prev: R \| undefined, data: T) => R` | The handler that should combine/update the subscription's data with incoming data                     |
@@ -288,7 +288,7 @@ It consists of `query` and optional `variables`.
 
 ```js
 type Operation = {
-  query: string | DocumentNode,
+  query: DocumentNode,
   variables?: object,
   key: number,
 };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ tie the two together.
 ```js
 type GraphQLRequest = {
   key: number,
-  query: string | DocumentNode,
+  query: DocumentNode,
   variables?: object,
 };
 ```

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -376,9 +376,10 @@ component. You can pass it a query and variables, and it will serve
 you render props with `data`, `error`, `extensions`, and `fetching`.
 
 ```js
+import gql from 'graphql-tag';
 import { Subscription } from 'urql';
 
-const newMessages = `
+const newMessages = gql`
   subscription MessageSub {
     newMessages {
       id
@@ -418,9 +419,10 @@ events.
 
 ```js
 import React from 'react';
+import gql from 'graphql-tag';
 import { useSubscription } from 'urql';
 
-const newMessages = `
+const newMessages = gql`
   subscription MessageSub {
     newMessages {
       id

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,9 +61,10 @@ component to fetch some GraphQL data.
 
 ```jsx
 import React from 'react';
+import gql from 'graphql-tag';
 import { Query } from 'urql';
 
-const getTodos = `
+const getTodos = gql`
   query GetTodos($limit: Int!) {
     todos(limit: $limit) {
       id
@@ -122,9 +123,10 @@ We can rewrite the above example as follows.
 
 ```jsx
 import React from 'react';
+import gql from 'graphql-tag';
 import { useQuery } from 'urql';
 
-const getTodos = `
+const getTodos = gql`
   query GetTodos($limit: Int!) {
     todos(limit: $limit) {
       id
@@ -166,9 +168,8 @@ as soon as it's mounted and will rerun it when the query or variables change.
 
 ### Using `graphql-tag`
 
-You're not limited to just passing in strings as queries. You can also
-pass in a fully parsed AST in the form of `DocumentNode` instead.
-For this purpose you can use `graphql-tag`.
+For passing in queries you're expected to use `graphql-tag`, this allows
+you to pass a fully parsed AST to `urql`.
 
 This can be extremely helpful, since it enables syntax highlighting
 in some editors. It also can be used to pre-parse the GraphQL query
@@ -224,9 +225,10 @@ Here's an example of an imperative use case where we create a todo.
 
 ```js
 import React, { Component } from 'react';
+import gql from 'graphql-tag';
 import { Mutation } from 'urql';
 
-const addTodo = `
+const addTodo = gql`
   mutation AddTodo($text: String!) {
     addTodo(text: $text) {
       id
@@ -311,9 +313,10 @@ We can rewrite the second example from above as follows.
 
 ```jsx
 import React, { useCallback } from 'react';
+import gql from 'graphql-tag';
 import { useMutation } from 'urql';
 
-const addTodo = `
+const addTodo = gql`
   mutation AddTodo($text: String!) {
     addTodo(text: $text) {
       id
@@ -390,9 +393,10 @@ list of todos.
 
 ```jsx
 import React from 'react';
+import gql from 'graphql-tag';
 import { Query } from 'urql';
 
-const getTodos = `
+const getTodos = gql`
   query GetTodos {
     todos(limit: 10) {
       id
@@ -440,9 +444,10 @@ The same example can again also be implemented using hooks:
 
 ```jsx
 import React from 'react';
+import gql from 'graphql-tag';
 import { useQuery } from 'urql';
 
-const getTodos = `
+const getTodos = gql`
   query GetTodos($limit: Int!) {
     todos(limit: $limit) {
       id

--- a/examples/1-getting-started/src/app/components/Todo.tsx
+++ b/examples/1-getting-started/src/app/components/Todo.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { useMutation } from 'urql';
+import gql from 'graphql-tag';
 
 interface Props {
   complete: boolean;
@@ -22,7 +23,7 @@ export const Todo: FC<Props> = props => {
 
 Todo.displayName = 'Todo';
 
-const RemoveTodo = `
+const RemoveTodo = gql`
   mutation($id: ID!) {
     toggleTodo(id: $id) {
       id

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.0.0",
-    "graphql-tag": "^2.10.1",
     "prop-types": "^15.6.0",
     "wonka": "^3.2.0"
   }

--- a/src/components/Mutation.test.tsx
+++ b/src/components/Mutation.test.tsx
@@ -21,10 +21,15 @@ import * as React from 'react';
 import { act, cleanup, render } from '@testing-library/react';
 import { Mutation } from './Mutation';
 import { createClient } from '../client';
+import gql from 'graphql-tag';
 
 // @ts-ignore
 const client = createClient() as { executeMutation: jest.Mock };
-const query = 'mutation Example { example }';
+const query = gql`
+  mutation Example {
+    example
+  }
+`;
 
 describe('Mutation', () => {
   beforeEach(() => {

--- a/src/components/Mutation.ts
+++ b/src/components/Mutation.ts
@@ -4,7 +4,7 @@ import { OperationResult, OperationContext } from '../types';
 import { useMutation, UseMutationState } from '../hooks';
 
 export interface MutationProps<T, V> {
-  query: DocumentNode | string;
+  query: DocumentNode;
   children: (arg: MutationState<T, V>) => ReactElement<any>;
 }
 

--- a/src/components/Query.test.tsx
+++ b/src/components/Query.test.tsx
@@ -20,9 +20,14 @@ jest.mock('../client', () => {
 import * as React from 'react';
 import { cleanup, render } from '@testing-library/react';
 import { Query } from './Query';
+import gql from 'graphql-tag';
 
 // @ts-ignore
-const query = '{ example }';
+const query = gql`
+  {
+    example
+  }
+`;
 const variables = {
   myVar: 1234,
 };

--- a/src/components/Subscription.test.tsx
+++ b/src/components/Subscription.test.tsx
@@ -20,8 +20,13 @@ jest.mock('../client', () => {
 import * as React from 'react';
 import { cleanup, render } from '@testing-library/react';
 import { Subscription } from './Subscription';
+import gql from 'graphql-tag';
 
-const query = 'subscription Example { example }';
+const query = gql`
+  subscription Example {
+    example
+  }
+`;
 
 describe('Subscription', () => {
   beforeEach(() => {

--- a/src/exchanges/subscription.ts
+++ b/src/exchanges/subscription.ts
@@ -37,6 +37,8 @@ export interface ObservableLike<T> {
 }
 
 export interface SubscriptionOperation {
+  // TODO: why does this work?
+  // And why doesn't it work with DocumentNode
   query: string;
   variables?: object;
   key: string;

--- a/src/hooks/useMutation.test.tsx
+++ b/src/hooks/useMutation.test.tsx
@@ -29,7 +29,11 @@ import { useMutation } from './useMutation';
 // @ts-ignore
 const client = createClient() as { executeMutation: jest.Mock };
 const props = {
-  query: 'mutation Example { example }',
+  query: gql`
+    mutation Example {
+      example
+    }
+  `,
 };
 let state: any;
 let execute: any;
@@ -93,7 +97,7 @@ describe('on execute', () => {
     });
 
     const call = client.executeMutation.mock.calls[0][0];
-    expect(print(call.query)).toBe(print(gql([props.query])));
+    expect(print(call.query)).toBe(print(props.query));
   });
 
   it('calls executeMutation with variables', () => {

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -20,7 +20,7 @@ export type UseMutationResponse<T, V> = [
 ];
 
 export const useMutation = <T = any, V = object>(
-  query: DocumentNode | string
+  query: DocumentNode
 ): UseMutationResponse<T, V> => {
   const devtoolsContext = useDevtoolsContext();
   const client = useContext(Context);

--- a/src/hooks/useQuery.spec.ts
+++ b/src/hooks/useQuery.spec.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { interval, map, pipe } from 'wonka';
+import gql from 'graphql-tag';
 
 import { createClient } from '../client';
 import { useQuery } from './useQuery';
@@ -25,7 +26,7 @@ jest.mock('../client', () => {
 // @ts-ignore
 const client = createClient() as { executeQuery: jest.Mock };
 
-const mockQuery = `
+const mockQuery = gql`
   query todo($id: ID!) {
     todo(id: $id) {
       id
@@ -143,7 +144,7 @@ describe('useQuery', () => {
     await waitForNextUpdate();
     expect(client.executeQuery).toBeCalledTimes(1);
 
-    const newQuery = `
+    const newQuery = gql`
       query places {
         id
         address

--- a/src/hooks/useQuery.spec.ts
+++ b/src/hooks/useQuery.spec.ts
@@ -5,6 +5,7 @@ import gql from 'graphql-tag';
 import { createClient } from '../client';
 import { useQuery } from './useQuery';
 import { RequestPolicy } from 'src/types';
+import { DocumentNode } from 'graphql';
 
 jest.mock('../client', () => {
   const d = { data: 'data', error: 'error' };
@@ -135,7 +136,7 @@ describe('useQuery', () => {
 
   it('should update if a new query is received', async () => {
     const { rerender, waitForNextUpdate } = renderHook<
-      { query: string; variables?: object },
+      { query: DocumentNode; variables?: object },
       {}
     >(({ query, variables }) => useQuery({ query, variables }), {
       initialProps: { query: mockQuery, variables: mockVariables },
@@ -168,7 +169,7 @@ describe('useQuery', () => {
 
   it('should update if new variables are received', async () => {
     const { rerender, waitForNextUpdate } = renderHook<
-      { query: string; variables: object },
+      { query: DocumentNode; variables: object },
       {}
     >(({ query, variables }) => useQuery({ query, variables }), {
       initialProps: { query: mockQuery, variables: mockVariables },

--- a/src/hooks/useQuery.test.tsx
+++ b/src/hooks/useQuery.test.tsx
@@ -20,6 +20,7 @@ jest.mock('../client', () => {
 
 import React, { FC } from 'react';
 import renderer, { act } from 'react-test-renderer';
+import gql from 'graphql-tag';
 import { pipe, onStart, onEnd, interval } from 'wonka';
 import { createClient } from '../client';
 import { OperationContext } from '../types';
@@ -28,7 +29,11 @@ import { useQuery, UseQueryArgs, UseQueryState } from './useQuery';
 // @ts-ignore
 const client = createClient() as { executeQuery: jest.Mock };
 const props: UseQueryArgs<{ myVar: number }> = {
-  query: '{ example }',
+  query: gql`
+    {
+      example
+    }
+  `,
   variables: {
     myVar: 1234,
   },
@@ -174,7 +179,11 @@ describe('on subscription update', () => {
 });
 
 describe('on change', () => {
-  const q = 'query NewQuery { example }';
+  const q = gql`
+    query NewQuery {
+      example
+    }
+  `;
 
   it('new query executes subscription', () => {
     const wrapper = renderer.create(<QueryUser {...props} />);

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -10,7 +10,7 @@ import { useImmediateEffect } from './useImmediateEffect';
 import { useImmediateState } from './useImmediateState';
 
 export interface UseQueryArgs<V> {
-  query: string | DocumentNode;
+  query: DocumentNode;
   variables?: V;
   requestPolicy?: RequestPolicy;
   context?: Partial<OperationContext>;

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -5,7 +5,7 @@ import { createRequest } from '../utils';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
 export const useRequest = (
-  query: string | DocumentNode,
+  query: DocumentNode,
   variables?: any
 ): GraphQLRequest => {
   const prev = useRef<undefined | GraphQLRequest>(undefined);

--- a/src/hooks/useSubscription.test.tsx
+++ b/src/hooks/useSubscription.test.tsx
@@ -15,6 +15,7 @@ jest.mock('../client', () => {
 
 import React, { FC } from 'react';
 import renderer, { act } from 'react-test-renderer';
+import gql from 'graphql-tag';
 // @ts-ignore - data is imported from mock only
 import { createClient, data } from '../client';
 import { useSubscription } from './useSubscription';
@@ -22,7 +23,11 @@ import { OperationContext } from '../types';
 
 // @ts-ignore
 const client = createClient() as { executeSubscription: jest.Mock };
-const query = 'subscription Example { example }';
+const query = gql`
+  subscription Example {
+    example
+  }
+`;
 let state: any;
 
 const SubscriptionUser: FC<{
@@ -103,8 +108,16 @@ describe('on subscription', () => {
 });
 
 describe('on change', () => {
-  const qa = 'subscription NewSubA { exampleA }';
-  const qb = 'subscription NewSubB { exampleB }';
+  const qa = gql`
+    subscription NewSubA {
+      exampleA
+    }
+  `;
+  const qb = gql`
+    subscription NewSubB {
+      exampleB
+    }
+  `;
 
   it('executes subscription', () => {
     const wrapper = renderer.create(<SubscriptionUser q={query} />);

--- a/src/hooks/useSubscription.test.tsx
+++ b/src/hooks/useSubscription.test.tsx
@@ -20,6 +20,7 @@ import gql from 'graphql-tag';
 import { createClient, data } from '../client';
 import { useSubscription } from './useSubscription';
 import { OperationContext } from '../types';
+import { DocumentNode } from 'graphql';
 
 // @ts-ignore
 const client = createClient() as { executeSubscription: jest.Mock };
@@ -31,7 +32,7 @@ const query = gql`
 let state: any;
 
 const SubscriptionUser: FC<{
-  q: string;
+  q: DocumentNode;
   handler?: (prev: any, data: any) => any;
   context?: Partial<OperationContext>;
 }> = ({ q, handler, context }) => {

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -9,7 +9,7 @@ import { useImmediateState } from './useImmediateState';
 import { OperationContext } from '../types';
 
 export interface UseSubscriptionArgs<V> {
-  query: DocumentNode | string;
+  query: DocumentNode;
   variables?: V;
   context?: Partial<OperationContext>;
 }

--- a/src/utils/request.test.ts
+++ b/src/utils/request.test.ts
@@ -1,21 +1,18 @@
-import { print } from 'graphql';
 import gql from 'graphql-tag';
 import { createRequest } from './request';
 
-const doc = print(
-  gql`
-    {
-      todos {
-        id
-      }
+const doc = gql`
+  {
+    todos {
+      id
     }
-  `
-);
+  }
+`;
 
 it('should return a valid query object', () => {
   const val = createRequest(doc);
 
-  expect(print(val.query)).toBe(doc);
+  expect(val.query).toBe(doc);
   expect(val).toMatchObject({
     key: expect.any(Number),
     query: expect.any(Object),
@@ -26,7 +23,7 @@ it('should return a valid query object', () => {
 it('should return a valid query object with variables', () => {
   const val = createRequest(doc, { test: 5 });
 
-  expect(print(val.query)).toBe(doc);
+  expect(val.query).toBe(doc);
   expect(val).toMatchObject({
     key: expect.any(Number),
     query: expect.any(Object),

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,20 +1,15 @@
 import { DocumentNode } from 'graphql';
-import gql from 'graphql-tag';
 import { getKeyForRequest } from './keyForQuery';
 import { GraphQLRequest, Operation, OperationContext } from '../types';
 
 export const createRequest = (
-  q: string | DocumentNode,
+  q: DocumentNode,
   vars?: object
-): GraphQLRequest => {
-  const query = typeof q === 'string' ? gql([q]) : q;
-
-  return {
-    key: getKeyForRequest(query, vars),
-    query,
-    variables: vars || {},
-  };
-};
+): GraphQLRequest => ({
+  key: getKeyForRequest(q, vars),
+  query: q,
+  variables: vars || {},
+});
 
 /** Spreads the provided metadata to the source operation's meta property in context.  */
 export const addMetadata = (


### PR DESCRIPTION
This PR forces consumers to pass in a `DocumentNode` instead of us parsing this double, since this is already a common practice in the wild.