### PR TITLE
Fix commutative squashing failing when lowest layer resolved earlier than others

### DIFF
--- a/.changeset/good-swans-cough.md
+++ b/.changeset/good-swans-cough.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix commutative layer edge case when lowest-priority layer comes back earlier than others

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -214,6 +214,8 @@ describe('commutative changes', () => {
 
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(2);
+
+    expect(data.optimisticOrder).toEqual([]);
   });
 
   it('creates optimistic layers that may be removed using clearLayer', () => {
@@ -239,6 +241,8 @@ describe('commutative changes', () => {
 
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(1);
+
+    expect(data.optimisticOrder).toEqual([]);
   });
 
   it('overrides data using optimistic layers', () => {
@@ -261,6 +265,8 @@ describe('commutative changes', () => {
 
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(3);
+
+    expect(data.optimisticOrder).toEqual([3, 2, 1]);
   });
 
   it('avoids optimistic layers when only one layer is pending', () => {
@@ -277,6 +283,8 @@ describe('commutative changes', () => {
 
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(1);
+
+    expect(data.optimisticOrder).toEqual([]);
   });
 
   it('continues applying optimistic layers even if the first one completes', () => {
@@ -312,5 +320,7 @@ describe('commutative changes', () => {
 
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(4);
+
+    expect(data.optimisticOrder).toEqual([]);
   });
 });

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -287,7 +287,7 @@ describe('commutative changes', () => {
     expect(data.optimisticOrder).toEqual([]);
   });
 
-  it('continues applying optimistic layers even if the first one completes', () => {
+  it.only('continues applying optimistic layers even if the first one completes', () => {
     InMemoryData.reserveLayer(data, 1);
     InMemoryData.reserveLayer(data, 2);
     InMemoryData.reserveLayer(data, 3);

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -100,16 +100,15 @@ export const clearDataState = () => {
     const commutativeIndex =
       data.optimisticOrder.length - data.commutativeKeys.size;
 
-    // Find `i` to be the lowest commutative layer that can be squashed
+    // Squash all layers in reverse order (low priority upwards) that have
+    // been written already
     let i = data.optimisticOrder.length;
     while (--i >= commutativeIndex) {
-      if (!data.refLock[data.optimisticOrder[i]]) break;
-    }
-
-    // Squash all layers down to `i`, in order
-    let j = data.optimisticOrder.length;
-    while (--j > i) {
-      squashLayer(data.optimisticOrder[j]);
+      if (data.refLock[data.optimisticOrder[i]]) {
+        squashLayer(data.optimisticOrder[i]);
+      } else {
+        break;
+      }
     }
   }
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -494,6 +494,10 @@ export const clearLayer = (data: InMemoryData, layerKey: number) => {
 
 /** Merges an optimistic layer of links and records into the base data */
 const squashLayer = (layerKey: number) => {
+  // Hide current dependencies from squashing operations
+  // const prevDependencies = currentDependencies;
+  // currentDependencies = new Set();
+
   const links = currentData!.links.optimistic[layerKey];
   if (links) {
     links.forEach((keyMap, entityKey) => {
@@ -510,6 +514,7 @@ const squashLayer = (layerKey: number) => {
     });
   }
 
+  // currentDependencies = prevDependencies;
   clearLayer(currentData!, layerKey);
 };
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -490,8 +490,8 @@ export const clearLayer = (data: InMemoryData, layerKey: number) => {
 /** Merges an optimistic layer of links and records into the base data */
 const squashLayer = (layerKey: number) => {
   // Hide current dependencies from squashing operations
-  // const prevDependencies = currentDependencies;
-  // currentDependencies = new Set();
+  const prevDependencies = currentDependencies;
+  currentDependencies = new Set();
 
   const links = currentData!.links.optimistic[layerKey];
   if (links) {
@@ -509,7 +509,7 @@ const squashLayer = (layerKey: number) => {
     });
   }
 
-  // currentDependencies = prevDependencies;
+  currentDependencies = prevDependencies;
   clearLayer(currentData!, layerKey);
 };
 


### PR DESCRIPTION
The commutative squashing would previously only start when
the lowest commutative layer (the first one) was written.
This ignored the case however of when this layer has already
been written. When this was the case the stopping condition
was unreachable and commutative layers were never squashed.

The change is to continuously squash the commutative layers
with the least priorities as they're written.

This change also gets rid of the temporary `squash` queue,
which ends up making it a rather nice implementation.

Resolve #574 