### PR TITLE
Fix teardown operation breaking commutative layers

### DIFF
--- a/.changeset/two-guests-hide.md
+++ b/.changeset/two-guests-hide.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix teardown events leading to broken commutativity

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -29,7 +29,7 @@ import {
 import { query, write, writeOptimistic } from './operations';
 import { hydrateData } from './store/data';
 import { makeDict } from './helpers/dict';
-import { Store, clearLayer, reserveLayer } from './store';
+import { Store, noopDataState, clearLayer, reserveLayer } from './store';
 
 import {
   UpdatesConfig,
@@ -174,7 +174,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
     if (operation.operationName === 'query') {
       reserveLayer(store.data, operation.key);
     } else if (operation.operationName === 'teardown') {
-      clearLayer(store.data, operation.key);
+      noopDataState(store.data, operation.key);
     }
   };
 

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -287,7 +287,7 @@ describe('commutative changes', () => {
     expect(data.optimisticOrder).toEqual([]);
   });
 
-  it.only('continues applying optimistic layers even if the first one completes', () => {
+  it('continues applying optimistic layers even if the first one completes', () => {
     InMemoryData.reserveLayer(data, 1);
     InMemoryData.reserveLayer(data, 2);
     InMemoryData.reserveLayer(data, 3);
@@ -322,5 +322,14 @@ describe('commutative changes', () => {
     expect(InMemoryData.readRecord('Query', 'index')).toBe(4);
 
     expect(data.optimisticOrder).toEqual([]);
+  });
+
+  it('allows noopDataState to clear layers only if necessary', () => {
+    InMemoryData.reserveLayer(data, 1);
+    InMemoryData.reserveLayer(data, 2);
+
+    InMemoryData.noopDataState(data, 2);
+
+    expect(data.optimisticOrder).toEqual([2, 1]);
   });
 });

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -329,7 +329,9 @@ describe('commutative changes', () => {
     InMemoryData.reserveLayer(data, 2);
 
     InMemoryData.noopDataState(data, 2);
-
     expect(data.optimisticOrder).toEqual([2, 1]);
+
+    InMemoryData.noopDataState(data, 1);
+    expect(data.optimisticOrder).toEqual([]);
   });
 });

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -135,6 +135,12 @@ export const clearDataState = () => {
   }
 };
 
+/** Initialises then resets the data state, which may squash this layer if necessary */
+export const noopDataState = (data: InMemoryData, layerKey: number | null) => {
+  initDataState(data, layerKey);
+  clearDataState();
+};
+
 /** As we're writing, we keep around all the records and links we've read or have written to */
 export const getCurrentDependencies = (): Set<string> => {
   invariant(

--- a/exchanges/graphcache/src/store/index.ts
+++ b/exchanges/graphcache/src/store/index.ts
@@ -1,6 +1,7 @@
 export {
   initDataState,
   clearDataState,
+  noopDataState,
   reserveLayer,
   clearLayer,
   getCurrentDependencies,


### PR DESCRIPTION
Previously a commutative layer would be deleted when a `teardown` event came in, which wasn't respecting layers that may already have been written to. Instead the `teardown` now triggers an empty data change, which will only delete the layer if it exists and if it can be.