### PR TITLE
Filter results that are being retried from retryExchange's output

### DIFF
--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -4,7 +4,6 @@ import {
   pipe,
   merge,
   filter,
-  tap,
   fromValue,
   delay,
   mergeMap,
@@ -27,43 +26,32 @@ interface RetryExchangeOptions {
   retryIf?: (e: CombinedError) => boolean;
 }
 
-export interface OperationWithRetry extends Operation {
-  retryCount?: number;
-}
-
-export interface OperationResultWithRetry extends OperationResult {
-  operation: OperationWithRetry;
-}
-
 export const retryExchange = ({
   initialDelayMs,
   maxDelayMs,
   randomDelay,
   maxNumberAttempts,
-  retryIf,
+  retryIf: retryIfOption,
 }: RetryExchangeOptions): Exchange => {
   const MIN_DELAY = initialDelayMs || 1000;
   const MAX_DELAY = maxDelayMs || 15000;
   const MAX_ATTEMPTS = maxNumberAttempts || Infinity;
   const RANDOM_DELAY = randomDelay || true;
 
-  const networkErrorOrRetryIf = err =>
-    (retryIf && retryIf(err)) || err.networkError;
+  const retryIf =
+    retryIfOption || ((err: CombinedError) => err && err.networkError);
 
   return ({ forward }) => ops$ => {
     const sharedOps$ = pipe(ops$, share);
     const { source: retry$, next: nextRetryOperation } = makeSubject<
-      OperationWithRetry
+      Operation
     >();
-    let maxNumberAttemptsExceeded = false;
 
     const retryWithBackoff$ = pipe(
       retry$,
-      mergeMap((op: OperationWithRetry) => {
-        const { key, context, retryCount } = op;
-        if (retryCount && retryCount > MAX_ATTEMPTS) {
-          maxNumberAttemptsExceeded = true;
-        }
+      mergeMap((op: Operation) => {
+        const { key, context } = op;
+        const retryCount = context.retryCount || 0;
         let delayAmount = context.retryDelay || MIN_DELAY;
 
         const backoffFactor = Math.random() + 1.5;
@@ -75,7 +63,7 @@ export const retryExchange = ({
 
         // We stop the retries if a teardown event for this operation comes in
         // But if this event comes through regularly we also stop the retries, since it's
-        // basically the query retrying itself, so no backoff should be added!
+        // basically the query retrying itself, no backoff should be added!
         const teardown$ = pipe(
           sharedOps$,
           filter(op => {
@@ -94,11 +82,9 @@ export const retryExchange = ({
             context: {
               ...op.context,
               retryDelay: delayAmount,
+              retryCount: retryCount + 1,
             },
-            retryCount: retryCount != null ? retryCount + 1 : 1,
           }),
-          filter(op => op.retryCount < MAX_ATTEMPTS),
-          // Here's the actual delay
           delay(delayAmount),
           // Stop retry if a teardown comes in
           takeUntil(teardown$)
@@ -109,29 +95,23 @@ export const retryExchange = ({
     const result$ = pipe(
       merge([sharedOps$, retryWithBackoff$]),
       forward,
-      share
-    ) as sourceT<OperationResultWithRetry>;
-
-    const successResult$ = pipe(
-      result$,
-      // We let through all results that don't fit the criteria
-      filter(res => !res.error || !networkErrorOrRetryIf(res.error))
-    );
-
-    const failedResult$ = pipe(
-      result$,
-      // Only retry if the error passes the conditional retryIf function (if passed)
-      // or if the error contains a networkError
-      filter(res => !!(res.error && networkErrorOrRetryIf(res.error))),
-      // Send failed responses to be retried by calling next on the retry$ subject
-      // Exclude operations that have been retried more than the specified max
-      tap(op => {
-        if (!maxNumberAttemptsExceeded) {
-          nextRetryOperation(op.operation);
+      share,
+      filter(res => {
+        const maxNumberAttemptsExceeded =
+          (res.operation.context.retryCount || 0) >= MAX_ATTEMPTS - 1;
+        // Only retry if the error passes the conditional retryIf function (if passed)
+        // or if the error contains a networkError
+        if (res.error && retryIf(res.error) && !maxNumberAttemptsExceeded) {
+          // Send failed responses to be retried by calling next on the retry$ subject
+          // Exclude operations that have been retried more than the specified max
+          nextRetryOperation(res.operation);
+          return false;
+        } else {
+          return true;
         }
       })
-    );
+    ) as sourceT<OperationResult>;
 
-    return merge([successResult$, failedResult$]);
+    return result$;
   };
 };

--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -35,7 +35,7 @@ export const retryExchange = ({
 }: RetryExchangeOptions): Exchange => {
   const MIN_DELAY = initialDelayMs || 1000;
   const MAX_DELAY = maxDelayMs || 15000;
-  const MAX_ATTEMPTS = maxNumberAttempts || Infinity;
+  const MAX_ATTEMPTS = maxNumberAttempts || 2;
   const RANDOM_DELAY = randomDelay || true;
 
   const retryIf =


### PR DESCRIPTION

<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

In preparation for getting  `retryExchange` ready to publish:

- `retryExchange` now only returns an error if the max number of retries have been exceeded
- `retryCount` have been moved to operation context (removes unnecessary typings)
- Update tests to reflect that only 1 result should be returned per operation
<!-- What's the motivation of this change? What does it solve? -->

