### PR TITLE
Commutative updates

### DIFF
--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -126,8 +126,7 @@ const readRoot = (
     const fieldAlias = getFieldAlias(node);
     const fieldValue = originalData[fieldAlias];
     if (node.selectionSet !== undefined && fieldValue !== null) {
-      const fieldData = ensureData(fieldValue);
-      data[fieldAlias] = readRootField(ctx, getSelectionSet(node), fieldData);
+      data[fieldAlias] = readRootField(ctx, getSelectionSet(node), ensureData(fieldValue));
     } else {
       data[fieldAlias] = fieldValue;
     }
@@ -188,7 +187,7 @@ export const readFragment = (
 
   const entityKey =
     typeof entity !== 'string'
-      ? store.keyOfEntity({ __typename: typename, ...entity } as Data)
+      ? store.keyOfEntity(entity)
       : entity;
 
   if (!entityKey) {
@@ -236,6 +235,7 @@ const readSelection = (
   const typename = !isQuery
     ? InMemoryData.readRecord(entityKey, '__typename')
     : entityKey;
+
   if (typeof typename !== 'string') {
     return undefined;
   }

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -55,9 +55,10 @@ interface Context {
 export const write = (
   store: Store,
   request: OperationRequest,
-  data: Data
+  data: Data,
+  key?: number
 ): WriteResult => {
-  initDataState(store.data, 0);
+  initDataState(store.data, key || 0);
   const result = startWrite(store, request, data);
   clearDataState();
   return result;

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -52,6 +52,7 @@ export const initDataState = (
   currentData = data;
   currentDependencies = new Set();
   currentOptimisticKey = optimisticKey;
+
   if (process.env.NODE_ENV !== 'production') {
     currentDebugStack.length = 0;
   }
@@ -170,6 +171,17 @@ const getNode = <T>(
   const node = map.base.get(entityKey);
   return node !== undefined ? node[fieldKey] : undefined;
 };
+
+export const hasOptimisticKey = (map: NodeMap<any>, optimisticKey: number): boolean =>
+  map.keys.indexOf(optimisticKey) !== -1;
+
+export const mergeAndDeleteOptimisticLayer = (map: NodeMap<any>, optimisticKey: number) => {
+  const index = map.keys.indexOf(optimisticKey);
+  const optimisticData = map.optimistic[optimisticKey];
+  // TODO: MERGE
+  delete map.optimistic[optimisticKey];
+  map.keys.splice(index, 1);
+}
 
 /** Clears an optimistic layers from a NodeMap */
 const clearOptimisticNodes = <T>(map: NodeMap<T>, optimisticKey: number) => {

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -172,15 +172,24 @@ const getNode = <T>(
   return node !== undefined ? node[fieldKey] : undefined;
 };
 
-export const hasOptimisticKey = (map: NodeMap<any>, optimisticKey: number): boolean =>
-  map.keys.indexOf(optimisticKey) !== -1;
+export const hasOptimisticKey = (map: NodeMap<any>, optimisticKey: number): boolean => map.keys.indexOf(optimisticKey) !== -1;
 
-export const mergeAndDeleteOptimisticLayer = (map: NodeMap<any>, optimisticKey: number) => {
-  const index = map.keys.indexOf(optimisticKey);
-  const optimisticData = map.optimistic[optimisticKey];
-  // TODO: MERGE
-  delete map.optimistic[optimisticKey];
-  map.keys.splice(index, 1);
+export const mergeAndDeleteOptimisticLayer = (data: InMemoryData, optimisticKey: number) => {
+  initDataState(data, 0);
+
+  data.records.optimistic[optimisticKey].forEach((recordMap, entityKey) => {
+    Object.entries(recordMap).forEach(([fieldKey, value]) => {
+      writeRecord(entityKey, fieldKey, value);
+    });
+  });
+
+  data.links.optimistic[optimisticKey].forEach((linkMap, entityKey) => {
+    Object.entries(linkMap).forEach(([fieldKey, value]) => {
+      writeLink(entityKey, fieldKey, value);
+    });
+  });
+
+  clearDataState();
 }
 
 /** Clears an optimistic layers from a NodeMap */

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -96,7 +96,7 @@ export const getCurrentDependencies = (): Set<string> => {
     2
   );
 
-  return currentDependencies;
+  return currentDependencies as Set<string>;
 };
 
 export const make = (queryRootKey: string): InMemoryData => ({
@@ -172,20 +172,20 @@ const getNode = <T>(
   return node !== undefined ? node[fieldKey] : undefined;
 };
 
-export const hasOptimisticKey = (map: NodeMap<any>, optimisticKey: number): boolean => map.keys.indexOf(optimisticKey) !== -1;
+export const hasOptimisticKey = (map: InMemoryData, optimisticKey: number): boolean => map.records.keys.indexOf(optimisticKey) !== -1 || map.links.keys.indexOf(optimisticKey) !== -1;
 
-export const mergeAndDeleteOptimisticLayer = (data: InMemoryData, optimisticKey: number) => {
+export const mergeOptimisticLayerToData = (data: InMemoryData, optimisticKey: number) => {
   initDataState(data, 0);
 
   data.records.optimistic[optimisticKey].forEach((recordMap, entityKey) => {
-    Object.entries(recordMap).forEach(([fieldKey, value]) => {
-      writeRecord(entityKey, fieldKey, value);
+    Object.entries(recordMap).forEach(record => {
+      writeRecord(entityKey, record[0], record[1]);
     });
   });
 
   data.links.optimistic[optimisticKey].forEach((linkMap, entityKey) => {
-    Object.entries(linkMap).forEach(([fieldKey, value]) => {
-      writeLink(entityKey, fieldKey, value);
+    Object.entries(linkMap).forEach(link => {
+      writeLink(entityKey, link[0], link[1]);
     });
   });
 


### PR DESCRIPTION
## Summary

This PR aims at making applying updates predictable, let's explain this with a scenario rather than abstract terms.

Imagine we are 3 queries that are related, 1 - 2 - 3 in that order. These can be list, details, ... If these arrive as a server response in the same order 1 - 2 - 3 this will be the outcome we desire but what happens if this happens out-of-sync? We could start overriding properties/methods we don't want.

In this PR we'll apply responses that have queries queued up before them as optimistic responses. This way we can when all preceding queries come in merge them in order.

## Set of changes

- queries are applied in order
- when an out of order query returns it's written as an optimistic layer
