### PR TITLE
(fix) - resolve issues with next example

### DIFF
--- a/examples/3-ssr-with-nextjs/components/PostList.js
+++ b/examples/3-ssr-with-nextjs/components/PostList.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import ErrorMessage from './ErrorMessage';
 import PostUpvoter from './PostUpvoter';
 
-const allPostsQuery = gql`
+export const allPostsQuery = gql`
   query allPosts($first: Int!, $skip: Int!) {
     allPosts(orderBy: createdAt_DESC, first: $first, skip: $skip) {
       id
@@ -18,7 +18,7 @@ const allPostsQuery = gql`
   }
 `;
 
-const allPostsQueryVars = {
+export const allPostsQueryVars = {
   skip: 0,
   first: 10,
 };

--- a/examples/3-ssr-with-nextjs/pages/index.js
+++ b/examples/3-ssr-with-nextjs/pages/index.js
@@ -14,10 +14,11 @@ const Root = () => (
 Root.getInitialProps = async () => {
   const [urqlClient] = initUrqlClient();
   // Prefetch data
-  await urqlClient
-    .query(allPostsQuery, allPostsQueryVars, undefined, true)
+  const { data } = await urqlClient
+    .query(allPostsQuery, allPostsQueryVars)
     .toPromise();
-  return {};
+
+  return { posts: data.allPosts };
 }
 
 export default withUrqlClient(Root);

--- a/examples/3-ssr-with-nextjs/pages/index.js
+++ b/examples/3-ssr-with-nextjs/pages/index.js
@@ -1,13 +1,23 @@
 import React from 'react';
 import Submit from '../components/Submit';
-import PostList from '../components/PostList';
+import PostList, { allPostsQuery, allPostsQueryVars } from '../components/PostList';
 import withUrqlClient from '../src/with-urql-client';
+import initUrqlClient from '../src/init-urql-client';
 
 const Root = () => (
-  <React.Fragment>
+  <>
     <Submit />
     <PostList />
-  </React.Fragment>
+  </>
 );
+
+Root.getInitialProps = async () => {
+  const [urqlClient] = initUrqlClient();
+  // Prefetch data
+  await urqlClient
+    .query(allPostsQuery, allPostsQueryVars, undefined, true)
+    .toPromise();
+  return {};
+}
 
 export default withUrqlClient(Root);

--- a/examples/3-ssr-with-nextjs/src/with-urql-client.js
+++ b/examples/3-ssr-with-nextjs/src/with-urql-client.js
@@ -18,9 +18,9 @@ const withUrqlClient = App => {
   };
 
   withUrql.getInitialProps = async ctx => {
+    const { AppTree } = ctx;
     // Run the wrapped component's getInitialProps function
     let appProps = {};
-
     if (App.getInitialProps) appProps = await App.getInitialProps(ctx);
 
     // getInitialProps is universal, but we only want
@@ -32,9 +32,12 @@ const withUrqlClient = App => {
 
     // Run suspense and hence all urql queries
     await ssrPrepass(
-      <Provider value={urqlClient}>
-        <App {...appProps} urqlClient={urqlClient} />
-      </Provider>
+      <AppTree
+        pageProps={{
+          ...appProps,
+          urqlClient
+        }}
+      />
     );
 
     // Extract query data from the urql store

--- a/src/client.ts
+++ b/src/client.ts
@@ -166,7 +166,7 @@ export class Client {
   }
 
   /** Executes an Operation by sending it through the exchange pipeline It returns an observable that emits all related exchange results and keeps track of this observable's subscribers. A teardown signal will be emitted when no subscribers are listening anymore. */
-  executeRequestOperation(operation: Operation): Source<OperationResult> {
+  executeRequestOperation(operation: Operation,): Source<OperationResult> {
     const { key, operationName } = operation;
     const operationResults$ = pipe(
       this.results$,
@@ -211,11 +211,12 @@ export class Client {
   query(
     query: DocumentNode | string,
     variables?: object,
-    context?: Partial<OperationContext>
+    context?: Partial<OperationContext>,
   ): PromisifiedSource<OperationResult> {
     if (!context || typeof context.suspense !== 'boolean') {
       context = { ...context, suspense: false };
     }
+
     return withPromise<OperationResult>(
       this.executeQuery(createRequest(query, variables), context)
     );
@@ -223,7 +224,7 @@ export class Client {
 
   executeQuery = (
     query: GraphQLRequest,
-    opts?: Partial<OperationContext>
+    opts?: Partial<OperationContext>,
   ): Source<OperationResult> => {
     const operation = this.createRequestOperation('query', query, opts);
     const response$ = this.executeRequestOperation(operation);

--- a/src/client.ts
+++ b/src/client.ts
@@ -166,7 +166,7 @@ export class Client {
   }
 
   /** Executes an Operation by sending it through the exchange pipeline It returns an observable that emits all related exchange results and keeps track of this observable's subscribers. A teardown signal will be emitted when no subscribers are listening anymore. */
-  executeRequestOperation(operation: Operation,): Source<OperationResult> {
+  executeRequestOperation(operation: Operation): Source<OperationResult> {
     const { key, operationName } = operation;
     const operationResults$ = pipe(
       this.results$,
@@ -211,7 +211,7 @@ export class Client {
   query(
     query: DocumentNode | string,
     variables?: object,
-    context?: Partial<OperationContext>,
+    context?: Partial<OperationContext>
   ): PromisifiedSource<OperationResult> {
     if (!context || typeof context.suspense !== 'boolean') {
       context = { ...context, suspense: false };
@@ -224,7 +224,7 @@ export class Client {
 
   executeQuery = (
     query: GraphQLRequest,
-    opts?: Partial<OperationContext>,
+    opts?: Partial<OperationContext>
   ): Source<OperationResult> => {
     const operation = this.createRequestOperation('query', query, opts);
     const response$ = this.executeRequestOperation(operation);


### PR DESCRIPTION
This is mainly meant to be an entry point for discussion, this shows how we would fix the nextjs example. The issue is that an error gets thrown in the getInitialProps meaning that we can't prefetch data. Something we wanted to enable with the `query` method.

This isn't the ideal solution yet but as it stands i'm a bit at a loss, for example putting getInitialProps in PostsList will make it so that that getInitialProps is never reached.

This wasn't easy to debug so this could be detriment to another deeper issue.

I have tried doing the following with prepass aswell:

```
    await ssrPrepass(
      <AppTree
        pageProps={{
          ...appProps,
          urqlClient
        }}
      />, e => {
        if (e && e.type && typeof e.type.getInitialProps === 'function') {
          return e.type.getInitialProps();
        }
      }
    );
```

In my opinion it's just getInitialProps that doesn't support suspense.