### PR TITLE
exports useDevtoolsContext

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useMutation';
 export * from './useQuery';
 export * from './useSubscription';
+export * from './useDevtoolsContext';


### PR DESCRIPTION
 - exports the useDevtoolsContext hook - resolves https://github.com/FormidableLabs/urql/issues/382

tested by importing into the example project and logging the returned object. 
