### PR TITLE
(refactor) - remove gql-tag dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.0.0",
-    "graphql-tag": "^2.10.1",
     "prop-types": "^15.6.0",
     "wonka": "^3.2.0"
   }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -2,11 +2,16 @@ import { DocumentNode, parse } from 'graphql';
 import { getKeyForRequest } from './keyForQuery';
 import { GraphQLRequest, Operation, OperationContext } from '../types';
 
+const parseQuery = (queryString: string) => {
+  const trimmedQuery = queryString.replace(/[\s,]+/g, ' ').trim();
+  return parse(trimmedQuery);
+};
+
 export const createRequest = (
   q: string | DocumentNode,
   vars?: object
 ): GraphQLRequest => {
-  const query = typeof q === 'string' ? parse(q) : q;
+  const query = typeof q === 'string' ? parseQuery(q) : q;
 
   return {
     key: getKeyForRequest(query, vars),

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -2,10 +2,8 @@ import { DocumentNode, parse } from 'graphql';
 import { getKeyForRequest } from './keyForQuery';
 import { GraphQLRequest, Operation, OperationContext } from '../types';
 
-const parseQuery = (queryString: string) => {
-  const trimmedQuery = queryString.replace(/[\s,]+/g, ' ').trim();
-  return parse(trimmedQuery);
-};
+const parseQuery = (queryString: string) =>
+  parse(queryString.replace(/[\s,]+/g, ' ').trim());
 
 export const createRequest = (
   q: string | DocumentNode,

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,5 +1,4 @@
-import { DocumentNode } from 'graphql';
-import gql from 'graphql-tag';
+import { DocumentNode, parse } from 'graphql';
 import { getKeyForRequest } from './keyForQuery';
 import { GraphQLRequest, Operation, OperationContext } from '../types';
 
@@ -7,7 +6,7 @@ export const createRequest = (
   q: string | DocumentNode,
   vars?: object
 ): GraphQLRequest => {
-  const query = typeof q === 'string' ? gql([q]) : q;
+  const query = typeof q === 'string' ? parse(q) : q;
 
   return {
     key: getKeyForRequest(query, vars),


### PR DESCRIPTION
Well this makes it a lot easier on us :D

This should reduce the footprint of urql to 6.5KB

Resolves: https://github.com/FormidableLabs/urql/issues/377