### PR TITLE
Modify subscribe in useSource not to allow getCurrentValue in effects

### DIFF
--- a/src/hooks/useSource.ts
+++ b/src/hooks/useSource.ts
@@ -35,14 +35,12 @@ export const useSource = <T>(source: Source<T>, init: T): T =>
           return currentValue;
         },
         subscribe(onValue: () => void): Unsubscribe {
-          return pipe(
-            updateValue,
-            subscribe(() => {
-              hasUpdate = true;
-              onValue();
-              hasUpdate = false;
-            })
-          ).unsubscribe as Unsubscribe;
+          hasUpdate = true;
+          const { unsubscribe } = pipe(updateValue, subscribe(onValue));
+          return () => {
+            unsubscribe();
+            hasUpdate = false;
+          };
         },
       };
     }, [source])


### PR DESCRIPTION
This stops us from creating temporary subscriptions when useSubscription
calls getCurrentValue in useEffect. This may happen because React first
checks whether it has missed any values.

Due to this change we may miss changed values, but this shouldn't be
an issue, because `subscribe` is pretty reliable in returning up-to-date
state.