### PR TITLE
Add pollInterval argument to queries

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@ interface UseQueryArgs {
   variables?: any;
   requestPolicy?: RequestPolicy;
   pause?: boolean;
+  pollInterval?: number;
   context?: Partial<OperationContext>;
 }
 ```
@@ -109,6 +110,7 @@ interface UseSubscriptionState<T> {
 | context       | `?object`                  | The GraphQL request's context                                                                         |
 | requestPolicy | `?RequestPolicy`           | An optional request policy that should be used                                                        |
 | pause         | `?boolean`                 | A boolean flag instructing `Query` to pause execution of the subsequent query operation               |
+| pollInterval  | `?number`                  | Every `pollInterval` milliseconds the query will be refetched                                         |
 | children      | `RenderProps => ReactNode` | A function that follows the typical render props pattern. The shape of the render props is as follows |
 
 #### Render Props

--- a/src/hooks/useQuery.spec.ts
+++ b/src/hooks/useQuery.spec.ts
@@ -14,6 +14,8 @@ jest.mock('../client', () => {
         map(i => ({ data: i, error: i + 1 }))
       )
     ),
+    reexecuteOperation: jest.fn(() => undefined),
+    createRequestOperation: jest.fn(() => undefined),
   };
 
   return {
@@ -23,7 +25,11 @@ jest.mock('../client', () => {
 });
 
 // @ts-ignore
-const client = createClient() as { executeQuery: jest.Mock };
+const client = createClient() as {
+  executeQuery: jest.Mock;
+  reexecuteOperation: jest.Mock;
+  createRequestOperation: jest.Mock;
+};
 
 const mockQuery = `
   query todo($id: ID!) {
@@ -323,11 +329,9 @@ describe('useQuery', () => {
     expect(client.executeQuery).toBeCalledTimes(1);
 
     jest.runOnlyPendingTimers();
-    expect(client.executeQuery).toBeCalled();
-    expect(client.executeQuery).toHaveBeenCalledTimes(2);
+    expect(client.reexecuteOperation).toBeCalled();
 
     jest.runOnlyPendingTimers();
-    expect(client.executeQuery).toBeCalled();
-    expect(client.executeQuery).toHaveBeenCalledTimes(3);
+    expect(client.reexecuteOperation).toBeCalled();
   });
 });

--- a/src/hooks/useQuery.spec.ts
+++ b/src/hooks/useQuery.spec.ts
@@ -304,4 +304,30 @@ describe('useQuery', () => {
     rerender({ query: mockQuery, variables: mockVariables, pause: true });
     expect(client.executeQuery).toBeCalledTimes(1);
   });
+
+  it('should reexecute in intervals if pollInterval is true', async () => {
+    jest.useFakeTimers();
+    renderHook(
+      ({ query, variables, pause, pollInterval }) =>
+        useQuery({ query, variables, pause, pollInterval }),
+      {
+        initialProps: {
+          query: mockQuery,
+          variables: mockVariables,
+          pause: false,
+          pollInterval: 100,
+        },
+      }
+    );
+
+    expect(client.executeQuery).toBeCalledTimes(1);
+
+    jest.runOnlyPendingTimers();
+    expect(client.executeQuery).toBeCalled();
+    expect(client.executeQuery).toHaveBeenCalledTimes(2);
+
+    jest.runOnlyPendingTimers();
+    expect(client.executeQuery).toBeCalled();
+    expect(client.executeQuery).toHaveBeenCalledTimes(3);
+  });
 });

