### PR TITLE
Skip specific query/mutation operations when enableAllOperations is on

### DIFF
--- a/.changeset/few-horses-cough.md
+++ b/.changeset/few-horses-cough.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Add `skipOperation` to the subscriptionExchange, this allows skipping of specific query/mutation operations when `enableAllOperations` is turned on.

--- a/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -1,5 +1,265 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should allow for query operations with all operations enabled 1`] = `
+Object {
+  "data": Object {},
+  "error": undefined,
+  "extensions": undefined,
+  "operation": Object {
+    "context": Object {
+      "fetchOptions": Object {
+        "method": "POST",
+      },
+      "requestPolicy": "cache-first",
+      "url": "http://localhost:3000/graphql",
+    },
+    "key": 2,
+    "operationName": "query",
+    "query": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "getUser",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "name",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "name",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "user",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "firstName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "lastName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "String",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "name",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 124,
+        "start": 0,
+      },
+    },
+    "variables": Object {
+      "name": "Clara",
+    },
+  },
+}
+`;
+
+exports[`should allow for selective operation skipping with all operations enabled 1`] = `
+Object {
+  "data": Object {},
+  "error": undefined,
+  "extensions": undefined,
+  "operation": Object {
+    "context": Object {
+      "fetchOptions": Object {
+        "method": "POST",
+      },
+      "requestPolicy": "cache-first",
+      "url": "http://localhost:3000/graphql",
+    },
+    "key": 2,
+    "operationName": "query",
+    "query": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "getUser",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "name",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "name",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "user",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "firstName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "lastName",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "String",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "name",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 124,
+        "start": 0,
+      },
+    },
+    "variables": Object {
+      "name": "Clara",
+    },
+  },
+}
+`;
+
+exports[`should allow for selective operation skipping with all operations enabled 2`] = `[Function]`;
+
 exports[`should return response data from forwardSubscription observable 1`] = `
 Object {
   "data": Object {},

--- a/packages/core/src/exchanges/subscription.test.ts
+++ b/packages/core/src/exchanges/subscription.test.ts
@@ -9,7 +9,11 @@ import {
   toPromise,
 } from 'wonka';
 import { Client } from '../client';
-import { subscriptionOperation, subscriptionResult } from '../test-utils';
+import {
+  subscriptionOperation,
+  subscriptionResult,
+  queryOperation,
+} from '../test-utils';
 import { OperationResult } from '../types';
 import { subscriptionExchange, SubscriptionForwarder } from './subscription';
 
@@ -73,4 +77,112 @@ it('should tear down the operation if the source subscription ends', async () =>
 
   expect(unsubscribe).not.toHaveBeenCalled();
   expect(reexecuteOperation).toHaveBeenCalled();
+});
+
+it('should allow for query operations with all operations enabled', async () => {
+  const exchangeArgs = {
+    forward: () => empty as Source<OperationResult>,
+    client: {} as Client,
+  };
+
+  const unsubscribe = jest.fn();
+  const forwardSubscription: SubscriptionForwarder = operation => {
+    expect(operation.query).toBe(print(queryOperation.query));
+    expect(operation.variables).toBe(queryOperation.variables);
+    expect(operation.context).toEqual(queryOperation.context);
+
+    return {
+      subscribe(observer) {
+        Promise.resolve().then(() => {
+          observer.next(subscriptionResult);
+        });
+
+        return { unsubscribe };
+      },
+    };
+  };
+
+  const data = await pipe(
+    fromValue(queryOperation),
+    subscriptionExchange({
+      enableAllOperations: true,
+      forwardSubscription,
+    })(exchangeArgs),
+    take(1),
+    toPromise
+  );
+
+  expect(data).toMatchSnapshot();
+  expect(unsubscribe).toHaveBeenCalled();
+});
+
+it('should allow for selective operation skipping with all operations enabled', async () => {
+  const exchangeArgs = {
+    forward: () => empty as Source<OperationResult>,
+    client: {} as Client,
+  };
+
+  const unsubscribe = jest.fn();
+  const forwardSubscription: SubscriptionForwarder = operation => {
+    expect(operation.query).toBe(print(queryOperation.query));
+    expect(operation.variables).toBe(queryOperation.variables);
+    expect(operation.context).toEqual(queryOperation.context);
+
+    return {
+      subscribe(observer) {
+        Promise.resolve().then(() => {
+          observer.next(subscriptionResult);
+        });
+
+        return { unsubscribe };
+      },
+    };
+  };
+
+  const data = await pipe(
+    fromValue(queryOperation),
+    subscriptionExchange({
+      enableAllOperations: true,
+      forwardSubscription,
+    })(exchangeArgs),
+    take(1),
+    toPromise
+  );
+
+  expect(data).toMatchSnapshot();
+  expect(unsubscribe).toHaveBeenCalled();
+});
+
+it('should allow for selective operation skipping with all operations enabled', async () => {
+  const exchangeArgs = {
+    forward: () => empty as Source<OperationResult>,
+    client: {} as Client,
+  };
+
+  const unsubscribe = jest.fn();
+  const forwardSubscription: SubscriptionForwarder = () => {
+    expect(true).toBeFalsy();
+
+    return {
+      subscribe(observer) {
+        Promise.resolve().then(() => {
+          observer.next(subscriptionResult);
+        });
+
+        return { unsubscribe };
+      },
+    };
+  };
+
+  const data = pipe(
+    fromValue(queryOperation),
+    subscriptionExchange({
+      enableAllOperations: true,
+      forwardSubscription,
+      skipOperation: op => op.key === queryOperation.key,
+    })(exchangeArgs)
+  );
+
+  expect(data).toMatchSnapshot();
+  expect(unsubscribe).toHaveBeenCalledTimes(0);
 });

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -55,11 +55,14 @@ export interface SubscriptionExchangeOpts {
 
   /** This flag may be turned on to allow your subscriptions-transport to handle all operation types */
   enableAllOperations?: boolean;
+
+  skipOperation?: (operation: Operation) => boolean;
 }
 
 export const subscriptionExchange = ({
   forwardSubscription,
   enableAllOperations,
+  skipOperation,
 }: SubscriptionExchangeOpts): Exchange => ({ client, forward }) => {
   const createSubscriptionSource = (
     operation: Operation
@@ -110,7 +113,9 @@ export const subscriptionExchange = ({
     return (
       operationName === 'subscription' ||
       (!!enableAllOperations &&
-        (operationName === 'query' || operationName === 'mutation'))
+        (operationName === 'query' || operationName === 'mutation') &&
+        // When we have no skipOperation or skipOperation returns true we should not use this exchange
+        (!skipOperation || !skipOperation(operation)))
     );
   };
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Allows for selective skipping of  (query/mutation) operations when `enableAllOperations` is turned on for subscriptions.

## Set of changes

- add `skipOperation` option to the `subscriptionExchange`
