### PR TITLE
warn when creating a client without url

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -90,6 +90,9 @@ export class Client {
   activeOperations = Object.create(null) as ActiveOperations;
 
   constructor(opts: ClientOptions) {
+    if (process.env.NODE_ENV !== 'production' && !opts.url) {
+      console.warn('You are creating an urql-client without a url.');
+    }
     this.url = opts.url;
     this.fetchOptions = opts.fetchOptions;
     this.fetch = opts.fetch;

--- a/src/client.ts
+++ b/src/client.ts
@@ -91,7 +91,7 @@ export class Client {
 
   constructor(opts: ClientOptions) {
     if (process.env.NODE_ENV !== 'production' && !opts.url) {
-      console.warn('You are creating an urql-client without a url.');
+      throw new Error('You are creating an urql-client without a url.');
     }
     this.url = opts.url;
     this.fetchOptions = opts.fetchOptions;


### PR DESCRIPTION
This stems from a twitter conversation where the undefined url would lead to an error in a minimalistic fetch-shim.