### PR TITLE
Fix tsc and Jest setup for paths mapping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,8 +140,11 @@ an appropriate extension (`.esm.js` for `module` and `.cjs.js` for `main`).
 
 If your entrypoint won't be at `src/index.ts` you may alter it. But the `types` field has to match
 the same file relative to the `dist/types` folder, where `rollup` will output the TypeScript
-declaration files. When setting up your package make sure to create a `src/index.ts` file (or a file
-at what you've set `source` to)
+declaration files.
+
+When setting up your package make sure to create a `src/index.ts` file
+(or any other file which you've pointed `package.json:source` to). Also don't forget to
+copy over the `tsconfig.json` from another package (You won't need to change it).
 
 The `scripts.prepare` task is set up to check your new `package.json` file for correctness. So in
 case you get anything wrong, you'll get a short error when running `yarn` after setting your new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,16 @@ yarn
 
 ## How do I add a new package?
 
+First of all we need to know where to put the package.
+
+- Exchanges should be added to `exchanges/` and the folder should be the plain
+  name of the exchange. Since the `package.json:name` is following the convention
+  of `@urql/exchange-*` the folder should just be without this conventional prefix.
+- All other packages should be added to `packages/`. Typically all packages should
+  be named `@urql/*` and their folders should be named exactly this without the
+  prefix or `*-urql`. Optionally if the package will be named `*-urql` then the folder
+  can take on the same name.
+
 When adding a new package, start by copying a `package.json` file from another project.
 You may want to alter the following fields first:
 
@@ -136,10 +146,6 @@ at what you've set `source` to)
 The `scripts.prepare` task is set up to check your new `package.json` file for correctness. So in
 case you get anything wrong, you'll get a short error when running `yarn` after setting your new
 project up. Just in case! 😄
-
-Lastly, your new package will need to be added to the `tsconfig.json` in the root of the repository.
-Add a new entry to `compilerOptions.paths` where the key is the `name` you've used in your
-`package.json` and the value is an array with a single entry, the path to your package + `src/`.
 
 Afterwards you can check whether everything is working correctly by running:
 

--- a/exchanges/graphcache/tsconfig.json
+++ b/exchanges/graphcache/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^2.3.0",
     "execa": "^4.0.0",
+    "glob": "^7.1.6",
     "graphql": "^14.6.0",
     "graphql-tag": "^2.10.1",
     "husky": "^4.2.1",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}

--- a/packages/preact-urql/tsconfig.json
+++ b/packages/preact-urql/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}

--- a/packages/react-urql/tsconfig.json
+++ b/packages/react-urql/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}

--- a/packages/svelte-urql/tsconfig.json
+++ b/packages/svelte-urql/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}

--- a/scripts/jest/preset.js
+++ b/scripts/jest/preset.js
@@ -1,6 +1,3 @@
-const { pathsToModuleNameMapper } = require('ts-jest/utils');
-const { compilerOptions } = require('../../tsconfig.json');
-
 module.exports = {
   preset: 'ts-jest',
   setupFiles: [
@@ -9,10 +6,11 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  moduleNameMapper: pathsToModuleNameMapper(
-    compilerOptions.paths,
-    { prefix: '<rootDir>/../../' }
-  ),
+  moduleNameMapper: {
+    "^urql$": "<rootDir>/../../node_modules/urql/src",
+    "^(.*-urql)$": "<rootDir>/../../node_modules/$1/src",
+    "^@urql/(.*)$": "<rootDir>/../../node_modules/@urql/$1/src",
+  },
   watchPlugins: ['jest-watch-yarn-workspaces'],
   testRegex: '(src/.*(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json'],

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
 const path = require('path');
+const glob = require('glob').sync;
 const execa = require('execa');
 
-const { compilerOptions: { paths } } = require('../../tsconfig.json');
 const workspaceRoot = path.resolve(__dirname, '../../');
 const rollupConfig = path.resolve(__dirname, './config.js');
 
-let packages = Object.keys(paths).map(package => {
-  return path.resolve(workspaceRoot, paths[package][0], '../');
+let packages = glob('{packages,exchanges}/*/package.json').map(pkg => {
+  return path.resolve(pkg, '../');
 });
 
 // CircleCI parallelism

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -36,7 +36,6 @@ export const makePlugins = ({ isProduction } = {}) => [
     : typescript({
       useTsconfigDeclarationDir: true,
       objectHashIgnoreUnknownHack: true,
-      tsconfigDefaults: require('../../tsconfig.json'),
       tsconfigOverride: {
         exclude: [
           'src/**/*.test.ts',
@@ -45,9 +44,8 @@ export const makePlugins = ({ isProduction } = {}) => [
         ],
         compilerOptions: {
           sourceMap: true,
-          baseUrl: '.',
           declaration: !isProduction,
-          declarationDir: './dist/types',
+          declarationDir: settings.types,
           target: 'es6',
         },
       },

--- a/scripts/rollup/settings.js
+++ b/scripts/rollup/settings.js
@@ -1,7 +1,8 @@
 const path = require('path');
-const cwd = process.cwd();
 
+export const cwd = process.cwd();
 export const pkg = require(path.resolve(cwd, './package.json'));
+export const types = path.resolve(cwd, 'dist/types/');
 
 const normalize = name => name
   .replace(/[@\s\/\.]+/g, ' ')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,8 @@
     "paths": {
       "urql": ["packages/react-urql/src"],
       "*-urql": ["packages/*-urql/src"],
-      "@urql/*": ["packages/*-urql/src", "packages/*/src"],
-      "@urql/exchange-*": ["exchanges/*/src"]
+      "@urql/exchange-*": ["exchanges/*/src"],
+      "@urql/*": ["packages/*-urql/src", "packages/*/src"]
     },
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,10 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@urql/core": ["packages/core/src"],
-      "@urql/exchange-graphcache": ["exchanges/graphcache/src"],
       "urql": ["packages/react-urql/src"],
-      "preact-urql": ["packages/preact-urql/src"],
-      "svelte-urql": ["packages/svelte-urql/src"]
+      "*-urql": ["packages/*-urql/src"],
+      "@urql/*": ["packages/*-urql/src", "packages/*/src"],
+      "@urql/exchange-*": ["exchanges/*/src"]
     },
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -21,10 +20,7 @@
     "noImplicitAny": false,
     "noUnusedParameters": true
   },
-  "include": [
-    "packages",
-    "exchanges"
-  ],
+  "include": ["packages", "exchanges"],
   "exclude": [
     "scripts",
     "packages/*/examples",


### PR DESCRIPTION
## Summary

This fixes the `tsconfig.json` setup in all packages and introduces a new package naming convention so the `tsconfig.json` files won't have to change or be maintained in the future.

## Set of changes

- Update `compilerOptions.path` convention
- Add new `tsconfig.json` files to all packages
- Ensure that `dist/types` will be built correctly for all packages
- Fix Jest's `moduleNameMapper` option