### PR TITLE
(chore) - apply minimum of 90%coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,8 @@
 comment: off
 coverage:
   status:
-    project: yes
+    project:
+      default:
+        target: 90%
     patch: no
     changes: no


### PR DESCRIPTION
I noticed that codecov is a bit too strict, we want to stay above 90% a drop of 0.3 shouldn't make a PR fail.

Related to: https://github.com/FormidableLabs/urql/pull/397