### PR TITLE
shorten help urls

### DIFF
--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -27,8 +27,7 @@ export type ErrorCode =
 
 type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
 
-const helpUrl =
-  '\nhttps://github.com/FormidableLabs/urql/tree/master/exchanges/graphcache/help.md#';
+const helpUrl = '\nhttps://bit.ly/38yWDau#';
 const cache = new Set<string>();
 
 export const currentDebugStack: string[] = [];

--- a/exchanges/populate/src/helpers/help.ts
+++ b/exchanges/populate/src/helpers/help.ts
@@ -22,8 +22,7 @@ export type ErrorCode =
   | 18
   | 19;
 
-const helpUrl =
-  '\nhttps://github.com/FormidableLabs/urql/tree/master/exchanges/graphcache/help.md#';
+const helpUrl = '\nhttps://bit.ly/38yWDau#';
 const cache = new Set<string>();
 
 export function invariant(


### PR DESCRIPTION
## Summary

Shorten url's for the help files, this reduces bundle size
