### PR TITLE
Add multipartFetchExchange package

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -5,7 +5,8 @@
     "packages/preact-urql",
     "packages/svelte-urql",
     "exchanges/graphcache",
-    "exchanges/suspense"
+    "exchanges/suspense",
+    "exchanges/multipart-fetch"
   ],
   "sandboxes": ["urql-issue-template-client-iui0o"],
   "buildCommand": "build",

--- a/exchanges/multipart-fetch/CHANGELOG.md
+++ b/exchanges/multipart-fetch/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @urql/exchange-populate
+
+## 0.1.0
+
+### Initial release
+
+- Release the `multipartFetchExchange`

--- a/exchanges/multipart-fetch/CHANGELOG.md
+++ b/exchanges/multipart-fetch/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @urql/exchange-populate
+# @urql/exchange-multipart-fetch
 
 ## 0.1.0
 

--- a/exchanges/multipart-fetch/README.md
+++ b/exchanges/multipart-fetch/README.md
@@ -1,0 +1,32 @@
+# @urql/exchange-multipart-fetch
+
+The `multipartFetchExchange` is an exchange that builds on the regular `fetchExchange`
+but adds the multipart file upload capability.
+
+## Quick Start Guide
+
+First install `@urql/exchange-multipart-fetch` alongside `urql`:
+
+```sh
+yarn add @urql/exchange-multipart-fetch
+# or
+npm install --save @urql/exchange-multipart-fetch
+```
+
+You'll then need to add the `multipartFetchExchange`, that this package exposes.
+
+```js
+import { createClient, dedupExchange, cacheExchange } from 'urql';
+import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';
+
+const client = createClient({
+  url: 'http://localhost:1234/graphql',
+  exchanges: [
+    dedupExchange,
+    cacheExchange,
+    multipartFetchExchange,
+  ],
+});
+```
+
+now we can start uploading files to our server!

--- a/exchanges/multipart-fetch/README.md
+++ b/exchanges/multipart-fetch/README.md
@@ -13,7 +13,8 @@ yarn add @urql/exchange-multipart-fetch
 npm install --save @urql/exchange-multipart-fetch
 ```
 
-You'll then need to add the `multipartFetchExchange`, that this package exposes.
+You'll then need to add the `multipartFetchExchange` method, that this package exposes,
+to your `exchanges`.
 
 ```js
 import { createClient, dedupExchange, cacheExchange } from 'urql';
