### PR TITLE
Add @urql/exchange-populate as dependency to @urql/exchange-graphcache

### DIFF
--- a/.changeset/olive-donuts-talk.md
+++ b/.changeset/olive-donuts-talk.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Externalise @urql/exchange-populate from bundle

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -58,7 +58,8 @@
   },
   "dependencies": {
     "wonka": "^3.2.1 || ^4.0.0",
-    "@urql/core": ">=1.9.2"
+    "@urql/core": ">=1.9.2",
+    "@urql/exchange-populate": ">=0.1.1"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"


### PR DESCRIPTION
Externalise `@urql/exchange-populate` from `@urql/exchange-graphcache`'s build bundles.