### PR TITLE
[feat] - stripping typenames

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,4 +9,5 @@ export {
   makeResult,
   makeErrorResult,
   formatDocument,
+  stripTypename,
 } from './utils';

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './result';
 export * from './typenames';
 export * from './toSuspenseSource';
 export * from './stringifyVariables';
+export * from './stripTypename';
 export * from './withPromise';
 
 export const noop = () => {

--- a/packages/core/src/utils/stripTypename.test.ts
+++ b/packages/core/src/utils/stripTypename.test.ts
@@ -1,0 +1,48 @@
+import { stripTypename } from './stripTypename';
+
+it('strips typename from flat objects', () => {
+  expect(
+    stripTypename({ __typename: 'Todo', id: 1 })
+  ).toEqual({ id: 1 });
+});
+
+it('strips typename from nested objects', () => {
+  expect(
+    stripTypename({
+      __typename: 'Todo',
+      id: 1,
+      author: {
+        id: 2,
+        __typename: 'Author'
+      }
+    })
+  ).toEqual({ id: 1, author: { id: 2 } });
+});
+
+it('strips typename from nested objects with arrays', () => {
+  expect(
+    stripTypename({
+      __typename: 'Todo',
+      id: 1,
+      author: {
+        id: 2,
+        __typename: 'Author',
+        books: [
+          { id: 3, __typename: 'Book', review: { id: 8, __typename: 'Review' } },
+          { id: 4, __typename: 'Book' },
+          { id: 5, __typename: 'Book' },
+        ]
+      }
+    })
+  ).toEqual({
+    id: 1,
+    author: {
+      id: 2,
+      books: [
+        { id: 3, review: { id: 8 } },
+        { id: 4 },
+        { id: 5 },
+      ]
+    }
+  });
+});

--- a/packages/core/src/utils/stripTypename.ts
+++ b/packages/core/src/utils/stripTypename.ts
@@ -1,4 +1,6 @@
 export const stripTypename = (data: any): any => {
+  if (!data) return data;
+
   const result = {};
 
   Object.keys(data).forEach((key: string) => {

--- a/packages/core/src/utils/stripTypename.ts
+++ b/packages/core/src/utils/stripTypename.ts
@@ -1,0 +1,17 @@
+export const stripTypename = (data: any): any => {
+  const result = {};
+
+  Object.keys(data).forEach((key: string) => {
+    const value = data[key];
+    if (key === '__typename') { // SKIP!
+    } else if (Array.isArray(value)) {
+      result[key] = value.map(stripTypename);
+    } else if (typeof value === 'object') {
+      result[key] = stripTypename(value);
+    } else {
+      result[key] = value;
+    }
+  });
+
+  return result;
+}

--- a/packages/preact-urql/src/hooks/useMutation.ts
+++ b/packages/preact-urql/src/hooks/useMutation.ts
@@ -6,7 +6,6 @@ import {
   OperationContext,
   CombinedError,
   createRequest,
-  stripTypename,
 } from '@urql/core';
 import { useClient } from '../context';
 import { useImmediateState } from './useImmediateState';
@@ -44,10 +43,11 @@ export const useMutation = <T = any, V = object>(
         fetching: true,
       });
 
-      const request = createRequest(query, stripTypename(variables as any));
-
       return pipe(
-        client.executeMutation(request, context || {}),
+        client.executeMutation(
+          createRequest(query, variables as any),
+          context || {},
+        ),
         toPromise
       ).then(result => {
         setState({

--- a/packages/preact-urql/src/hooks/useMutation.ts
+++ b/packages/preact-urql/src/hooks/useMutation.ts
@@ -6,6 +6,7 @@ import {
   OperationContext,
   CombinedError,
   createRequest,
+  stripTypename,
 } from '@urql/core';
 import { useClient } from '../context';
 import { useImmediateState } from './useImmediateState';
@@ -43,7 +44,7 @@ export const useMutation = <T = any, V = object>(
         fetching: true,
       });
 
-      const request = createRequest(query, variables as any);
+      const request = createRequest(query, stripTypename(variables as any));
 
       return pipe(
         client.executeMutation(request, context || {}),

--- a/packages/preact-urql/src/hooks/useRequest.ts
+++ b/packages/preact-urql/src/hooks/useRequest.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql';
 import { useRef, useMemo } from 'preact/hooks';
-import { GraphQLRequest, createRequest } from '@urql/core';
+import { GraphQLRequest, createRequest, stripTypename } from '@urql/core';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
 export const useRequest = (
@@ -10,7 +10,7 @@ export const useRequest = (
   const prev = useRef<undefined | GraphQLRequest>(undefined);
 
   return useMemo(() => {
-    const request = createRequest(query, variables);
+    const request = createRequest(query, stripTypename(variables));
     // We manually ensure reference equality if the key hasn't changed
     if (prev.current !== undefined && prev.current.key === request.key) {
       return prev.current;

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -7,7 +7,6 @@ import {
   OperationContext,
   CombinedError,
   createRequest,
-  stripTypename,
 } from '@urql/core';
 
 import { useClient } from '../context';
@@ -40,10 +39,11 @@ export const useMutation = <T = any, V = object>(
     (variables?: V, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
 
-      const request = createRequest(query, stripTypename(variables as any));
-
       return pipe(
-        client.executeMutation(request, context || {}),
+        client.executeMutation(
+          createRequest(query, variables as any),
+          context || {},
+        ),
         toPromise
       ).then(result => {
         setState({

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -6,7 +6,8 @@ import {
   OperationResult,
   OperationContext,
   CombinedError,
-  createRequest
+  createRequest,
+  stripTypename,
 } from '@urql/core';
 
 import { useClient } from '../context';
@@ -39,7 +40,7 @@ export const useMutation = <T = any, V = object>(
     (variables?: V, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
 
-      const request = createRequest(query, variables as any);
+      const request = createRequest(query, stripTypename(variables as any));
 
       return pipe(
         client.executeMutation(request, context || {}),

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql';
 import { useCallback, useMemo } from 'react';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
-import { CombinedError, OperationContext, RequestPolicy } from '@urql/core';
+import { CombinedError, OperationContext, RequestPolicy, stripTypename } from '@urql/core';
 
 import { useClient } from '../context';
 import { useSource, useBehaviourSubject } from './useSource';
@@ -15,6 +15,7 @@ export interface UseQueryArgs<V> {
   pollInterval?: number;
   context?: Partial<OperationContext>;
   pause?: boolean;
+  stripTypename?: boolean;
 }
 
 export interface UseQueryState<T> {
@@ -71,7 +72,9 @@ export const useQuery = <T = any, V = object>(
               map(({ stale, data, error, extensions }) => ({
                 fetching: false,
                 stale: !!stale,
-                data,
+                data: args.stripTypename ?
+                  stripTypename(data) :
+                  data,
                 error,
                 extensions,
               }))
@@ -89,7 +92,7 @@ export const useQuery = <T = any, V = object>(
           initialState
         )
       );
-    }, [query$$]),
+    }, [args.stripTypename, query$$]),
     initialState
   );
 

--- a/packages/react-urql/src/hooks/useRequest.ts
+++ b/packages/react-urql/src/hooks/useRequest.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql';
 import { useRef, useMemo } from 'react';
-import { GraphQLRequest, createRequest } from '@urql/core';
+import { GraphQLRequest, createRequest, stripTypename } from '@urql/core';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
 export const useRequest = (
@@ -10,7 +10,7 @@ export const useRequest = (
   const prev = useRef<undefined | GraphQLRequest>(undefined);
 
   return useMemo(() => {
-    const request = createRequest(query, variables);
+    const request = createRequest(query, stripTypename(variables));
     // We manually ensure reference equality if the key hasn't changed
     if (prev.current !== undefined && prev.current.key === request.key) {
       return prev.current;


### PR DESCRIPTION
This adds the possibility of telling `useQuery` to strip `__typename` of the result and will sanitise our `variables`.

Sorry this should've been a draft...

> TODO: add tests