### PR TITLE
Update Docs View for Mobile/Tablet 

### DIFF
--- a/packages/site/src/components/navigation.js
+++ b/packages/site/src/components/navigation.js
@@ -18,9 +18,11 @@ export const Navigation = styled.div`
 `;
 
 export const SidebarContainer = styled.div`
-  display: none;
+  display: ${p => (p.hidden ? 'none' : 'block')};
+  position: absolute;
   @media ${({ theme }) => theme.media.sm} {
     display: block;
+    position: static;
     width: ${p => p.theme.layout.sidebar};
   }
 `;
@@ -40,16 +42,17 @@ export const SidebarWrapper = styled.aside`
   display: flex;
   flex-direction: column;
   z-index: 1;
-
   overflow-y: scroll;
   min-height: 100%;
-  width: ${p => p.theme.layout.sidebar};
-
+  width: 100%;
   padding: ${p => p.theme.spacing.md};
   padding-right: ${p => p.theme.spacing.sm};
   background: ${p => p.theme.colors.bg};
   line-height: ${p => p.theme.lineHeights.body};
   font-size: ${p => p.theme.fontSizes.small};
+  @media ${({ theme }) => theme.media.sm} {
+    width: ${p => p.theme.layout.sidebar};
+  }
 `;
 
 export const SidebarNavItem = styled(Link)`

--- a/packages/site/src/components/navigation.js
+++ b/packages/site/src/components/navigation.js
@@ -1,22 +1,6 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
-export const Navigation = styled.div`
-  align-items: center;
-  background: #8196ff;
-  display: flex;
-  flex-direction: row;
-  height: 6rem;
-  width: 100%;
-
-  & img {
-    margin-left: auto;
-    @media (min-width: 768px) {
-      margin-left: 0;
-    }
-  }
-`;
-
 export const SidebarContainer = styled.div`
   display: ${p => (p.hidden ? 'none' : 'block')};
   position: absolute;

--- a/packages/site/src/components/navigation.js
+++ b/packages/site/src/components/navigation.js
@@ -18,7 +18,11 @@ export const Navigation = styled.div`
 `;
 
 export const SidebarContainer = styled.div`
-  width: ${p => p.theme.layout.sidebar};
+  display: none;
+  @media ${({ theme }) => theme.media.sm} {
+    display: block;
+    width: ${p => p.theme.layout.sidebar};
+  }
 `;
 
 export const SideBarStripes = styled.div`

--- a/packages/site/src/components/sidebar.js
+++ b/packages/site/src/components/sidebar.js
@@ -17,8 +17,6 @@ import {
 
 import { mediaSizes } from '../styles/theme';
 
-import closeButton from '../assets/close.svg';
-import burger from '../assets/burger.svg';
 import logoSidebar from '../assets/sidebar-badge.svg';
 
 const HeroLogo = styled.img.attrs(() => ({
@@ -40,41 +38,15 @@ const ContentWrapper = styled.div`
   padding: ${p => p.theme.spacing.xs} 0;
 `;
 
-const OpenCloseButton = css`
-  cursor: pointer;
-  display: ${p => (p.hidden ? 'none' : 'block')};
-  margin: ${p => p.theme.spacing.sm} ${p => p.theme.spacing.md};
-  position: absolute;
-  right: 0;
-  top: 0;
-  z-index: 1;
-  @media ${p => p.theme.media.sm} {
-    display: none;
-  }
-`;
-
-const OpenButton = styled.img.attrs(() => ({
-  src: burger,
-}))`
-  ${OpenCloseButton}
-`;
-
-const CloseButton = styled.img.attrs(() => ({
-  src: closeButton
-}))`
-  ${OpenCloseButton}
-`;
-
 const relative = (from, to) => {
   if (!from || !to) return null;
   const pathname = path.relative(path.dirname(from), to);
   return { pathname };
 };
 
-const Sidebar = () => {
+const Sidebar = ({ sidebarOpen }) => {
   const currentPage = useMarkdownPage();
   const tree = useMarkdownTree();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const sidebarItems = useMemo(() => {
     if (!currentPage || !tree || !tree.children) {
@@ -106,20 +78,13 @@ const Sidebar = () => {
   }, [tree, currentPage]);
 
   return (
-    <>
-      <OpenButton hidden={sidebarOpen} onClick={() => setSidebarOpen(true)} />
-      <CloseButton
-        hidden={!sidebarOpen}
-        onClick={() => setSidebarOpen(false)}
-      />
-      <SidebarContainer hidden={!sidebarOpen}>
-        <SideBarStripes />
-        <SidebarWrapper>
-          <HeroLogo />
-          <ContentWrapper>{sidebarItems}</ContentWrapper>
-        </SidebarWrapper>
-      </SidebarContainer>
-    </>
+    <SidebarContainer hidden={!sidebarOpen}>
+      <SideBarStripes />
+      <SidebarWrapper>
+        <HeroLogo />
+        <ContentWrapper>{sidebarItems}</ContentWrapper>
+      </SidebarWrapper>
+    </SidebarContainer>
   );
 };
 

--- a/packages/site/src/components/sidebar.js
+++ b/packages/site/src/components/sidebar.js
@@ -1,6 +1,7 @@
-import React, { Fragment, useMemo } from 'react';
+import React, { Fragment, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
+import styled, { css } from 'styled-components';
 import * as path from 'path';
 
 import { useMarkdownTree, useMarkdownPage } from 'react-static-plugin-md-pages';
@@ -14,16 +15,23 @@ import {
   SideBarStripes,
 } from './navigation';
 
+import { mediaSizes } from '../styles/theme';
+
 import closeButton from '../assets/close.svg';
+import burger from '../assets/burger.svg';
 import logoSidebar from '../assets/sidebar-badge.svg';
 
 const HeroLogo = styled.img.attrs(() => ({
   src: logoSidebar,
   alt: 'urql',
 }))`