@@ -21,12 +22,8 @@ import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';
 
 const client = createClient({
   url: 'http://localhost:1234/graphql',
-  exchanges: [
-    dedupExchange,
-    cacheExchange,
-    multipartFetchExchange,
-  ],
+  exchanges: [dedupExchange, cacheExchange, multipartFetchExchange],
 });
 ```
 
-now we can start uploading files to our server!
+Now we can start uploading files to our server!

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@urql/exchange-multipart-fetch",
+  "version": "0.1.1",
+  "description": "An exchange that automaticcally populates the mutation selection body",
+  "sideEffects": false,
+  "homepage": "https://formidable.com/open-source/urql/docs/",
+  "bugs": "https://github.com/FormidableLabs/urql/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/urql.git",
+    "directory": "exchanges/populate"
+  },
+  "keywords": [
+    "urql",
+    "formidablelabs",
+    "exchanges"
+  ],
+  "main": "dist/urql-exchange-populate.cjs.js",
+  "module": "dist/urql-exchange-populate.esm.js",
+  "types": "dist/types/index.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "dist/urql-exchange-populate.esm.js",
+      "require": "dist/urql-exchange-populate.cjs.js",
+      "types": "dist/types/index.d.ts",
+      "source": "src/index.ts"
+    }
+  },
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "README.md",
+    "dist/",
+    "extras/"
+  ],
+  "scripts": {
+    "test": "jest",
+    "clean": "rimraf dist extras",
+    "check": "tsc --noEmit",
+    "lint": "eslint --ext=js,jsx,ts,tsx .",
+    "build": "rollup -c ../../scripts/rollup/config.js",
+    "prepare": "../../scripts/prepare/index.js",
+    "prepublishOnly": "run-s clean test build"
+  },
+  "jest": {
+    "preset": "../../scripts/jest/preset"
+  },
+  "dependencies": {
+    "@urql/core": ">=1.9.2",
+    "extract-files": "^7.0.0",
+    "wonka": "^3.2.1 || ^4.0.0"
+  },
+  "peerDependencies": {
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+  },
+  "devDependencies": {
+    "graphql": "^14.5.8",
+    "graphql-tag": "^2.10.1"
+  }
+}

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@urql/exchange-multipart-fetch",
   "version": "0.1.1",
-  "description": "An exchange that automaticcally populates the mutation selection body",
+  "description": "An exchange that allows regular fetch and will transition to multipart when files are included",
   "sideEffects": false,
   "homepage": "https://formidable.com/open-source/urql/docs/",
   "bugs": "https://github.com/FormidableLabs/urql/issues",
@@ -9,21 +9,21 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/FormidableLabs/urql.git",
-    "directory": "exchanges/populate"
+    "directory": "exchanges/multipart-fetch"
   },
   "keywords": [
     "urql",
     "formidablelabs",
     "exchanges"
   ],
-  "main": "dist/urql-exchange-populate.cjs.js",
-  "module": "dist/urql-exchange-populate.esm.js",
+  "main": "dist/urql-exchange-multipart-fetch.cjs.js",
+  "module": "dist/urql-exchange-multipart-fetch.esm.js",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "dist/urql-exchange-populate.esm.js",
-      "require": "dist/urql-exchange-populate.cjs.js",
+      "import": "dist/urql-exchange-multipart-fetch.esm.js",
+      "require": "dist/urql-exchange-multipart-fetch.cjs.js",
       "types": "dist/types/index.d.ts",
       "source": "src/index.ts"
     }

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urql/exchange-multipart-fetch",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "An exchange that allows regular fetch and will transition to multipart when files are included",
   "sideEffects": false,
   "homepage": "https://formidable.com/open-source/urql/docs/",

--- a/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
+++ b/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
@@ -1,0 +1,533 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`on error returns error data 1`] = `
+Object {
+  "data": undefined,
+  "error": [CombinedError: [Network] ],
+  "extensions": undefined,
+  "operation": Object {
+    "context": Object {
+      "fetchOptions": Object {
+        "method": "POST",
+      },
+      "requestPolicy": "cache-first",
+      "url": "http://localhost:3000/graphql",
+    },
+    "key": 2,
+    "operationName": "query",
+    "query": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "getUser",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "name",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "name",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "user",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "firstName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "lastName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "String",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "name",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 124,
+        "start": 0,
+      },
+    },
+    "variables": Object {
+      "name": "Clara",
+    },
+  },
+}
+`;
+
+exports[`on error returns error data with status 400 and manual redirect mode 1`] = `
+Object {
+  "data": undefined,
+  "error": [CombinedError: [Network] ],
+  "extensions": undefined,
+  "operation": Object {
+    "context": Object {
+      "fetchOptions": [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Object {
+              "redirect": "manual",
+            },
+          },
+        ],
+      },
+      "requestPolicy": "cache-first",
+      "url": "http://localhost:3000/graphql",
+    },
+    "key": 2,
+    "operationName": "query",
+    "query": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "getUser",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "name",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "name",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "user",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "firstName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "lastName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "String",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "name",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 124,
+        "start": 0,
+      },
+    },
+    "variables": Object {
+      "name": "Clara",
+    },
+  },
+}
+`;
+
+exports[`on success returns response data 1`] = `
+Object {
+  "data": Object {
+    "data": Object {
+      "user": 1200,
+    },
+  },
+  "error": undefined,
+  "extensions": undefined,
+  "operation": Object {
+    "context": Object {
+      "fetchOptions": [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Object {},
+          },
+        ],
+      },
+      "requestPolicy": "cache-first",
+      "url": "http://localhost:3000/graphql",
+    },
+    "key": 2,
+    "operationName": "query",
+    "query": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "getUser",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "name",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "name",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "user",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "firstName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "lastName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "String",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "name",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 124,
+        "start": 0,
+      },
+    },
+    "variables": Object {
+      "name": "Clara",
+    },
+  },
+}
+`;
+
+exports[`on success returns response data 2`] = `"{\\"query\\":\\"query getUser($name: String) {\\\\n  user(name: $name) {\\\\n    id\\\\n    firstName\\\\n    lastName\\\\n  }\\\\n}\\\\n\\",\\"variables\\":{\\"name\\":\\"Clara\\"},\\"operationName\\":\\"getUser\\"}"`;
+
+exports[`on success uses a file when given 1`] = `
+Object {
+  "data": Object {
+    "data": Object {
+      "user": 1200,
+    },
+  },
+  "error": undefined,
+  "extensions": undefined,
+  "operation": Object {
+    "context": Object {
+      "fetchOptions": [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Object {},
+          },
+        ],
+      },
+      "requestPolicy": "cache-first",
+      "url": "http://localhost:3000/graphql",
+    },
+    "key": 3,
+    "operationName": "mutation",
+    "query": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "uploadProfilePicture",
+          },
+          "operation": "mutation",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "picture",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "picture",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "uploadProfilePicture",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "location",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "File",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "picture",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 134,
+        "start": 0,
+      },
+    },
+    "variables": Object {
+      "picture": File {},
+    },
+  },
+}
+`;
+
+exports[`on success uses a file when given 2`] = `FormData {}`;

--- a/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
+++ b/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
@@ -530,4 +530,6 @@ Object {
 }
 `;
 
