### PR TITLE
(chore) - update example 1 to work with both caches

### DIFF
--- a/examples/1-getting-started/src/app/components/Todo.tsx
+++ b/examples/1-getting-started/src/app/components/Todo.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export const Todo: FC<Props> = props => {
-  const [mutation, executeMutation] = useMutation(RemoveTodo);
+  const [mutation, executeMutation] = useMutation(ToggleTodo);
 
   const handleToggle = () => executeMutation({ id: props.id });
 
@@ -22,10 +22,11 @@ export const Todo: FC<Props> = props => {
 
 Todo.displayName = 'Todo';
 
-const RemoveTodo = `
+const ToggleTodo = `
   mutation($id: ID!) {
     toggleTodo(id: $id) {
       id
+      complete
     }
   }
 `;


### PR DESCRIPTION
 update todo example so toggling the todo does also work for graphcache. This because we were lacking the complete property. An empty response does not give context about the performed operation to graphcache.