### PR TITLE
Fixes graphcache warning & error links

### DIFF
--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -9,7 +9,7 @@ import { ErrorCode } from '../types';
 type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
 
 const helpUrl =
-  '\nhttps://github.com/FormidableLabs/urql-exchange-graphcache/blob/master/docs/help.md#';
+  '\nhttps://github.com/FormidableLabs/urql/blob/master/docs/graphcache/help.md#';
 const cache = new Set<string>();
 
 export const currentDebugStack: string[] = [];


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Links to graphcache warnings are out of date. 

https://github.com/FormidableLabs/urql-exchange-graphcache/blob/master/docs/help.md# is a 404, updates the pattern to https://github.com/FormidableLabs/urql/blob/master/docs/graphcache/help.md#

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
