### PR TITLE
exchange authoring guide clarifications for Urql noobs

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -103,13 +103,13 @@ import { Client, dedupeExchange, fetchExchange } from 'urql';
 const noopExchange = ({ client, forward }) => {
   return operation$ => { // <-- This exchange's ExchangeIO function
     // calling forward() here will call the next exchange's ExchangeIO function.
-    // So before this...
+    // So before this,
     // urql creates an Operation object, places it in a stream (operation$),
-    // and calls composeExchange's ExchangeIO function.
+    // and calls composeExchange's ExchangeIO function with it.
     // composeExchange forward()s the operation$ stream to dedupeExchange's ExchangeIO function.
     // dedupeExchange filters duplicates and forward()s the stream to noopExchange's ExchangeIO function.
-    // noopExchange forward()s the operation$ stream to fetchExchange's ExchangeIO function
     
+    // Here, noopExchange forward()s the operation$ stream to fetchExchange's ExchangeIO function
     const operationResult$ = forward(operations$);
     
     // fetchExchange receives the operation$ stream, creates an OperationResult object,
@@ -118,8 +118,7 @@ const noopExchange = ({ client, forward }) => {
     
     return operationResult$;
     
-    // After this...
-    // dedupExchange returns operationResult$ to composeExchange's forward() call.
+    // After this, dedupExchange returns operationResult$ to composeExchange's forward() call.
     // urql client receives the operationResult$ from composeExchange and provides data to components.
   };
 };

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -95,7 +95,7 @@ By convention, variables ending with `$` are streams. Each exchange's `ExchangeI
 
 #### Forward and Return Composition
 
-When you create a client and pass it an array of exchanges, Urql composes them left-to-right into a single exchange using [`composeExchanges`](https://github.com/FormidableLabs/urql/blob/master/src/exchanges/compose.ts). `composeExchanges` orchestrates stream forward and return between exchanges. Here's the noopExchange in context:
+When you create a client and pass it an array of exchanges, `urql` composes them left-to-right into a single exchange using [`composeExchanges`](https://github.com/FormidableLabs/urql/blob/master/src/exchanges/compose.ts). `composeExchanges` orchestrates stream forward and return between exchanges. Here's the `noopExchange` in context:
 
 ```js
 import { Client, dedupeExchange, fetchExchange } from 'urql';
@@ -114,21 +114,6 @@ const noopExchange = ({ client, forward }) => {
 const client = new Client({
   exchanges: [dedupeExchange, noopExchange, fetchExchange],
 });
-```
-
-#### Forward + Return = Request + Response
-
-Interacting with a request occurs before the forward() call. Interacting with a response occurs after the forward call. Here's the noopExchange with explicit request and response stream handlers.
-
-```js
-const handleRequest = operation$ => {/*do stuff*/ return operation$;};
-const handleResponse = operationResult$ => {/*do stuff*/ return operationResult$;};
-
-const noopExchange = ({ client, forward }) => {
-  return operations$ => { // <-- The ExchangeIO function
-    return handleResponse( forward( handleRequest( operations$ )));
-  };
-};
 ```
 
 ### One operations stream only


### PR DESCRIPTION
These updates would have helped me when learning to write exchanges.  They add context for the noop exchange, comment the examples' anonymous ExchangeIO function, explain what happens with forwarded + returned streams, where operationResults get created, and how request/response relate to forward/return.