### PR TITLE
(docs) - fix typos and invalid syntax

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -146,7 +146,7 @@ result may be displayed that is then updated with fresh data
 from the API.
 
 > _Note:_ `'network-only'` and `'cache-and-network'` are extremely valuable
-> given the limitations of the default cache. The can be used to ensure
+> given the limitations of the default cache. They can be used to ensure
 > that data skips the cache, if it's clear to you that the result will
 > need to be up-to-date.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,7 +73,7 @@ const getTodos = `
   }
 `;
 
-const TodoList = ({ limit = 10 }) => {
+const TodoList = ({ limit = 10 }) => (
   <Query query={getTodos} variables={{ limit }}>
     {({ fetching, data, error, extensions }) => {
       if (fetching) {
@@ -91,7 +91,7 @@ const TodoList = ({ limit = 10 }) => {
       );
     }}
   </Query>;
-};
+);
 ```
 
 When this component is mounted it will send the `query` and `variables`


### PR DESCRIPTION
I should also fix these in the PR to urql-docs, the others mentioned are already fixed in urql master but aren't reflected to the docs publish yet

Resolves: https://github.com/FormidableLabs/urql/issues/390