### PR TITLE
Allow passing a custom client instance.

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -11,16 +11,16 @@ export const Consumer = Context.Consumer;
 
 let hasWarnedAboutDefault = false;
 
-export const useClient = (client?: Client): Client => {
-  const context = useContext(Context);
+export const useClient = (overrideClient?: Client): Client => {
+  const client = useContext(Context);
 
-  if (!!client) {
-    return client;
+  if (overrideClient) {
+    return overrideClient;
   }
 
   if (
     process.env.NODE_ENV !== 'production' &&
-    context === defaultClient &&
+    client === defaultClient &&
     !hasWarnedAboutDefault
   ) {
     hasWarnedAboutDefault = true;
@@ -33,5 +33,5 @@ export const useClient = (client?: Client): Client => {
     );
   }
 
-  return context;
+  return client;
 };

--- a/src/context.ts
+++ b/src/context.ts
@@ -11,12 +11,16 @@ export const Consumer = Context.Consumer;
 
 let hasWarnedAboutDefault = false;
 
-export const useClient = (): Client => {
-  const client = useContext(Context);
+export const useClient = (client?: Client): Client => {
+  const context = useContext(Context);
+
+  if (!!client) {
+    return client;
+  }
 
   if (
     process.env.NODE_ENV !== 'production' &&
-    client === defaultClient &&
+    context === defaultClient &&
     !hasWarnedAboutDefault
   ) {
     hasWarnedAboutDefault = true;
@@ -29,5 +33,5 @@ export const useClient = (): Client => {
     );
   }
 
-  return client;
+  return context;
 };

--- a/src/hooks/useQuery.spec.ts
+++ b/src/hooks/useQuery.spec.ts
@@ -303,4 +303,24 @@ describe('useQuery', () => {
     rerender({ query: mockQuery, variables: mockVariables, pause: true });
     expect(client.executeQuery).toBeCalledTimes(1);
   });
+
+  it('should support passing a custom client instance', async () => {
+    const mock = {
+      executeQuery: jest.fn(() =>
+        pipe(
+          interval(1),
+          map(() => ({ data: {} }))
+        )
+      ),
+    } as any;
+
+    const { waitForNextUpdate } = renderHook(
+      ({ query, variables }) => useQuery({ query, variables, client: mock }),
+      { initialProps: { query: mockQuery, variables: mockVariables } }
+    );
+
+    await waitForNextUpdate();
+    expect(mock.executeQuery).toBeCalledTimes(1);
+    expect(client.executeQuery).toBeCalledTimes(0);
+  });
 });

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -4,10 +4,10 @@ import { pipe, onEnd, subscribe } from 'wonka';
 import { useClient } from '../context';
 import { OperationContext, RequestPolicy } from '../types';
 import { CombinedError, noop } from '../utils';
+import { Client } from '../client';
 import { useRequest } from './useRequest';
 import { useImmediateEffect } from './useImmediateEffect';
 import { useImmediateState } from './useImmediateState';
-import { Client } from 'src/client';
 
 export interface UseQueryArgs<V> {
   query: string | DocumentNode;

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -7,6 +7,7 @@ import { CombinedError, noop } from '../utils';
 import { useRequest } from './useRequest';
 import { useImmediateEffect } from './useImmediateEffect';
 import { useImmediateState } from './useImmediateState';
+import { Client } from 'src/client';
 
 export interface UseQueryArgs<V> {
   query: string | DocumentNode;
@@ -14,6 +15,7 @@ export interface UseQueryArgs<V> {
   requestPolicy?: RequestPolicy;
   pollInterval?: number;
   context?: Partial<OperationContext>;
+  client?: Client;
   pause?: boolean;
 }
 
@@ -33,7 +35,7 @@ export const useQuery = <T = any, V = object>(
   args: UseQueryArgs<V>
 ): UseQueryResponse<T> => {
   const unsubscribe = useRef(noop);
-  const client = useClient();
+  const client = useClient(args.client);
 
   // This is like useState but updates the state object
   // immediately, when we're still before the initial mount


### PR DESCRIPTION
Resolve #429

Hi there. Apparently this came up with another user too: https://github.com/FormidableLabs/urql/issues/429

I had the same need so instead of continuing to roll a custom useQuery hook I thought I'd write a quick PR.