### PR TITLE
(graphcache) - Invalidating entities

### DIFF
--- a/.changeset/stupid-lizards-return.md
+++ b/.changeset/stupid-lizards-return.md
@@ -2,4 +2,4 @@
 '@urql/exchange-graphcache': minor
 ---
 
-Add the possibility of invalidating an entity through the cache instance, this allows you to remove entities from the cache. For example `cache.invalidateEntity({ __typename: 'Todo', id: 1 })`, next time we query the todos we know it will need refetching unless your schema dictates this as an optional listItem
+Add the possibility of invalidating an entity through the cache instance, this allows you to remove entities from the cache. For example `cache.invalite({ __typename: 'Todo', id: 1 })`, next time we query the todos we know it will need refetching unless your schema dictates this as an optional listItem

--- a/.changeset/stupid-lizards-return.md
+++ b/.changeset/stupid-lizards-return.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Add the possibility of invalidating an entity through the cache instance, this allows you to remove entities from the cache. For example `cache.invalidateEntity({ __typename: 'Todo', id: 1 })`, next time we query the todos we know it will need refetching unless your schema dictates this as an optional listItem

--- a/docs/graphcache/help.md
+++ b/docs/graphcache/help.md
@@ -268,12 +268,12 @@ field somewhere, maybe due to a typo.
 Please open an issue if it happens on a query that you expect to be supported
 by the `populateExchange`.
 
-## (19) Can't generate a key for invalidateEntity(...)
+## (19) Can't generate a key for invalidate(...)
 
-> Can't generate a key for invalidateEntity(...).
+> Can't generate a key for invalidate(...).
 > You need to pass in a valid key (__typename:id) or an object with the "__typename" property and an "id" or "_id" property.
 
-You probably have called `cache.invalidateEntity` with data that the cache can't generate a key for.
+You probably have called `cache.invalidate` with data that the cache can't generate a key for.
 
 This may either happen because you're missing the `__typename` and `id` or `_id` field or if the last two
 aren't applicable to this entity a custom `keys` entry.

--- a/docs/graphcache/help.md
+++ b/docs/graphcache/help.md
@@ -267,3 +267,13 @@ field somewhere, maybe due to a typo.
 
 Please open an issue if it happens on a query that you expect to be supported
 by the `populateExchange`.
+
+## (19) Can't generate a key for invalidateEntity(...)
+
+> Can't generate a key for invalidateEntity(...).
+> You need to pass in a valid key (__typename:id) or an object with the "__typename" property and an "id" or "_id" property.
+
+You probably have called `cache.invalidateEntity` with data that the cache can't generate a key for.
+
+This may either happen because you're missing the `__typename` and `id` or `_id` field or if the last two
+aren't applicable to this entity a custom `keys` entry.

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -406,6 +406,14 @@ describe('Store with OptimisticMutationConfig', () => {
       todos: todosData.todos,
     });
   });