+  display: none;
   width: ${p => p.theme.layout.logo};
   margin-bottom: ${p => p.theme.spacing.sm};
   align-self: center;
+  @media ${p => p.theme.media.sm} {
+    display: block;
+  }
 `;
 
 const ContentWrapper = styled.div`
@@ -32,14 +40,29 @@ const ContentWrapper = styled.div`
   padding: ${p => p.theme.spacing.xs} 0;
 `;
 
+const OpenCloseButton = css`
+  cursor: pointer;
+  display: ${p => (p.hidden ? 'none' : 'block')};
+  margin: ${p => p.theme.spacing.sm} ${p => p.theme.spacing.md};
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1;
+  @media ${p => p.theme.media.sm} {
+    display: none;
+  }
+`;
+
+const OpenButton = styled.img.attrs(() => ({
+  src: burger,
+}))`
+  ${OpenCloseButton}
+`;
+
 const CloseButton = styled.img.attrs(() => ({
   src: closeButton
 }))`
-  cursor: pointer;
-  top: 1rem;
-  right: 7rem;
-  position: absolute;
-  display: none;
+  ${OpenCloseButton}
 `;
 
 const relative = (from, to) => {
@@ -51,6 +74,7 @@ const relative = (from, to) => {
 const Sidebar = () => {
   const currentPage = useMarkdownPage();
   const tree = useMarkdownTree();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const sidebarItems = useMemo(() => {
     if (!currentPage || !tree || !tree.children) {
@@ -82,16 +106,20 @@ const Sidebar = () => {
   }, [tree, currentPage]);
 
   return (
-    <SidebarContainer>
-      <SideBarStripes />
-      <SidebarWrapper>
-        <CloseButton />
-        <HeroLogo />
-        <ContentWrapper>
-          {sidebarItems}
-        </ContentWrapper>
-      </SidebarWrapper>
-    </SidebarContainer>
+    <>
+      <OpenButton hidden={sidebarOpen} onClick={() => setSidebarOpen(true)} />
+      <CloseButton
+        hidden={!sidebarOpen}
+        onClick={() => setSidebarOpen(false)}
+      />
+      <SidebarContainer hidden={!sidebarOpen}>
+        <SideBarStripes />
+        <SidebarWrapper>
+          <HeroLogo />
+          <ContentWrapper>{sidebarItems}</ContentWrapper>
+        </SidebarWrapper>
+      </SidebarContainer>
+    </>
   );
 };
 

--- a/packages/site/src/html.js
+++ b/packages/site/src/html.js
@@ -5,12 +5,13 @@ const Document = ({ Html, Head, Body, children }) => (
     <Head>
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <link href="https://fonts.googleapis.com/css?family=Space+Mono&display=swap" rel="stylesheet" />
+      <link
+        href="https://fonts.googleapis.com/css?family=Space+Mono&display=swap"
+        rel="stylesheet"
+      />
       <title>urql Documentation</title>
     </Head>
-    <Body>
-      {children}
-    </Body>
+    <Body>{children}</Body>
   </Html>
 );
 

--- a/packages/site/src/screens/docs/article.js
+++ b/packages/site/src/screens/docs/article.js
@@ -11,7 +11,7 @@ const Container = styled.main.attrs(() => ({
   width: 100%;
   position: sticky;
 
-  display: flex;
+  display: ${p => (p.sidebarOpen ? 'none' : 'flex')};
   flex-direction: row-reverse;
 `;
 
@@ -80,8 +80,8 @@ const SectionList = () => {
   );
 };
 
-const Article = ({ children }) => (
-  <Container>
+const Article = ({ children, sidebarOpen }) => (
+  <Container sidebarOpen={sidebarOpen}>
     <Legend>
       <SectionList />
     </Legend>

--- a/packages/site/src/screens/docs/article.js
+++ b/packages/site/src/screens/docs/article.js
@@ -25,12 +25,18 @@ const Content = styled.article.attrs(() => ({
 `;
 
 const Legend = styled.aside`
-  position: sticky;
-  top: ${p => p.theme.layout.header};
-  max-height: 100vh;
-  width: ${p => p.theme.layout.legend};
-  margin: ${p => p.theme.spacing.sm} ${p => p.theme.spacing.md};
-  padding: ${p => p.theme.spacing.md} 0;
+  display: none;
+
+  @media ${({ theme }) => theme.media.lg} {
+    display: block;
+    position: sticky;
+    top: ${p => p.theme.layout.header};
+    max-height: 100vh;
+    width: ${p => p.theme.layout.legend};
+    max-width: ${p => p.theme.layout.legendMaxWidth};
+    padding: ${p => p.theme.spacing.md} 0;
+    margin: ${p => p.theme.spacing.sm} ${p => p.theme.spacing.md};
+  }
 `;
 
 const LegendTitle = styled.h3`
@@ -62,15 +68,11 @@ const SectionList = () => {
 
   return (
     <>
-      <LegendTitle>
-        In this section
-      </LegendTitle>
+      <LegendTitle>In this section</LegendTitle>
       <HeadingList>
         {headings.map(heading => (
           <li key={heading.slug}>
-            <HeadingItem href={`#${heading.slug}`}>
-              {heading.value}
-            </HeadingItem>
+            <HeadingItem href={`#${heading.slug}`}>{heading.value}</HeadingItem>
           </li>
         ))}
       </HeadingList>
@@ -84,9 +86,7 @@ const Article = ({ children }) => (
       <SectionList />
     </Legend>
     <Content>
-      <MDXComponents>
-        {children}
-      </MDXComponents>
+      <MDXComponents>{children}</MDXComponents>
     </Content>
   </Container>
 );

--- a/packages/site/src/screens/docs/header.js
+++ b/packages/site/src/screens/docs/header.js
@@ -48,7 +48,7 @@ const ProjectWording = styled(Link)`
 `;
 
 const FormidableLogo = styled.img.attrs(() => ({
-  src: formidableLogo
+  src: formidableLogo,
 }))`
   height: 2.8rem;
   position: relative;
@@ -62,9 +62,7 @@ const Header = () => {
         <BlockLink href="https://formidable.com/">
           <FormidableLogo />
         </BlockLink>
-        <ProjectWording to="/">
-          urql
-        </ProjectWording>
+        <ProjectWording to="/">urql</ProjectWording>
       </Wrapper>
     </Fixed>
   );

--- a/packages/site/src/screens/docs/index.js
+++ b/packages/site/src/screens/docs/index.js
@@ -9,6 +9,7 @@ import Header from './header';
 import Sidebar from '../../components/sidebar';
 
 import burger from '../../assets/burger.svg';
+import closeButton from '../../assets/close.svg';
 import logoFormidableDark from '../../assets/logo_formidable_dark.svg';
 
 const Container = styled.div`
@@ -26,15 +27,34 @@ const Container = styled.div`
   margin-top: ${p => p.theme.layout.header};
 `;
 
+const OpenCloseSidebar = styled.img.attrs(props => ({
+  src: props.sidebarOpen ? closeButton : burger,
+}))`
+  cursor: pointer;
+  display: block;
+  margin: ${p => p.theme.spacing.sm} ${p => p.theme.spacing.md};
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1;
+  @media ${p => p.theme.media.sm} {
+    display: none;
+  }
+`;
+
 const Docs = props => {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   return (
     <>
       <Header />
       <Container>
-        <Sidebar />
-        <Article>
-          {props.children}
-        </Article>
+        <OpenCloseSidebar
+          sidebarOpen={sidebarOpen}
+          onClick={() => setSidebarOpen(prev => !prev)}
+        />
+        <Sidebar sidebarOpen={sidebarOpen} />
+        <Article sidebarOpen={sidebarOpen}>{props.children}</Article>
       </Container>
     </>
   );

--- a/packages/site/src/styles/global.js
+++ b/packages/site/src/styles/global.js
@@ -18,6 +18,7 @@ const systemFonts = [
 export const GlobalStyle = createGlobalStyle`
   * {
     box-sizing: inherit;
+    min-width: 0;
   }
 
   html {

--- a/packages/site/src/styles/theme.js
+++ b/packages/site/src/styles/theme.js
@@ -30,7 +30,8 @@ export const layout = {
   header: '4.8rem',
   stripes: '0.9rem',
   sidebar: '28rem',
-  legend: '24rem',
+  legend: '100%',
+  legendMaxWidth: '25rem',
   logo: '12rem',
 };
 
@@ -66,7 +67,7 @@ export const shadows = {
 };
 
 export const media = {
-  sm: '(min-width: 650px)',
+  sm: '(min-width: 700px)',
   md: '(min-width: 960px)',
   lg: '(min-width: 1200px)',
 };

--- a/packages/site/src/styles/theme.js
+++ b/packages/site/src/styles/theme.js
@@ -66,10 +66,16 @@ export const shadows = {
   input: 'rgba(0, 0, 0, 0.09) 0px 2px 10px -3px',
 };
 
+export const mediaSizes = {
+  sm: 700,
+  md: 960,
+  lg: 1200,
+};
+
 export const media = {
-  sm: '(min-width: 700px)',
-  md: '(min-width: 960px)',
-  lg: '(min-width: 1200px)',
+  sm: `(min-width: ${mediaSizes.sm}px)`,
+  md: `(min-width: ${mediaSizes.md}px)`,
+  lg: `(min-width: ${mediaSizes.lg}px)`,
 };
 
 export const spacing = {


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Add new styling to improve the docs look and feel on mobile/tablet viewports.

## Set of changes

- Legend is now hidden on below `lg` width
- On mobile width the `urql` icon is now hidden
- There is an open/close sidebar button top right on small widths
- On small widths the sidebar is now `100%` width
- Pull the open/close logic into the `Docs` component so that it was available to stop scrolling in `Article`

## Screens
![screens](https://media.giphy.com/media/fvkhrMG2BFe2lVpBKB/giphy.gif)
