### PR TITLE
Fix react-wonka update bug that occurs with Context Providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "react-dom": ">= 16.8.0"
   },
   "dependencies": {
-    "react-wonka": "^1.0.1",
+    "react-wonka": "^1.0.2",
     "wonka": "^3.2.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,8 +16,6 @@ if (pkgInfo.peerDependencies)
 if (pkgInfo.dependencies)
   external.push(...Object.keys(pkgInfo.dependencies));
 
-external = external.filter(x => x !== 'react-wonka');
-
 const externalPredicate = new RegExp(`^(${external.join('|')})($|/)`);
 const externalTest = id => {
   if (id === 'babel-plugin-transform-async-to-promises/helpers') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4588,10 +4588,10 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.10.2:
     react-is "^16.8.6"
     scheduler "^0.16.2"
 
-react-wonka@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-wonka/-/react-wonka-1.0.1.tgz#66b44aa1fb4e3e38cb2ef49f7d7195de1a322775"
-  integrity sha512-SMZCQUQ1gTxCqH9ftx5RecykOx1wWDtbZa6lJDmBU8aCpX3Xxs3baTtbGP+PIvrDMIOZIJN7Ezv1e/8jWQ2vXw==
+react-wonka@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-wonka/-/react-wonka-1.0.2.tgz#b8d5a095e5ce40548842036898a2665ea5202f69"
+  integrity sha512-oZgI5Z0DY7HjqPQZPbY5+2hEmDSWJfdurt1uaB65bvH4FLWA9/0cW4KNn8Y776fnicsxTNMtVMYMlFgB/2KJjQ==
 
 react@^16.10.2:
   version "16.10.2"


### PR DESCRIPTION
Fix #450 
See: https://github.com/kitten/react-wonka/pull/1

This upgrade `react-wonka` to fix an issue where updates weren't propagated to context providers. This seems to be closely related to some kind of React internals that cause these kinds of updates to be run twice (presumably in two separate Fiber phases) to update the context consumers.

This also now externalises `react-wonka`, in case we need to push out another patch.