### PR TITLE
Add babel transform to deconstruct Wonka's pipe

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ import buble from 'rollup-plugin-buble';
 import babel from 'rollup-plugin-babel';
 import replace from 'rollup-plugin-replace';
 import { terser } from 'rollup-plugin-terser';
+import transformPipe from './scripts/transform-pipe';
 
 const pkgInfo = require('./package.json');
 const external = ['dns', 'fs', 'path', 'url'];
@@ -119,8 +120,9 @@ const makePlugins = (isProduction = false) => [
     exclude: 'node_modules/**',
     presets: [],
     plugins: [
-      ['babel-plugin-closure-elimination', {}],
-      ['@babel/plugin-transform-object-assign', {}],
+      transformPipe,
+      'babel-plugin-closure-elimination',
+      '@babel/plugin-transform-object-assign',
       ['@babel/plugin-transform-react-jsx', {
         pragma: 'React.createElement',
         pragmaFrag: 'React.Fragment',

--- a/scripts/transform-pipe.js
+++ b/scripts/transform-pipe.js
@@ -1,21 +1,15 @@
 const pipeExpression = (t, pipeline) => {
-  if (pipeline.length === 1) {
-    return pipeline[0];
-  } else {
-    const operator = pipeline[pipeline.length - 1];
-    const rest = pipeline.slice(0, -1);
-    return t.callExpression(
-      pipeExpression(t, rest),
-      [operator]
-    );
-  }
+  let x = pipeline[0];
+  for (let i = 1; i < pipeline.length; i++)
+    x = t.callExpression(pipeline[i], [x]);
+  return x;
 };
 
 const pipePlugin = ({ types: t }) => ({
   visitor: {
     ImportDeclaration(path, state) {
       if (path.node.source.value === 'wonka') {
-        const { specifiers } = path.node
+        const { specifiers } = path.node;
         const pipeSpecifierIndex = specifiers.findIndex(spec => {
           return spec.imported.name === 'pipe';
         });

--- a/scripts/transform-pipe.js
+++ b/scripts/transform-pipe.js
@@ -1,0 +1,43 @@
+const pipeExpression = (t, pipeline) => {
+  if (pipeline.length === 1) {
+    return pipeline[0];
+  } else {
+    const operator = pipeline[pipeline.length - 1];
+    const rest = pipeline.slice(0, -1);
+    return t.callExpression(
+      pipeExpression(t, rest),
+      [operator]
+    );
+  }
+};
+
+const pipePlugin = ({ types: t }) => ({
+  visitor: {
+    ImportDeclaration(path) {
+      if (path.node.source.value === 'wonka') {
+        const specifiers = path.node.specifiers.filter(spec => {
+          return spec.imported.name !== 'pipe';
+        });
+
+        if (specifiers.length > 0) {
+          path.node.specifiers = specifiers;
+        } else {
+          path.remove();
+        }
+      }
+    },
+    CallExpression(path) {
+      const callee = path.node.callee;
+      const args = path.node.arguments;
+      if (callee.name !== 'pipe') {
+        return;
+      } else if (args.length === 0) {
+        path.replaceWith(t.identifier('undefined'));
+      } else {
+        path.replaceWith(pipeExpression(t, args));
+      }
+    }
+  }
+});
+
+export default pipePlugin;


### PR DESCRIPTION
If this works well I'll probably publish this separately, so we can reuse it. ~Right now it doesn't check whether the import actually matches up with the callee name `pipe` and whether it's present.~