+
+  describe('Invalidating an entity', () => {
+    it('removes an entity from a list.', () => {
+      store.invalidateEntity(todosData.todos[1]);
+      const { data } = query(store, { query: Todos });
+      expect(data).toBe(null);
+    });
+  });
 });
 
 describe('Store with storage', () => {

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -409,7 +409,7 @@ describe('Store with OptimisticMutationConfig', () => {
 
   describe('Invalidating an entity', () => {
     it('removes an entity from a list.', () => {
-      store.invalidateEntity(todosData.todos[1]);
+      store.invalidate(todosData.todos[1]);
       const { data } = query(store, { query: Todos });
       expect(data).toBe(null);
     });

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -156,14 +156,15 @@ export class Store implements Cache {
   }
 
   invalidateEntity(entity: Data | string) {
-    const entityKey = typeof entity === 'string' ? entity : this.keyOfEntity(entity);
+    const entityKey =
+      typeof entity === 'string' ? entity : this.keyOfEntity(entity);
 
     if (!entityKey) {
       invariant(
         entityKey,
         `Can't generate a key for invalidateEntity(${entity}),
         You need to pass in a valid key (__typename:id) or an object with the "__typename" property and an "id" or "_id" property.`,
-        19,
+        19
       );
     }
 
@@ -172,7 +173,11 @@ export class Store implements Cache {
       if (InMemoryData.readLink(entityKey as string, field.fieldKey)) {
         InMemoryData.writeLink(entityKey as string, field.fieldKey, undefined);
       } else {
-        InMemoryData.writeRecord(entityKey as string, field.fieldKey, undefined);
+        InMemoryData.writeRecord(
+          entityKey as string,
+          field.fieldKey,
+          undefined
+        );
       }
     }
   }

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -161,11 +161,13 @@ export class Store implements Cache {
 
     invariant(
       entityKey,
-        "Can't generate a key for invalidate(...).\n" +
-        "You have to pass an id or _id field or create a custom `keys` field for `" +
-        typeof entity === 'object' ? (entity as Data).__typename : entity +
-        "`.",
-      19,
+      "Can't generate a key for invalidate(...).\n" +
+        'You have to pass an id or _id field or create a custom `keys` field for `' +
+        typeof entity ===
+        'object'
+        ? (entity as Data).__typename
+        : entity + '`.',
+      19
     );
 
     const fields = this.inspectFields(entityKey);

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -163,7 +163,7 @@ export class Store implements Cache {
       entityKey,
         "Can't generate a key for invalidate(...).\n" +
         "You have to pass an id or _id field or create a custom `keys` field for `" +
-        (entity as Data).__typename +
+        typeof entity === 'object' ? (entity as Data).__typename : entity +
         "`.",
       19,
     );

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -159,7 +159,12 @@ export class Store implements Cache {
     const entityKey = typeof entity === 'string' ? entity : this.keyOfEntity(entity);
 
     if (!entityKey) {
-      invariant(entityKey, `Invalidate entity passed to "invalidateEntity", expected an entityKey (__typename:id) or an entity with the "__typename" and "id" or "_id" properties. Received ${entity}`, 19);
+      invariant(
+        entityKey,
+        `Can't generate a key for invalidateEntity(${entity}),
+        You need to pass in a valid key (__typename:id) or an object with the "__typename" property and an "id" or "_id" property.`,
+        19,
+      );
     }
 
     const fields = this.inspectFields(entityKey);

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -155,18 +155,18 @@ export class Store implements Cache {
     invalidate(this, createRequest(query, variables));
   }
 
-  invalidateEntity(entity: Data | string) {
+  invalidate(entity: Data | string) {
     const entityKey =
       typeof entity === 'string' ? entity : this.keyOfEntity(entity);
 
-    if (!entityKey) {
-      invariant(
-        entityKey,
-        `Can't generate a key for invalidateEntity(${entity}),
-        You need to pass in a valid key (__typename:id) or an object with the "__typename" property and an "id" or "_id" property.`,
-        19
-      );
-    }
+    invariant(
+      entityKey,
+        "Can't generate a key for invalidate(...).\n" +
+        "You have to pass an id or _id field or create a custom `keys` field for `" +
+        (entity as Data).__typename +
+        "`.",
+      19,
+    );
 
     const fields = this.inspectFields(entityKey);
     for (const field of fields) {

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -200,4 +200,5 @@ export type ErrorCode =
   | 15
   | 16
   | 17
-  | 18;
+  | 18
+  | 19;


### PR DESCRIPTION
## Summary

For use cases described in [this issue](https://github.com/FormidableLabs/urql/issues/559) an `invalidate` method seemed very suitable. Now we can remove an entity (with its properties) from the cache.

This has an added benefit that it removes links, if the links has no more ties with other entities it will get garbage collected.

> Note that schema awareness can cause a `null` in your data if this is marked as optional (partial result)

## Set of changes

- Adds `cache.invalidate`
