### PR TITLE
(graphcache) - fix cache type

### DIFF
--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -102,6 +102,9 @@ export interface Cache {
   /** invalidateQuery() invalidates all data of a given query */
   invalidateQuery(query: DocumentNode, variables?: Variables): void;
 
+  /** invalidate invalidates an entity */
+  invalidate(entity: Data | string): void;
+
   /** updateQuery() can be used to update the data of a given query using an updater function */
   updateQuery(
     input: QueryInput,

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -102,7 +102,7 @@ export interface Cache {
   /** invalidateQuery() invalidates all data of a given query */
   invalidateQuery(query: DocumentNode, variables?: Variables): void;
 
-  /** invalidate invalidates an entity */
+  /** invalidate() invalidates an entity */
   invalidate(entity: Data | string): void;
 
   /** updateQuery() can be used to update the data of a given query using an updater function */


### PR DESCRIPTION
This fixes the `cache` typings to include the newly added `invalidate` function.