### PR TITLE
fix updateQuery updater function type

### DIFF
--- a/.changeset/famous-ducks-smash.md
+++ b/.changeset/famous-ducks-smash.md
@@ -2,4 +2,4 @@
 '@urql/exchange-graphcache': patch
 ---
 
-Changes the type for the `updater` function of `cache.updateQuery` to `DataFields` this doesn't require `__typename` to be defined.
+Update the `updater` function type of `cache.updateQuery` to have a return type of `DataFields` so that `__typename` does not need to be defined.

--- a/.changeset/famous-ducks-smash.md
+++ b/.changeset/famous-ducks-smash.md
@@ -2,4 +2,4 @@
 '@urql/exchange-graphcache': patch
 ---
 
-Changes the type for the `updater` function of `cache.updateQuery` to `DataFields` this doesn't require `__typename` to be defined. This PR also adds a fallback in `updateQuery` when `__typename` is missing.
+Changes the type for the `updater` function of `cache.updateQuery` to `DataFields` this doesn't require `__typename` to be defined.

--- a/.changeset/famous-ducks-smash.md
+++ b/.changeset/famous-ducks-smash.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Changes the type for the `updater` function of `cache.updateQuery` to `DataFields` this doesn't require `__typename` to be defined. This PR also adds a fallback in `updateQuery` when `__typename` is missing.

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -18,6 +18,7 @@ import {
   UpdatesConfig,
   OptimisticMutationConfig,
   KeyingConfig,
+  DataFields,
 } from '../types';
 
 import { read, readFragment } from '../operations/query';
@@ -163,12 +164,15 @@ export class Store implements Cache {
 
   updateQuery(
     input: QueryInput,
-    updater: (data: Data | null) => Data | null
+    updater: (data: Data | null) => DataFields | null
   ): void {
     const request = createRequest(input.query, input.variables);
     const output = updater(this.readQuery(request as QueryInput));
     if (output !== null) {
-      startWrite(this, request, output);
+      if (!output.__typename) {
+        output.__typename = this.rootFields.query;
+      }
+      startWrite(this, request, output as Data);
     }
   }
 

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -169,9 +169,6 @@ export class Store implements Cache {
     const request = createRequest(input.query, input.variables);
     const output = updater(this.readQuery(request as QueryInput));
     if (output !== null) {
-      if (!output.__typename) {
-        output.__typename = this.rootFields.query;
-      }
       startWrite(this, request, output as Data);
     }
   }


### PR DESCRIPTION
## Summary

This should make life easier on people using custom updaters with mutations/subscriptions

Resolves: https://github.com/FormidableLabs/urql/issues/537

## Set of changes

- Moves away from Data return value for the `updater` function for `updateQuery` and goes to `DataFields` this type doesn't need `__typename` to be present
- Adds a fallback for `__typename` in the updater function.
