### PR TITLE
fix problem with stringifying date objects

### DIFF
--- a/src/utils/stringifyVariables.test.ts
+++ b/src/utils/stringifyVariables.test.ts
@@ -28,3 +28,9 @@ it('throws for circular structures', () => {
     stringifyVariables(x);
   }).toThrow();
 });
+
+it('stringifies date correctly', () => {
+  expect(stringifyVariables(new Date('2019-12-11T04:20:00'))).toBe(
+    '2019-12-11T04:20:00.000Z'
+  );
+});

--- a/src/utils/stringifyVariables.ts
+++ b/src/utils/stringifyVariables.ts
@@ -1,9 +1,10 @@
 const seen = new Set();
 
 const stringify = (x: any): string => {
-  if (x && x.toJson) x = x.toJSON();
   if (x === undefined) {
     return '';
+  } else if (x && x.toJSON) {
+    return x.toJSON();
   } else if (typeof x == 'number') {
     return isFinite(x) ? '' + x : 'null';
   } else if (typeof x !== 'object') {

--- a/src/utils/stringifyVariables.ts
+++ b/src/utils/stringifyVariables.ts
@@ -1,6 +1,7 @@
 const seen = new Set();
 
 const stringify = (x: any): string => {
+  if (x && x.toJson) x = x.toJSON();
   if (x === undefined) {
     return '';
   } else if (typeof x == 'number') {

--- a/src/utils/stringifyVariables.ts
+++ b/src/utils/stringifyVariables.ts
@@ -3,14 +3,14 @@ const seen = new Set();
 const stringify = (x: any): string => {
   if (x === undefined) {
     return '';
-  } else if (x && x.toJSON) {
-    return x.toJSON();
   } else if (typeof x == 'number') {
     return isFinite(x) ? '' + x : 'null';
   } else if (typeof x !== 'object') {
     return JSON.stringify(x);
   } else if (x === null) {
     return 'null';
+  } else if (x.toJSON) {
+    return x.toJSON();
   }
 
   let out = '';


### PR DESCRIPTION
For some reason when I tried to include the library locally I got an error about Invalid hook calls:

`Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:`

So I was not able to test if it fixes those for sure

This possibly: 
fixes #479 and fixes #478 