### PR TITLE
Fix cache-only for the caches

### DIFF
--- a/.changeset/fluffy-guests-begin.md
+++ b/.changeset/fluffy-guests-begin.md
@@ -3,4 +3,4 @@
 '@urql/core': patch
 ---
 
-Prevents `cache-only` operations from getting forwarded outside of the cache when no result was found
+Fix `cache-only` operations being forwarded and triggering fetch requests

--- a/.changeset/fluffy-guests-begin.md
+++ b/.changeset/fluffy-guests-begin.md
@@ -1,0 +1,6 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/core': patch
+---
+
+Prevents `cache-only` operations from getting forwarded outside of the cache when no result was found

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -305,7 +305,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
     const cacheOps$ = pipe(
       cache$,
       filter(res => res.outcome === 'miss'),
-      map(res => addCacheOutcome(res.operation, res.outcome))
+      map(res => addCacheOutcome(res.operation, res.outcome)),
     );
 
     // Resolve OperationResults that the cache was able to assemble completely and trigger
@@ -342,15 +342,15 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
     // Forward operations that aren't cacheable and rebound operations
     // Also update the cache with any network results
     const result$ = pipe(
-      forward(
-        merge([
-          pipe(
-            inputOps$,
-            filter(op => !isCacheableQuery(op))
-          ),
-          cacheOps$,
-        ])
-      ),
+      merge([
+        pipe(
+          inputOps$,
+          filter(op => !isCacheableQuery(op))
+        ),
+        cacheOps$,
+      ]),
+      filter(op => !(op.operationName === 'query' && op.context.requestPolicy === 'cache-only')),
+      forward,
       map(updateCacheWithResult)
     );
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -349,7 +349,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
         ),
         cacheOps$,
       ]),
-      filter(op => !(op.operationName === 'query' && op.context.requestPolicy === 'cache-only')),
+      filter(op => op.context.requestPolicy !== 'cache-only'),
       forward,
       map(updateCacheWithResult)
     );

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -76,7 +76,7 @@ describe('promisified methods', () => {
           }
         `,
         { example: 1234 },
-        {}
+        { requestPolicy: 'cache-only' }
       )
       .toPromise();
 
@@ -87,7 +87,7 @@ describe('promisified methods', () => {
     expect(received.operationName).toEqual('query');
     expect(received.context).toEqual({
       url: 'https://hostname.com',
-      requestPolicy: 'cache-and-network',
+      requestPolicy: 'cache-only',
       fetchOptions: undefined,
       fetch: undefined,
       suspense: false,

--- a/packages/core/src/exchanges/cache.test.ts
+++ b/packages/core/src/exchanges/cache.test.ts
@@ -104,6 +104,23 @@ describe('on query', () => {
     });
   });
 
+  it('respects cache-only', () => {
+    const { source: ops$, next, complete } = input;
+    const exchange = cacheExchange(exchangeArgs)(ops$);
+
+    publish(exchange);
+    next({
+      ...queryOperation,
+      context: {
+        ...queryOperation.context,
+        requestPolicy: 'cache-only',
+      },
+    });
+    complete();
+    expect(forwardedOperations.length).toBe(0);
+    expect(reexecuteOperation).not.toBeCalled();
+  });
+
   describe('cache hit', () => {
     it('is miss when operation is forwarded', () => {
       const { source: ops$, next, complete } = input;

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -86,7 +86,7 @@ export const cacheExchange: Exchange = ({ forward, client }) => {
         ),
       ]),
       map(op => addMetadata(op, { cacheOutcome: 'miss' })),
-      filter(op => !(op.operationName === 'query' && op.context.requestPolicy === 'cache-only')),
+      filter(op => op.operationName !== 'query' || op.context.requestPolicy !== 'cache-only'),
       forward,
       tap(response => {
         if (

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -86,6 +86,7 @@ export const cacheExchange: Exchange = ({ forward, client }) => {
         ),
       ]),
       map(op => addMetadata(op, { cacheOutcome: 'miss' })),
+      filter(op => !(op.operationName === 'query' && op.context.requestPolicy === 'cache-only')),
       forward,
       tap(response => {
         if (


### PR DESCRIPTION
## Summary

`cache-only` currently dispatches a network-call when the result isn't in cache.

## Set of changes

- Add a `cache-only` filter so the operation does not get forwarded in doc-cache.
- Moves the `graphcache` operations outside of `forward` so we can add the same filter as introduced in doc-cache

Issue: https://github.com/FormidableLabs/next-urql/issues/39#issuecomment-588901815