### PR TITLE
add originalError

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -28,7 +28,7 @@ const rehydrateGraphQlError = (error: any): GraphQLError => {
       error.source,
       error.positions,
       error.path,
-      error.originalError,
+      error,
       error.extensions || {}
     );
   } else {


### PR DESCRIPTION
So I think this is better than relying on the `Error` instance received from the backend having an `originalError` property this way we allow for our users to have enriched errors with for instance `code` or `key`.

In the docs they also state this to be an `Error` instance so I think this is perfectly valid https://graphql.org/graphql-js/error/#graphqlerror

Resolves: https://github.com/FormidableLabs/urql/issues/469