### PR TITLE
Add guide on using urql outside of React.

### DIFF
--- a/docs/extending-and-experimenting.md
+++ b/docs/extending-and-experimenting.md
@@ -20,6 +20,7 @@ and hooks or even React at all.
 The Client is structured so that it can easily be reused to create different
 APIs or integrate `urql` with other libraries and frameworks than React.
 [Have a look at the API docs to see a full list of the client's methods.](api.md#client-class)
+Also take a look at [how to use `urql` outside of a React context.](url-outside-react.md)
 
 While it's possible to write new APIs outside of React or new components
 quite easily, this section will only focus on hooks, for illustrative

--- a/docs/urql-outside-react.md
+++ b/docs/urql-outside-react.md
@@ -1,17 +1,18 @@
 # `urql` Outside of React
 
-While you'll get the best experience with `urql` in a React codebase, it's still possible to use parts of `urql`'s functionality outside of React. In this guide, we'll take a look at using `urql` in environments other than React, including NodeJS and Vue.
+While `urql` is a GraphQL client that's mainly targeting React, apart from our React-specific APIs (i.e. the hooks and components), all other elements of the library function the same outside of a React context. In this guide, we'll take a look at using `urql` in environments other than React, including NodeJS and Vue.
 
-The most useful element for using `urql` outside of React is the `client`, the library's central orchestrator. The `client` handles all outgoing requests and incoming responses in `urql`, and comes along with a variety of methods to help you orchestrate communication with your GraphQL API. The most useful of these are the `execute*` methods (`executeQuery`, `executeMutation`, and `executeSubscription`).
+The most useful element for using `urql` outside of React is the `Client`, the library's central orchestrator. The `Client` handles all outgoing requests and incoming responses in `urql`, and comes along with a variety of methods to help you orchestrate communication with your GraphQL API. The most useful of these are the `execute*` methods (`executeQuery`, `executeMutation`, and `executeSubscription`).
 
 The `execute*` methods all accept an instance of a `GraphQLRequest`, which can be created by using `urql`'s `createRequest` function. `createRequest` will create a unique hash used to identify the GraphQL operation, which is used internally to track it for things like deduplication and caching.
 
 ```javascript
 // load dependencies
+require('isomorphic-fetch');
 const { createClient, createRequest } = require('urql');
 const gql = require('graphql-tag');
 
-// create the urql client
+// create the urql Client
 const client = createClient({
   url: 'https://graphbrainz.herokuapp.com/graphql',
 });
@@ -54,37 +55,30 @@ const request = createRequest(query, { search: 'Courtney Barnett' });
 Once you've created your request, all that's left is to execute it! When you execute a query, mutation, or subscription, `urql` returns you [a `wonka` Source](https://wonka.kitten.sh/api/sources) containing the `data` and `error` states of that request. You can use [`wonka`'s Sinks](https://wonka.kitten.sh/api/sinks) to access these like so:
 
 ```javascript
-const http = require('http');
 const { pipe, subscribe } = require('wonka');
 
-http
-  .createServer((req, res) => {
-    pipe(
-      client.executeQuery(request),
-      subscribe(({ data, error }) => {
-        if (error) {
-          console.log('Error', error);
-        }
+pipe(
+  client.executeQuery(request),
+  subscribe(({ data, error }) => {
+    if (error) {
+      console.log('Error', error);
+    }
 
-        res.write(JSON.stringify(data));
-        res.end();
-      })
-    );
+    console.log('Data', data);
   })
-  .listen(8080);
+);
 ```
 
-Awesome, we've successfully executed a GraphQL query on the server in NodeJS! In practice, this is more useful for writing small Node scripts or a simple CLI for interacting with a GraphQL API. But it does show off the flexibility that `urql`'s `client` gives us!
+Awesome, we've successfully executed a GraphQL query on the server in NodeJS! In practice, this is more useful for writing small Node scripts or a simple CLI for interacting with a GraphQL API. But it does show off the flexibility that `urql`'s `Client` gives us!
 
 See the full CodeSandbox example [here](https://codesandbox.io/s/urql-node-1jhj8).
 
 ## Doing More with the Client
 
-The `client` comes with more methods than just the `execute*` methods. While the use cases for these additional methods are fairly specific to `urql`'s implementation, they do give you more direct control over the `client`. Let's say, for example, that you want to reexecute an operation on a predefined interval (a form of long polling). This is fairly trivial to do by calling `client.reexecuteOperation` with the request's `Operation` object. To create the `Operation` object, use `client.createOperation`, passing the operation type as the first argument (`"query"`, `"mutation"`, `"subscription"`, or `"teardown"`).
+The `Client` comes with more methods than just the `execute*` methods. While the use cases for these additional methods are fairly specific to `urql`'s implementation, they do give you more direct control over the `Client`. Let's say, for example, that you want to reexecute an operation on a predefined interval (a form of long polling). This is fairly trivial to do by calling `Client.reexecuteOperation` with the request's `Operation` object. To create the `Operation` object, use `Client.createOperation`, passing the operation type as the first argument (`"query"`, `"mutation"`, `"subscription"`, or `"teardown"`).
 
 ```javascript
 require('isomorphic-fetch');
-const http = require('http');
 const { createClient, createRequest } = require('urql');
 const gql = require('graphql-tag');
 const { pipe, subscribe, interval, take } = require('wonka');
@@ -125,43 +119,34 @@ const query = gql`
 
 const request = createRequest(query, { search: 'Courtney Barnett' });
 
-http
-  .createServer((req, res) => {
-    pipe(
-      client.executeQuery(request),
-      subscribe(({ data, error }) => {
-        if (error) {
-          console.log('Error', error);
-        }
+pipe(
+  client.executeQuery(request),
+  subscribe(({ data, error }) => {
+    if (error) {
+      console.log('Error', error);
+    }
 
-        console.log('Data', data);
-        res.write(JSON.stringify(data));
-      })
-    );
-
-    pipe(
-      interval(2000),
-      take(10),
-      subscribe(n => {
-        // Call client.createRequest operation to create the Operation object.
-        // The optional third argument is a partial operation context, which allows you
-        // to change the operation's request policy or fetch options.
-        const operation = client.createRequestOperation('query', request, {
-          requestPolicy: 'network-only',
-        });
-
-        // Reexecute the operation. Active subscribers will receive updates.
-        client.reexecuteOperation(operation);
-
-        if (n === 9) {
-          res.end();
-        }
-      })
-    );
+    console.log('Data', data);
   })
-  .listen(8080); //the server object listens on port 8080
+);
+
+pipe(
+  interval(2000),
+  take(10),
+  subscribe(n => {
+    // Call client.createRequest operation to create the Operation object.
+    // The optional third argument is a partial operation context, which allows you
+    // to change the operation's request policy or fetch options.
+    const operation = client.createRequestOperation('query', request, {
+      requestPolicy: 'network-only',
+    });
+
+    // Reexecute the operation. Active subscribers will receive updates.
+    client.reexecuteOperation(operation);
+  })
+);
 ```
 
-Awesome, we've got basic long polling working, where our `client` is reexecuting the initial request every 2 seconds. By passing `{ requestPolicy: 'network-only' }` as the third argument to `reexecuteOperation`, we ensure that the `client` issues a new request to the GraphQL API every time rather than pulling results from the cache. You'll notice in this example we use `wonka`'s `take` operator to limit the number of times we call `reexecuteOperation` – in true long polling, you wouldn't do this.
+Awesome, we've got basic long polling working, where our `Client` is reexecuting the initial request every 2 seconds. By passing `{ requestPolicy: 'network-only' }` as the third argument to `reexecuteOperation`, we ensure that the `Client` issues a new request to the GraphQL API every time rather than pulling results from the cache. You'll notice in this example we use `wonka`'s `take` operator to limit the number of times we call `reexecuteOperation` – in true long polling, you wouldn't do this.
 
 See the full CodeSanbox example [here](https://codesandbox.io/s/urql-node-polling-erkwe).

--- a/docs/urql-outside-react.md
+++ b/docs/urql-outside-react.md
@@ -1,0 +1,167 @@
+# `urql` Outside of React
+
+While you'll get the best experience with `urql` in a React codebase, it's still possible to use parts of `urql`'s functionality outside of React. In this guide, we'll take a look at using `urql` in environments other than React, including NodeJS and Vue.
+
+The most useful element for using `urql` outside of React is the `client`, the library's central orchestrator. The `client` handles all outgoing requests and incoming responses in `urql`, and comes along with a variety of methods to help you orchestrate communication with your GraphQL API. The most useful of these are the `execute*` methods (`executeQuery`, `executeMutation`, and `executeSubscription`).
+
+The `execute*` methods all accept an instance of a `GraphQLRequest`, which can be created by using `urql`'s `createRequest` function. `createRequest` will create a unique hash used to identify the GraphQL operation, which is used internally to track it for things like deduplication and caching.
+
+```javascript
+// load dependencies
+const { createClient, createRequest } = require('urql');
+const gql = require('graphql-tag');
+
+// create the urql client
+const client = createClient({
+  url: 'https://graphbrainz.herokuapp.com/graphql',
+});
+
+// define your GraphQL query
+const query = gql`
+  query SearchArtist($search: String!) {
+    search {
+      artists(query: $search, first: 1) {
+        edges {
+          node {
+            name
+            country
+            releases(first: 10) {
+              edges {
+                node {
+                  title
+                  date
+                  media {
+                    format
+                    trackCount
+                    tracks {
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// create the urql request object
+const request = createRequest(query, { search: 'Courtney Barnett' });
+```
+
+Once you've created your request, all that's left is to execute it! When you execute a query, mutation, or subscription, `urql` returns you [a `wonka` Source](https://wonka.kitten.sh/api/sources) containing the `data` and `error` states of that request. You can use [`wonka`'s Sinks](https://wonka.kitten.sh/api/sinks) to access these like so:
+
+```javascript
+const http = require('http');
+const { pipe, subscribe } = require('wonka');
+
+http
+  .createServer((req, res) => {
+    pipe(
+      client.executeQuery(request),
+      subscribe(({ data, error }) => {
+        if (error) {
+          console.log('Error', error);
+        }
+
+        res.write(JSON.stringify(data));
+        res.end();
+      })
+    );
+  })
+  .listen(8080);
+```
+
+Awesome, we've successfully executed a GraphQL query on the server in NodeJS! In practice, this is more useful for writing small Node scripts or a simple CLI for interacting with a GraphQL API. But it does show off the flexibility that `urql`'s `client` gives us!
+
+See the full CodeSandbox example [here](https://codesandbox.io/s/urql-node-1jhj8).
+
+## Doing More with the Client
+
+The `client` comes with more methods than just the `execute*` methods. While the use cases for these additional methods are fairly specific to `urql`'s implementation, they do give you more direct control over the `client`. Let's say, for example, that you want to reexecute an operation on a predefined interval (a form of long polling). This is fairly trivial to do by calling `client.reexecuteOperation` with the request's `Operation` object. To create the `Operation` object, use `client.createOperation`, passing the operation type as the first argument (`"query"`, `"mutation"`, `"subscription"`, or `"teardown"`).
+
+```javascript
+require('isomorphic-fetch');
+const http = require('http');
+const { createClient, createRequest } = require('urql');
+const gql = require('graphql-tag');
+const { pipe, subscribe, interval, take } = require('wonka');
+
+const client = createClient({
+  url: 'https://graphbrainz.herokuapp.com/graphql',
+});
+
+const query = gql`
+  query SearchArtist($search: String!) {
+    search {
+      artists(query: $search, first: 1) {
+        edges {
+          node {
+            name
+            country
+            releases(first: 10) {
+              edges {
+                node {
+                  title
+                  date
+                  media {
+                    format
+                    trackCount
+                    tracks {
+                      title
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const request = createRequest(query, { search: 'Courtney Barnett' });
+
+http
+  .createServer((req, res) => {
+    pipe(
+      client.executeQuery(request),
+      subscribe(({ data, error }) => {
+        if (error) {
+          console.log('Error', error);
+        }
+
+        console.log('Data', data);
+        res.write(JSON.stringify(data));
+      })
+    );
+
+    pipe(
+      interval(2000),
+      take(10),
+      subscribe(n => {
+        // Call client.createRequest operation to create the Operation object.
+        // The optional third argument is a partial operation context, which allows you
+        // to change the operation's request policy or fetch options.
+        const operation = client.createRequestOperation('query', request, {
+          requestPolicy: 'network-only',
+        });
+
+        // Reexecute the operation. Active subscribers will receive updates.
+        client.reexecuteOperation(operation);
+
+        if (n === 9) {
+          res.end();
+        }
+      })
+    );
+  })
+  .listen(8080); //the server object listens on port 8080
+```
+
+Awesome, we've got basic long polling working, where our `client` is reexecuting the initial request every 2 seconds. By passing `{ requestPolicy: 'network-only' }` as the third argument to `reexecuteOperation`, we ensure that the `client` issues a new request to the GraphQL API every time rather than pulling results from the cache. You'll notice in this example we use `wonka`'s `take` operator to limit the number of times we call `reexecuteOperation` – in true long polling, you wouldn't do this.
+
+See the full CodeSanbox example [here](https://codesandbox.io/s/urql-node-polling-erkwe).


### PR DESCRIPTION
This PR is currently WiP, but I figured I'd get feedback early from folks. The purpose of this PR is to create a guide for using `urql` outside of React. Specifically, I'm focusing on highlighting how to use `urql`'s `client` directly, since that's the easiest way for non-React consumers to get access to the core functionality.

Currently, I have two examples for using `urql` with NodeJS. I'd like to add a basic example with Vue as well before merging.

The biggest issue I see with using `urql` in non-React codebases is the peer dependency on React, and the way our internal references to `react` require it being installed even in a Node or Vue environment where it isn't used. I'd be curious to see if our tree-shaking works out in a Vue environment. Regardless, this makes me think of two things:

1. We should probably have a Caveats section in this doc that makes this plain. It's not a big deal if you're just using `urql` to write quick little Node scripts / CLIs for personal use, but the peerDep on `react` makes me question how useful this is.
2. As @kitten suggested in #253, there may be a time in the future where we consider splitting the `client` into a separate package to support non-React consumers who just want access to the client. But I don't think we're there yet 😅 We should continue to focus on making this the best it can be for React.