### PR TITLE
Fixed executeMutation type in useMutation hook result

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,6 @@ You can then run the build using:
 yarn build
 ```
 
-Or run just the TypeScript build for type checks:
-
-```sh
-yarn build:types
-```
-
 ## How do I test my changes?
 
 It's always good practice to run the tests when making changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ You can then run the build using:
 yarn build
 ```
 
+Or run just the TypeScript build for type checks:
+
+```sh
+yarn run check
+```
+
 ## How do I test my changes?
 
 It's always good practice to run the tests when making changes.

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -15,7 +15,10 @@ export interface UseMutationState<T> {
 
 export type UseMutationResponse<T, V> = [
   UseMutationState<T>,
-  (variables?: V) => Promise<OperationResult<T>>
+  (
+    variables?: V,
+    context?: Partial<OperationContext>
+  ) => Promise<OperationResult<T>>
 ];
 
 export const useMutation = <T = any, V = object>(


### PR DESCRIPTION
And removed non-existing `build:types` entry from contributing doc