### PR TITLE
(next-urql) - call init once browser side

### DIFF
--- a/.changeset/dirty-tips-sin.md
+++ b/.changeset/dirty-tips-sin.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Pass the urqlClient down in withUrqlClient.getInitialProps to prevent it from being called twice.

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -76,7 +76,7 @@ export function withUrqlClient(
       // getInitialProps runs on the server for initial render, and on the client for navigation.
       // We only want to run the prepass step on the server.
       if (typeof window !== 'undefined') {
-        return pageProps;
+        return { ...pageProps, urqlClient };
       }
 
       const props = { ...pageProps, urqlClient };


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Passes down `urqlClient` in `withUrqlClient.getInitialProps`, this prevents the HOC from having to call `initUrqlClient` again.

If anyone has suggestions for a test feel free to throw them out there since `typeof window === undefined` in tests

Implements https://github.com/FormidableLabs/urql/issues/582

## Set of changes

Passes down `urqlClient` in `withUrqlClient.getInitialProps`