-exports[`on success uses a file when given 2`] = `FormData {}`;
+exports[`on success uses a file when given 2`] = `Object {}`;
+
+exports[`on success uses a file when given 3`] = `FormData {}`;

--- a/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
+++ b/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
@@ -533,3 +533,132 @@ Object {
 exports[`on success uses a file when given 2`] = `Object {}`;
 
 exports[`on success uses a file when given 3`] = `FormData {}`;
+
+exports[`on success uses multiple files when given 1`] = `
+Object {
+  "data": Object {
+    "data": Object {
+      "user": 1200,
+    },
+  },
+  "error": undefined,
+  "extensions": undefined,
+  "operation": Object {
+    "context": Object {
+      "fetchOptions": [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Object {},
+          },
+        ],
+      },
+      "requestPolicy": "cache-first",
+      "url": "http://localhost:3000/graphql",
+    },
+    "key": 3,
+    "operationName": "mutation",
+    "query": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "uploadProfilePictures",
+          },
+          "operation": "mutation",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "pictures",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "pictures",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "uploadProfilePicture",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "location",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "ListType",
+                "type": Object {
+                  "kind": "NamedType",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "File",
+                  },
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "pictures",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 140,
+        "start": 0,
+      },
+    },
+    "variables": Object {
+      "picture": Array [
+        File {},
+        File {},
+      ],
+    },
+  },
+}
+`;
+
+exports[`on success uses multiple files when given 2`] = `Object {}`;
+
+exports[`on success uses multiple files when given 3`] = `FormData {}`;

--- a/exchanges/multipart-fetch/src/index.ts
+++ b/exchanges/multipart-fetch/src/index.ts
@@ -1,0 +1,1 @@
+export * from './multipartFetchExchange';

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
@@ -67,9 +67,7 @@ describe('on success', () => {
 
     expect(data).toMatchSnapshot();
     expect(fetchOptions).toHaveBeenCalled();
-    expect(fetch.mock.calls[0][1].headers).toEqual({
-      'content-type': 'multipart/form-data',
-    });
+    expect(fetch.mock.calls[0][1].headers).toMatchSnapshot();
     expect(fetch.mock.calls[0][1].body).toMatchSnapshot();
   });
 

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
@@ -1,0 +1,191 @@
+import { Client, OperationResult, OperationType } from '@urql/core';
+import { queryOperation } from '@urql/core/src/test-utils';
+import { empty, fromValue, pipe, Source, subscribe, toPromise } from 'wonka';
+import gql from 'graphql-tag';
+import { print } from 'graphql';
+
+import { multipartFetchExchange, convertToGet } from './multipartFetchExchange';
+
+const fetch = (global as any).fetch as jest.Mock;
+const abort = jest.fn();
+
+const abortError = new Error();
+abortError.name = 'AbortError';
+
+beforeAll(() => {
+  (global as any).AbortController = function AbortController() {
+    this.signal = undefined;
+    this.abort = abort;
+  };
+});
+
+afterEach(() => {
+  fetch.mockClear();
+  abort.mockClear();
+});
+
+afterAll(() => {
+  (global as any).AbortController = undefined;
+});
+
+const response = {
+  status: 200,
+  data: {
+    data: {
+      user: 1200,
+    },
+  },
+};
+
+const exchangeArgs = {
+  forward: () => empty as Source<OperationResult>,
+  client: {} as Client,
+};
+
+describe('on success', () => {
+  beforeEach(() => {
+    fetch.mockResolvedValue({
+      status: 200,
+      json: jest.fn().mockResolvedValue(response),
+    });
+  });
+
+  it('returns response data', async () => {
+    const fetchOptions = jest.fn().mockReturnValue({});
+
+    const data = await pipe(
+      fromValue({
+        ...queryOperation,
+        context: {
+          ...queryOperation.context,
+          fetchOptions,
+        },
+      }),
+      multipartFetchExchange(exchangeArgs),
+      toPromise
+    );
+
+    expect(data).toMatchSnapshot();
+    expect(fetchOptions).toHaveBeenCalled();
+    expect(fetch.mock.calls[0][1].body).toMatchSnapshot();
+  });
+});
+
+describe('on error', () => {
+  beforeEach(() => {
+    fetch.mockResolvedValue({
+      status: 400,
+      json: jest.fn().mockResolvedValue(response),
+    });
+  });
+
+  it('returns error data', async () => {
+    const data = await pipe(
+      fromValue(queryOperation),
+      multipartFetchExchange(exchangeArgs),
+      toPromise
+    );
+
+    expect(data).toMatchSnapshot();
+  });
+
+  it('returns error data with status 400 and manual redirect mode', async () => {
+    const fetchOptions = jest.fn().mockReturnValue({ redirect: 'manual' });
+
+    const data = await pipe(
+      fromValue({
+        ...queryOperation,
+        context: {
+          ...queryOperation.context,
+          fetchOptions,
+        },
+      }),
+      multipartFetchExchange(exchangeArgs),
+      toPromise
+    );
+
+    expect(data).toMatchSnapshot();
+  });
+});
+
+describe('on teardown', () => {
+  it('does not start the outgoing request on immediate teardowns', () => {
+    fetch.mockRejectedValueOnce(abortError);
+
+    const { unsubscribe } = pipe(
+      fromValue(queryOperation),
+      multipartFetchExchange(exchangeArgs),
+      subscribe(fail)
+    );
+
+    unsubscribe(undefined);
+    expect(fetch).toHaveBeenCalledTimes(0);
+    expect(abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the outgoing request', async () => {
+    fetch.mockRejectedValueOnce(abortError);
+
+    const { unsubscribe } = pipe(
+      fromValue(queryOperation),
+      multipartFetchExchange(exchangeArgs),
+      subscribe(fail)
+    );
+
+    await Promise.resolve();
+
+    unsubscribe(undefined);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call the query', () => {
+    pipe(
+      fromValue({
+        ...queryOperation,
+        operationName: 'teardown' as OperationType,
+      }),
+      multipartFetchExchange(exchangeArgs),
+      subscribe(fail)
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(0);
+    expect(abort).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('convert for GET', () => {
+  it('should do a basic conversion', () => {
+    const query = `query ($id: ID!) { node(id: $id) { id } }`;
+    const variables = { id: 2 };
+    expect(convertToGet('http://localhost:3000', { query, variables })).toBe(
+      `http://localhost:3000?query=${encodeURIComponent(
+        query
+      )}&variables=${encodeURIComponent(JSON.stringify(variables))}`
+    );
+  });
+
+  it('should do a basic conversion with fragments', () => {
+    const nodeFragment = gql`
+      fragment nodeFragment on Node {
+        id
+      }
+    `;
+
+    const variables = { id: 2 };
+    const query = print(gql`
+      query($id: ID!) {
+        node(id: $id) {
+          ...nodeFragment
+        }
+      }
+      ${nodeFragment}
+    `);
+
+    expect(convertToGet('http://localhost:3000', { query, variables })).toBe(
+      `http://localhost:3000?query=${encodeURIComponent(
+        query
+      )}&variables=${encodeURIComponent(JSON.stringify(variables))}`
+    );
+  });
+});

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
@@ -4,7 +4,11 @@ import gql from 'graphql-tag';
 import { print } from 'graphql';
 
 import { multipartFetchExchange, convertToGet } from './multipartFetchExchange';
-import { uploadOperation, queryOperation } from './utils';
+import {
+  uploadOperation,
+  queryOperation,
+  multipleUploadOperation,
+} from './test-utils';
 
 const fetch = (global as any).fetch as jest.Mock;
 const abort = jest.fn();
@@ -58,6 +62,27 @@ describe('on success', () => {
         ...uploadOperation,
         context: {
           ...uploadOperation.context,
+          fetchOptions,
+        },
+      }),
+      multipartFetchExchange(exchangeArgs),
+      toPromise
+    );
+
+    expect(data).toMatchSnapshot();
+    expect(fetchOptions).toHaveBeenCalled();
+    expect(fetch.mock.calls[0][1].headers).toMatchSnapshot();
+    expect(fetch.mock.calls[0][1].body).toMatchSnapshot();
+  });
+
+  it('uses multiple files when given', async () => {
+    const fetchOptions = jest.fn().mockReturnValue({});
+
+    const data = await pipe(
+      fromValue({
+        ...multipleUploadOperation,
+        context: {
+          ...multipleUploadOperation.context,
           fetchOptions,
         },
       }),

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -2,7 +2,13 @@
 import { Kind, DocumentNode, OperationDefinitionNode, print } from 'graphql';
 import { filter, make, merge, mergeMap, pipe, share, takeUntil } from 'wonka';
 import { extractFiles } from 'extract-files';
-import { Exchange, Operation, OperationResult, makeResult, makeErrorResult } from '@urql/core';
+import {
+  Exchange,
+  Operation,
+  OperationResult,
+  makeResult,
+  makeErrorResult,
+} from '@urql/core';
 
 interface Body {
   query: string;
@@ -107,27 +113,27 @@ const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
     };
 
     if (isFileUpload) {
-      fetchOptions.body = new FormData()
+      fetchOptions.body = new FormData();
       fetchOptions.headers['content-type'] = 'multipart/form-data';
       fetchOptions.body.append(
         'operations',
         JSON.stringify({
           query: print(operation.query),
           variables: Object.assign({}, operation.variables),
-        }),
+        })
       );
 
-      const map = {}
-      let i = 0
+      const map = {};
+      let i = 0;
       files.forEach(paths => {
-        map[++i] = paths
+        map[++i] = paths;
       });
 
       fetchOptions.body.append('map', JSON.stringify(map));
 
-      i = 0
+      i = 0;
       files.forEach((_paths, file) => {
-        (fetchOptions.body as FormData).append(`${++i}`, file, file.name)
+        (fetchOptions.body as FormData).append(`${++i}`, file, file.name);
       });
     } else if (shouldUseGet) {
       operation.context.url = convertToGet(operation.context.url, body);

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -1,0 +1,196 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { Kind, DocumentNode, OperationDefinitionNode, print } from 'graphql';
+import { filter, make, merge, mergeMap, pipe, share, takeUntil } from 'wonka';
+import { extractFiles } from 'extract-files';
+import { Exchange, Operation, OperationResult, makeResult, makeErrorResult } from '@urql/core';
+
+interface Body {
+  query: string;
+  variables: void | object;
+  operationName?: string;
+}
+
+export const multipartFetchExchange: Exchange = ({ forward }) => {
+  const isOperationFetchable = (operation: Operation) => {
+    const { operationName } = operation;
+    return operationName === 'query' || operationName === 'mutation';
+  };
+
+  return ops$ => {
+    const sharedOps$ = share(ops$);
+    const fetchResults$ = pipe(
+      sharedOps$,
+      filter(isOperationFetchable),
+      mergeMap(operation => {
+        const { key } = operation;
+        const teardown$ = pipe(
+          sharedOps$,
+          filter(op => op.operationName === 'teardown' && op.key === key)
+        );
+
+        return pipe(
+          createFetchSource(
+            operation,
+            operation.operationName === 'query' &&
+              !!operation.context.preferGetMethod
+          ),
+          takeUntil(teardown$)
+        );
+      })
+    );
+
+    const forward$ = pipe(
+      sharedOps$,
+      filter(op => !isOperationFetchable(op)),
+      forward
+    );
+
+    return merge([fetchResults$, forward$]);
+  };
+};
+
+const getOperationName = (query: DocumentNode): string | null => {
+  const node = query.definitions.find(
+    (node: any): node is OperationDefinitionNode => {
+      return node.kind === Kind.OPERATION_DEFINITION && node.name;
+    }
+  );
+
+  return node !== undefined && node.name ? node.name.value : null;
+};
+
+const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    operation.operationName === 'subscription'
+  ) {
+    throw new Error(
+      'Received a subscription operation in the httpExchange. You are probably trying to create a subscription. Have you added a subscriptionExchange?'
+    );
+  }
+
+  return make<OperationResult>(({ next, complete }) => {
+    const abortController =
+      typeof AbortController !== 'undefined'
+        ? new AbortController()
+        : undefined;
+
+    const { context } = operation;
+    const { files } = extractFiles(operation.variables);
+    const isFileUpload = !!files.size;
+
+    const extraOptions =
+      typeof context.fetchOptions === 'function'
+        ? context.fetchOptions()
+        : context.fetchOptions || {};
+
+    const operationName = getOperationName(operation.query);
+
+    const body: Body = {
+      query: print(operation.query),
+      variables: operation.variables,
+    };
+
+    if (operationName !== null) {
+      body.operationName = operationName;
+    }
+
+    const fetchOptions = {
+      ...extraOptions,
+      method: shouldUseGet ? 'GET' : 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...extraOptions.headers,
+      },
+      signal:
+        abortController !== undefined ? abortController.signal : undefined,
+    };
+
+    if (isFileUpload) {
+      fetchOptions.body = new FormData()
+      fetchOptions.headers['content-type'] = 'multipart/form-data';
+      fetchOptions.body.append(
+        'operations',
+        JSON.stringify({
+          query: print(operation.query),
+          variables: Object.assign({}, operation.variables),
+        }),
+      );
+
+      const map = {}
+      let i = 0
+      files.forEach(paths => {
+        map[++i] = paths
+      });
+
+      fetchOptions.body.append('map', JSON.stringify(map));
+
+      i = 0
+      files.forEach((_paths, file) => {
+        (fetchOptions.body as FormData).append(`${++i}`, file, file.name)
+      });
+    } else if (shouldUseGet) {
+      operation.context.url = convertToGet(operation.context.url, body);
+    } else {
+      fetchOptions.body = JSON.stringify(body);
+    }
+
+    let ended = false;
+
+    Promise.resolve()
+      .then(() => (ended ? undefined : executeFetch(operation, fetchOptions)))
+      .then((result: OperationResult | undefined) => {
+        if (!ended) {
+          ended = true;
+          if (result) next(result);
+          complete();
+        }
+      });
+
+    return () => {
+      ended = true;
+      if (abortController !== undefined) {
+        abortController.abort();
+      }
+    };
+  });
+};
+
+const executeFetch = (
+  operation: Operation,
+  opts: RequestInit
+): Promise<OperationResult> => {
+  const { url, fetch: fetcher } = operation.context;
+  let response: Response | undefined;
+
+  return (fetcher || fetch)(url, opts)
+    .then(res => {
+      const { status } = res;
+      const statusRangeEnd = opts.redirect === 'manual' ? 400 : 300;
+      response = res;
+
+      if (status < 200 || status >= statusRangeEnd) {
+        throw new Error(res.statusText);
+      } else {
+        return res.json();
+      }
+    })
+    .then(result => makeResult(operation, result, response))
+    .catch(err => {
+      if (err.name !== 'AbortError') {
+        return makeErrorResult(operation, err, response);
+      }
+    });
+};
+
+export const convertToGet = (uri: string, body: Body): string => {
+  const queryParams: string[] = [`query=${encodeURIComponent(body.query)}`];
+
+  if (body.variables) {
+    queryParams.push(
+      `variables=${encodeURIComponent(JSON.stringify(body.variables))}`
+    );
+  }
+
+  return uri + '?' + queryParams.join('&');
+};

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { Kind, DocumentNode, OperationDefinitionNode, print } from 'graphql';
 import { filter, make, merge, mergeMap, pipe, share, takeUntil } from 'wonka';
 import { extractFiles } from 'extract-files';

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -59,7 +59,7 @@ const getOperationName = (query: DocumentNode): string | null => {
     }
   );
 
-  return node !== undefined && node.name ? node.name.value : null;
+  return node && node.name ? node.name.value : null;
 };
 
 const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {

--- a/exchanges/multipart-fetch/src/test-utils.ts
+++ b/exchanges/multipart-fetch/src/test-utils.ts
@@ -25,7 +25,12 @@ const queryGql: GraphQLRequest = {
   },
 };
 
-const file = new File(['foo'], 'index.ts');
+const obj = { hello: 'world' };
+const file = new File(
+  [new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' })],
+  'index.ts'
+);
+const files = [file, file];
 
 const upload: GraphQLRequest = {
   key: 3,
@@ -41,8 +46,28 @@ const upload: GraphQLRequest = {
   },
 };
 
+const uploads: GraphQLRequest = {
+  key: 3,
+  query: gql`
+    mutation uploadProfilePictures($pictures: [File]) {
+      uploadProfilePicture(pictures: $pictures) {
+        location
+      }
+    }
+  `,
+  variables: {
+    picture: files,
+  },
+};
+
 export const uploadOperation: Operation = {
   ...upload,
+  operationName: 'mutation',
+  context,
+};
+
+export const multipleUploadOperation: Operation = {
+  ...uploads,
   operationName: 'mutation',
   context,
 };

--- a/exchanges/multipart-fetch/src/utils.ts
+++ b/exchanges/multipart-fetch/src/utils.ts
@@ -1,0 +1,54 @@
+import { GraphQLRequest, OperationContext, Operation } from '@urql/core';
+import gql from 'graphql-tag';
+
+const context: OperationContext = {
+  fetchOptions: {
+    method: 'POST',
+  },
+  requestPolicy: 'cache-first',
+  url: 'http://localhost:3000/graphql',
+};
+
+const queryGql: GraphQLRequest = {
+  key: 2,
+  query: gql`
+    query getUser($name: String) {
+      user(name: $name) {
+        id
+        firstName
+        lastName
+      }
+    }
+  `,
+  variables: {
+    name: 'Clara',
+  },
+};
+
+const file = new File(['foo'], 'index.ts');
+
+const upload: GraphQLRequest = {
+  key: 3,
+  query: gql`
+    mutation uploadProfilePicture($picture: File) {
+      uploadProfilePicture(picture: $picture) {
+        location
+      }
+    }
+  `,
+  variables: {
+    picture: file,
+  },
+};
+
+export const uploadOperation: Operation = {
+  ...upload,
+  operationName: 'mutation',
+  context,
+};
+
+export const queryOperation: Operation = {
+  ...queryGql,
+  operationName: 'query',
+  context,
+};

--- a/exchanges/multipart-fetch/tsconfig.json
+++ b/exchanges/multipart-fetch/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5275,6 +5275,11 @@ extract-css-chunks-webpack-plugin@^4.6.0:
     webpack-external-import "^1.1.0-beta.3"
     webpack-sources "^1.1.0"
 
+extract-files@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-7.0.0.tgz#3dc7853320ff7876ec62d6e98f2f4e6f3e6282f6"
+  integrity sha512-3AUlT7TD+DbQXNe3t70QrgJU6Wgcp7rk1Zm0vqWz8OYnw4vxihgG0TgZ2SIGrVqScc4WfOu7B4a0BezGJ0YqvQ==
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"


### PR DESCRIPTION
## Summary

This adds a new exchange meant to extend the feature-set of our default `fetchExchange` to include file-uploads!

Working playground https://codesandbox.io/s/urql-upload-client-05pcn

Implements https://github.com/FormidableLabs/urql/issues/560