### PR TITLE
allow switching fetchOptions on client

### DIFF
--- a/.changeset/selfish-pugs-visit.md
+++ b/.changeset/selfish-pugs-visit.md
@@ -1,5 +1,5 @@
 ---
-'@urql/core': patch
+'@urql/core': minor
 ---
 
 Allows setting the fetchOptions after client construction with the `client.setFetchOptions` method.

--- a/.changeset/selfish-pugs-visit.md
+++ b/.changeset/selfish-pugs-visit.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Allows setting the fetchOptions after client construction with the `client.setFetchOptions` method.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -153,6 +153,10 @@ export class Client {
     requestPolicy: (opts || {}).requestPolicy || this.requestPolicy,
   });
 
+  setFetchOptions(fetchOptions: RequestInit | (() => RequestInit))  {
+    this.fetchOptions = fetchOptions;
+  }
+
   createRequestOperation = (
     type: OperationType,
     request: GraphQLRequest,


### PR DESCRIPTION
## Summary

Imagine the following scenario:

```
const client = createClient(...);

const App = () => {
  const [token, setToken] = useState(null)

  useEffect(() => {
    if (token) client.setFetchOptions(...)
   }, [token]);

  return (
    <Provider value={client}>
      {token ? <Features /> : <Auth setToken={setToken} />}
    </Provider>
  )
}
```

Before this we would have to reconstruct the client or make an abstracted `useQuery` method that would get this token from context.

The alternative solution would be

```
const useAuthenticatedQuery = (...) => {
  const token = useAuth()
  return useQuery(... fetchOptions: token)
}
```

## Set of changes

- allow changing fetchOptions on the constructed client