### PR TITLE
Use preact for the docs-site to lower bundle size

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -34,6 +34,7 @@
     "formidable-oss-badges": "0.2.1",
     "history": "^4.7.2",
     "path": "^0.12.7",
+    "preact": "^10.3.3",
     "prism-react-renderer": "^1.0.2",
     "prop-types": "^15.6.2",
     "react": "^16.9.0",

--- a/packages/site/plugins/preact/node.api.js
+++ b/packages/site/plugins/preact/node.api.js
@@ -1,0 +1,11 @@
+export default () => ({
+  webpack: (config, { stage }) => {
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      react: 'preact/compat',
+      'react-dom': 'preact/compat',
+    };
+
+    return config;
+  },
+});

--- a/packages/site/static.config.js
+++ b/packages/site/static.config.js
@@ -9,7 +9,7 @@ const basePath = 'open-source/urql';
 export default {
   plugins: [
     resolve(__dirname, 'plugins/monorepo-fix/'),
-
+    resolve(__dirname, 'plugins/preact'),
     [
       'react-static-plugin-md-pages',
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10020,6 +10020,11 @@ preact@^10.3.1:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.3.1.tgz#70a2cc5484ca727c992216dfc528907d240e0a05"
 
+preact@^10.3.3:
+  version "10.3.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.3.3.tgz#31a949cdc89dd1cf72bc2b94f80ad55d1ac8c7e6"
+  integrity sha512-8EWUuHuLhX48uK0acnnXwBL/ZyrgeadnyhxG6hFI85BhwmquyGwWzfj2SylCNdEyltkdgbY3FZzQOM2mG1leAg==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
## Summary

Static websites don't need much special things, let's use Preact to make it faster, smaller and Preact-y

## Set of changes

- docs site uses Preact
