### PR TITLE
fix: (WIP) deduplicate fragment definitions

### DIFF
--- a/src/exchanges/dedupFragments.test.ts
+++ b/src/exchanges/dedupFragments.test.ts
@@ -1,0 +1,64 @@
+import { empty, pipe, fromValue, toPromise, Source } from 'wonka';
+import { dedupFragmentsExchange } from './dedupFragments';
+import { queryOperation } from '../test-utils';
+import { createRequest } from '../utils';
+import { OperationResult } from '../types';
+import { Client } from '../client';
+
+const linkFragment = `
+fragment LinkFragment on Link {
+  url
+}
+`;
+
+const imageFragment = `
+fragment ImageFragment on Image {
+  src 
+  link {
+    ...LinkFragment
+  }
+}
+${linkFragment}
+`;
+
+const queryWithDuplicateFragments = `
+query MyQuery {
+  homepage {
+    content {
+      ...on Image {
+        ...ImageFragment
+      }
+      ...on Link {
+        ...LinkFragment
+      }
+    }
+  }
+  ${linkFragment}
+  ${imageFragment}
+}
+`;
+
+const request = createRequest(queryWithDuplicateFragments);
+
+const exchangeArgs = {
+  forward: () => empty as Source<OperationResult>,
+  client: {} as Client,
+};
+
+it('removes duplicate fragment definitions from the query', async () => {
+  const fetchOptions = jest.fn().mockReturnValue({});
+  const data = await pipe(
+    fromValue({
+      ...queryOperation,
+      query: request.query,
+      operationName: 'query',
+      context: {
+        ...queryOperation.context,
+        fetchOptions,
+      },
+    }),
+    dedupFragmentsExchange(exchangeArgs),
+    toPromise
+  );
+  /** ?? */
+});

--- a/src/exchanges/dedupFragments.ts
+++ b/src/exchanges/dedupFragments.ts
@@ -1,0 +1,43 @@
+import { pipe, map } from 'wonka';
+import { Exchange, Operation } from '../types';
+import { DefinitionNode } from 'graphql';
+
+export const dedupFragmentsExchange: Exchange = ({ forward }) => {
+  const dedupFragments = (operation: Operation) => {
+    const { query } = operation;
+    const { definitions } = query;
+
+    const filteredDefinitions = definitions.reduce(
+      (acc: DefinitionNode[], definition: DefinitionNode) => {
+        // @ts-ignore TODO
+        const { kind, name } = definition;
+        /* If this definition isn't a fragment, include it */
+        if (kind !== 'FragmentDefinition') return [...acc, definition];
+        /* If the accumulator already has a fragment with this name, omit this definition */
+        return acc.some(
+          def =>
+            def.kind === 'FragmentDefinition' && def.name.value === name.value
+        )
+          ? acc
+          : [...acc, definition];
+      },
+      []
+    );
+
+    return {
+      ...operation,
+      query: {
+        ...query,
+        definitions: filteredDefinitions,
+      },
+    };
+  };
+
+  return ops$ => {
+    const forward$ = pipe(
+      ops$,
+      map(dedupFragments)
+    );
+    return forward(forward$);
+  };
+};


### PR DESCRIPTION
Addresses #403 

This includes a simple exchange that filters out duplicated fragment definitions.

- [ ] There's a typescript error on line 13 - it's complaining that "name" doesn't exist on type "DefinitionNode" - while `DefinitionNode` is an enum with a handful of types that *do* have a `name`. I wasn't sure how to fix this.
- [ ] The test isn't working. I'm not familiar enough with wonka, etc, to make it all happen - although, I've tested this in a project of my own and it works.