### PR TITLE
Add useClient and warning when default client is used

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 import { Client, createClient } from './client';
 
 // We assume some default options here; mainly not to actually be used
@@ -8,3 +8,26 @@ const defaultClient = createClient({ url: '/graphql' });
 export const Context = createContext<Client>(defaultClient);
 export const Provider = Context.Provider;
 export const Consumer = Context.Consumer;
+
+let hasWarnedAboutDefault = false;
+
+export const useClient = (): Client => {
+  const client = useContext(Context);
+
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    client === defaultClient &&
+    !hasWarnedAboutDefault
+  ) {
+    hasWarnedAboutDefault = true;
+
+    console.warn(
+      "Default Client: No client has been specified using urql's Provider." +
+        'This means that urql will be falling back to defaults including making ' +
+        'requests to `/graphql`.\n' +
+        "If that's not what you want, please create a client and add a Provider."
+    );
+  }
+
+  return client;
+};

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql';
-import { useContext, useCallback } from 'react';
+import { useCallback } from 'react';
 import { pipe, toPromise } from 'wonka';
-import { Context } from '../context';
+import { useClient } from '../context';
 import { OperationResult, OperationContext } from '../types';
 import { CombinedError, createRequest } from '../utils';
 import { useImmediateState } from './useImmediateState';
@@ -24,7 +24,7 @@ export type UseMutationResponse<T, V> = [
 export const useMutation = <T = any, V = object>(
   query: DocumentNode | string
 ): UseMutationResponse<T, V> => {
-  const client = useContext(Context);
+  const client = useClient();
   const [state, setState] = useImmediateState<UseMutationState<T>>({
     fetching: false,
     error: undefined,

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql';
-import { useCallback, useContext, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { pipe, onEnd, subscribe } from 'wonka';
-import { Context } from '../context';
+import { useClient } from '../context';
 import { OperationContext, RequestPolicy } from '../types';
 import { CombinedError, noop } from '../utils';
 import { useRequest } from './useRequest';
@@ -33,7 +33,7 @@ export const useQuery = <T = any, V = object>(
   args: UseQueryArgs<V>
 ): UseQueryResponse<T> => {
   const unsubscribe = useRef(noop);
-  const client = useContext(Context);
+  const client = useClient();
 
   // This is like useState but updates the state object
   // immediately, when we're still before the initial mount

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql';
-import { useCallback, useContext, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { pipe, onEnd, subscribe } from 'wonka';
-import { Context } from '../context';
+import { useClient } from '../context';
 import { CombinedError, noop } from '../utils';
 import { useRequest } from './useRequest';
 import { useImmediateEffect } from './useImmediateEffect';
@@ -35,7 +35,7 @@ export const useSubscription = <T = any, R = T, V = object>(
 ): UseSubscriptionResponse<R> => {
   const unsubscribe = useRef(noop);
   const handlerRef = useRef(handler);
-  const client = useContext(Context);
+  const client = useClient();
 
   const [state, setState] = useImmediateState<UseSubscriptionState<R>>({
     fetching: false,


### PR DESCRIPTION
Fix #227 

This adds a new `useClient` hook for convenience and warns when the default client is used, informing the user why requests are made to `/graphql`.

In the future we may just remove the default, but that'd be a breaking change.