### PR TITLE
(fix) - exclude subscription from becoming a suspenseSource

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -192,7 +192,9 @@ export class Client {
       onEnd<OperationResult>(() => this.onOperationEnd(operation))
     );
 
-    return this.suspense ? toSuspenseSource(result$) : result$;
+    return this.suspense && operationName !== 'subscription'
+      ? toSuspenseSource(result$)
+      : result$;
   }
 
   reexecuteOperation = (operation: Operation) => {

--- a/src/hooks/useRequest.test.ts
+++ b/src/hooks/useRequest.test.ts
@@ -3,7 +3,8 @@ import { queryGql } from '../test-utils';
 import { useRequest } from './useRequest';
 
 it('preserves instance of request when key has not changed', () => {
-  let { query, variables } = queryGql;
+  const { query } = queryGql;
+  let { variables } = queryGql;
 
   const { result, rerender } = renderHook(
     ({ query, variables }) => useRequest(query, variables),


### PR DESCRIPTION
Subscriptions and Suspense don't work together at this point so we have to prevent from making our Subscriptions a suspended source.