--- a/src/hooks/useQuery.test.tsx
+++ b/src/hooks/useQuery.test.tsx
@@ -42,8 +42,9 @@ const QueryUser: FC<UseQueryArgs<{ myVar: number }>> = ({
   query,
   variables,
   pause,
+  pollInterval,
 }) => {
-  const [s, e] = useQuery({ query, variables, pause });
+  const [s, e] = useQuery({ query, variables, pause, pollInterval });
   state = s;
   execute = e;
   return <p>{s.data}</p>;
@@ -237,5 +238,22 @@ describe('pause', () => {
     wrapper.update(<QueryUser {...props} pause={true} />);
     wrapper.update(<QueryUser {...props} pause={true} />);
     expect(client.executeQuery).toBeCalledTimes(1);
+  });
+});
+
+describe('pollInterval', () => {
+  it('reexecutes the query every pollInterval ms', () => {
+    jest.useFakeTimers();
+    renderer.create(<QueryUser {...props} pollInterval={100} />);
+    expect(client.executeQuery).toBeCalled();
+    expect(client.executeQuery).toHaveBeenCalledTimes(1);
+
+    jest.runOnlyPendingTimers();
+    expect(client.executeQuery).toBeCalled();
+    expect(client.executeQuery).toHaveBeenCalledTimes(2);
+
+    jest.runOnlyPendingTimers();
+    expect(client.executeQuery).toBeCalled();
+    expect(client.executeQuery).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/hooks/useQuery.test.tsx
+++ b/src/hooks/useQuery.test.tsx
@@ -10,6 +10,8 @@ jest.mock('../client', () => {
         map((i: number) => ({ data: i, error: i + 1, extensions: { i: 1 } }))
       )
     ),
+    reexecuteOperation: jest.fn(() => undefined),
+    createRequestOperation: jest.fn(() => undefined),
   };
 
   return {
@@ -26,7 +28,11 @@ import { OperationContext } from '../types';
 import { useQuery, UseQueryArgs, UseQueryState } from './useQuery';
 
 // @ts-ignore
-const client = createClient() as { executeQuery: jest.Mock };
+const client = createClient() as {
+  executeQuery: jest.Mock;
+  reexecuteOperation: jest.Mock;
+  createRequestOperation: jest.Mock;
+};
 const props: UseQueryArgs<{ myVar: number }> = {
   query: '{ example }',
   variables: {
@@ -246,14 +252,11 @@ describe('pollInterval', () => {
     jest.useFakeTimers();
     renderer.create(<QueryUser {...props} pollInterval={100} />);
     expect(client.executeQuery).toBeCalled();
-    expect(client.executeQuery).toHaveBeenCalledTimes(1);
 
     jest.runOnlyPendingTimers();
-    expect(client.executeQuery).toBeCalled();
-    expect(client.executeQuery).toHaveBeenCalledTimes(2);
+    expect(client.reexecuteOperation).toBeCalled();
 
     jest.runOnlyPendingTimers();
-    expect(client.executeQuery).toBeCalled();
-    expect(client.executeQuery).toHaveBeenCalledTimes(3);
+    expect(client.reexecuteOperation).toBeCalled();
   });
 });

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -90,7 +90,12 @@ export const useQuery = <T = any, V = object>(
     let interval: NodeJS.Timeout | null = null;
     if (args.pollInterval) {
       interval = setInterval(() => {
-        executeQuery();
+        const operation = client.createRequestOperation('query', request, {
+          requestPolicy: args.requestPolicy,
+          ...args.context,
+          ...devtoolsContext,
+        });
+        client.reexecuteOperation(operation);
       }, args.pollInterval);
     }
 
@@ -98,7 +103,17 @@ export const useQuery = <T = any, V = object>(
       unsubscribe.current(); // eslint-disable-line
       if (interval) clearInterval(interval);
     };
-  }, [executeQuery, args.pause, setState, args.pollInterval]);
+  }, [
+    executeQuery,
+    args.pause,
+    setState,
+    args.pollInterval,
+    args.requestPolicy,
+    args.context,
+    client,
+    request,
+    devtoolsContext,
+  ]);
 
   return [state, executeQuery];
 };


### PR DESCRIPTION
This PR adds `pollInterval` option to queries, which causes them to be refetched every `pollInterval` ms. Example:

 ```JS
 useQuery({
   query,
   pollInterval: 1000
 })
 ```