### PR TITLE
Prevent active teardown for queries on subscriptionExchange

### DIFF
--- a/.changeset/sharp-students-flash.md
+++ b/.changeset/sharp-students-flash.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Prevent active teardowns for queries on subscriptionExchange

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -85,10 +85,12 @@ export const subscriptionExchange = ({
           complete: () => {
             if (!isComplete) {
               isComplete = true;
-              client.reexecuteOperation({
-                ...operation,
-                operationName: 'teardown',
-              });
+              if (operation.operationName === 'subscription') {
+                client.reexecuteOperation({
+                  ...operation,
+                  operationName: 'teardown',
+                });
+              }
 
               complete();
             }


### PR DESCRIPTION
Fix #576

The `subscriptionExchange` now supports queries and mutations using the `enableAllOperations?: boolean` flag. However, it actively tears down, i.e. closes, active queries since for subscriptions the server may tell the client that subscriptions have ended.

For queries and mutations this doesn't apply though as we want to keep them active indefinitely.
