### PR TITLE
RFC: Configurable debugExchange

### DIFF
--- a/src/exchanges/debug.test.ts
+++ b/src/exchanges/debug.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 it('forwards query operations correctly', async () => {
   jest.spyOn(global.console, 'log').mockImplementation();
   const [ops$, next, complete] = input;
-  const exchange = debugExchange(exchangeArgs)(ops$);
+  const exchange = debugExchange({})(exchangeArgs)(ops$);
 
   publish(exchange);
   next(queryOperation);
@@ -52,7 +52,7 @@ describe('production', () => {
   it('is a noop in production', () => {
     const [ops$] = input;
 
-    debugExchange({
+    debugExchange({})({
       forward: ops => {
         expect(ops).toBe(ops$);
       },

--- a/src/exchanges/debug.ts
+++ b/src/exchanges/debug.ts
@@ -1,19 +1,26 @@
 import { pipe, tap } from 'wonka';
 import { Exchange } from '../types';
 
-export const debugExchange: Exchange = ({ forward }) => {
+const defaultLogFormat = (message: string, data: object) => ({ message, data });
+// eslint-disable-next-line no-console
+const defaultLogFn = ({ message, data }) => console.log(message, data);
+
+export const debugExchange = ({
+  logFn = defaultLogFn,
+  logFormat = defaultLogFormat,
+}): Exchange => ({ forward }) => {
   if (process.env.NODE_ENV === 'production') {
     return ops$ => forward(ops$);
   } else {
     return ops$ =>
       pipe(
         ops$,
-        // eslint-disable-next-line no-console
-        tap(op => console.log('[Exchange debug]: Incoming operation: ', op)),
+        tap(op =>
+          logFn(logFormat('[Exchange debug]: Incoming operation: ', op))
+        ),
         forward,
         tap(result =>
-          // eslint-disable-next-line no-console
-          console.log('[Exchange debug]: Completed operation: ', result)
+          logFn(logFormat('[Exchange debug]: Completed operation: ', result))
         )
       );
   }


### PR DESCRIPTION
Hey folks!

We're running URQL on both Server & Client, and we'd like to be able to use `pino` for server logging. I haven't really spent much time on this yet, as I'd like to understand whether you'd be interested in this, and if this is the right approach. Would love to hear your thoughts.

This is a breaking change, as it changes the signature of `debugExchange` to be an exchange factory, rather than an exchange.

New API:

```ts
interface DebugExchangeOptions {
  // default: console.log
  logFn?: (...args) => void;
  logFormat?: (message, data) => void;
}

type CreateDebugExchange = (options: DebugExchangeOptions) => Exchange;
```

Thanks! ❤️

edit: just to clarify, this is absolutely not mergeable in current shape, this is just to have a discussion around it.

## Todo
- [ ] Try out in current project
- [ ] Rename to `logExchange`
- [ ] Configure `logExchange` to `debugExchange`