### PR TITLE
(graphcache) - Apply commutativity to all operations

### DIFF
--- a/.changeset/funny-parents-beg.md
+++ b/.changeset/funny-parents-beg.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Apply commutative layers to all operations, so now including mutations and subscriptions, to ensure that unordered data is written in the correct order.

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -37,1039 +37,1049 @@ const queryOneData = {
   },
 };
 
-it('writes queries to the cache', () => {
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const op = client.createRequestOperation('query', {
-    key: 1,
-    query: queryOne,
+describe('data dependencies', () => {
+  it('writes queries to the cache', () => {
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const op = client.createRequestOperation('query', {
+      key: 1,
+      query: queryOne,
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        expect(forwardOp.key).toBe(op.key);
+        return { operation: forwardOp, data: queryOneData };
+      }
+    );
+
+    const { source: ops$, next } = makeSubject<Operation>();
+    const result = jest.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+
+    pipe(cacheExchange({})({ forward, client })(ops$), tap(result), publish);
+
+    next(op);
+    next(op);
+    expect(response).toHaveBeenCalledTimes(1);
+    expect(result).toHaveBeenCalledTimes(2);
+
+    expect(result.mock.calls[0][0]).toHaveProperty(
+      'operation.context.meta.cacheOutcome',
+      'miss'
+    );
+    expect(result.mock.calls[1][0]).toHaveProperty(
+      'operation.context.meta.cacheOutcome',
+      'hit'
+    );
   });
 
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      expect(forwardOp.key).toBe(op.key);
-      return { operation: forwardOp, data: queryOneData };
-    }
-  );
-
-  const { source: ops$, next } = makeSubject<Operation>();
-  const result = jest.fn();
-  const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
-
-  pipe(cacheExchange({})({ forward, client })(ops$), tap(result), publish);
-
-  next(op);
-  next(op);
-  expect(response).toHaveBeenCalledTimes(1);
-  expect(result).toHaveBeenCalledTimes(2);
-
-  expect(result.mock.calls[0][0]).toHaveProperty(
-    'operation.context.meta.cacheOutcome',
-    'miss'
-  );
-  expect(result.mock.calls[1][0]).toHaveProperty(
-    'operation.context.meta.cacheOutcome',
-    'hit'
-  );
-});
-
-it('updates related queries when their data changes', () => {
-  const queryMultiple = gql`
-    {
-      authors {
-        id
-        name
-      }
-    }
-  `;
-
-  const queryMultipleData = {
-    __typename: 'Query',
-    authors: [
+  it('updates related queries when their data changes', () => {
+    const queryMultiple = gql`
       {
-        __typename: 'Author',
-        id: '123',
-        name: 'Author',
-      },
-    ],
-  };
+        authors {
+          id
+          name
+        }
+      }
+    `;
 
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const { source: ops$, next } = makeSubject<Operation>();
+    const queryMultipleData = {
+      __typename: 'Query',
+      authors: [
+        {
+          __typename: 'Author',
+          id: '123',
+          name: 'Author',
+        },
+      ],
+    };
 
-  const reexec = jest
-    .spyOn(client, 'reexecuteOperation')
-    .mockImplementation(next);
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
 
-  const opOne = client.createRequestOperation('query', {
-    key: 1,
-    query: queryOne,
+    const reexec = jest
+      .spyOn(client, 'reexecuteOperation')
+      .mockImplementation(next);
+
+    const opOne = client.createRequestOperation('query', {
+      key: 1,
+      query: queryOne,
+    });
+
+    const opMultiple = client.createRequestOperation('query', {
+      key: 2,
+      query: queryMultiple,
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: opOne, data: queryOneData };
+        } else if (forwardOp.key === 2) {
+          return { operation: opMultiple, data: queryMultipleData };
+        }
+
+        return undefined as any;
+      }
+    );
+
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const result = jest.fn();
+
+    pipe(cacheExchange({})({ forward, client })(ops$), tap(result), publish);
+
+    next(opOne);
+    expect(response).toHaveBeenCalledTimes(1);
+    expect(result).toHaveBeenCalledTimes(1);
+
+    next(opMultiple);
+    expect(response).toHaveBeenCalledTimes(2);
+    expect(reexec).toHaveBeenCalledWith(opOne);
+    expect(result).toHaveBeenCalledTimes(3);
   });
 
-  const opMultiple = client.createRequestOperation('query', {
-    key: 2,
-    query: queryMultiple,
-  });
+  it('updates related queries when a mutation update touches query data', () => {
+    jest.useFakeTimers();
 
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      if (forwardOp.key === 1) {
-        return { operation: opOne, data: queryOneData };
-      } else if (forwardOp.key === 2) {
-        return { operation: opMultiple, data: queryMultipleData };
-      }
-
-      return undefined as any;
-    }
-  );
-
-  const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
-  const result = jest.fn();
-
-  pipe(cacheExchange({})({ forward, client })(ops$), tap(result), publish);
-
-  next(opOne);
-  expect(response).toHaveBeenCalledTimes(1);
-  expect(result).toHaveBeenCalledTimes(1);
-
-  next(opMultiple);
-  expect(response).toHaveBeenCalledTimes(2);
-  expect(reexec).toHaveBeenCalledWith(opOne);
-  expect(result).toHaveBeenCalledTimes(3);
-});
-
-it('updates related queries when a mutation update touches query data', () => {
-  jest.useFakeTimers();
-
-  const balanceFragment = gql`
-    fragment BalanceFragment on Author {
-      id
-      balance {
-        amount
-      }
-    }
-  `;
-
-  const queryById = gql`
-    query($id: ID!) {
-      author(id: $id) {
+    const balanceFragment = gql`
+      fragment BalanceFragment on Author {
         id
-        name
-        ...BalanceFragment
-      }
-    }
-
-    ${balanceFragment}
-  `;
-
-  const queryByIdDataA = {
-    __typename: 'Query',
-    author: {
-      __typename: 'Author',
-      id: '1',
-      name: 'Author 1',
-      balance: {
-        __typename: 'Balance',
-        amount: 100,
-      },
-    },
-  };
-
-  const queryByIdDataB = {
-    __typename: 'Query',
-    author: {
-      __typename: 'Author',
-      id: '2',
-      name: 'Author 2',
-      balance: {
-        __typename: 'Balance',
-        amount: 200,
-      },
-    },
-  };
-
-  const mutation = gql`
-    mutation($userId: ID!, $amount: Int!) {
-      updateBalance(userId: $userId, amount: $amount) {
-        userId
         balance {
           amount
         }
       }
-    }
-  `;
+    `;
 
-  const mutationData = {
-    __typename: 'Mutation',
-    updateBalance: {
-      __typename: 'UpdateBalanceResult',
-      userId: '1',
-      balance: {
-        __typename: 'Balance',
-        amount: 1000,
-      },
-    },
-  };
-
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const { source: ops$, next } = makeSubject<Operation>();
-
-  const reexec = jest
-    .spyOn(client, 'reexecuteOperation')
-    .mockImplementation(next);
-
-  const opOne = client.createRequestOperation('query', {
-    key: 1,
-    query: queryById,
-    variables: { id: 1 },
-  });
-
-  const opTwo = client.createRequestOperation('query', {
-    key: 2,
-    query: queryById,
-    variables: { id: 2 },
-  });
-
-  const opMutation = client.createRequestOperation('mutation', {
-    key: 3,
-    query: mutation,
-    variables: { userId: '1', amount: 1000 },
-  });
-
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      if (forwardOp.key === 1) {
-        return { operation: opOne, data: queryByIdDataA };
-      } else if (forwardOp.key === 2) {
-        return { operation: opTwo, data: queryByIdDataB };
-      } else if (forwardOp.key === 3) {
-        return { operation: opMutation, data: mutationData };
+    const queryById = gql`
+      query($id: ID!) {
+        author(id: $id) {
+          id
+          name
+          ...BalanceFragment
+        }
       }
 
-      return undefined as any;
-    }
-  );
+      ${balanceFragment}
+    `;
 
-  const result = jest.fn();
-  const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
-
-  const updates = {
-    Mutation: {
-      updateBalance: jest.fn((result, _args, cache) => {
-        const {
-          updateBalance: { userId, balance },
-        } = result;
-        cache.writeFragment(balanceFragment, { id: userId, balance });
-      }),
-    },
-  };
-
-  const keys = {
-    Balance: () => null,
-  };
-
-  pipe(
-    cacheExchange({ updates, keys })({ forward, client })(ops$),
-    tap(result),
-    publish
-  );
-
-  next(opTwo);
-  jest.runAllTimers();
-  expect(response).toHaveBeenCalledTimes(1);
-
-  next(opOne);
-  jest.runAllTimers();
-  expect(response).toHaveBeenCalledTimes(2);
-
-  next(opMutation);
-  jest.runAllTimers();
-
-  expect(response).toHaveBeenCalledTimes(3);
-  expect(updates.Mutation.updateBalance).toHaveBeenCalledTimes(1);
-
-  expect(reexec).toHaveBeenCalledTimes(1);
-  expect(reexec.mock.calls[0][0].key).toBe(1);
-
-  expect(result.mock.calls[2][0]).toHaveProperty(
-    'data.author.balance.amount',
-    1000
-  );
-});
-
-it('does nothing when no related queries have changed', () => {
-  const queryUnrelated = gql`
-    {
-      user {
-        id
-        name
-      }
-    }
-  `;
-
-  const queryUnrelatedData = {
-    __typename: 'Query',
-    user: {
-      __typename: 'User',
-      id: 'me',
-      name: 'Me',
-    },
-  };
-
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const { source: ops$, next } = makeSubject<Operation>();
-  const reexec = jest
-    .spyOn(client, 'reexecuteOperation')
-    .mockImplementation(next);
-
-  const opOne = client.createRequestOperation('query', {
-    key: 1,
-    query: queryOne,
-  });
-  const opUnrelated = client.createRequestOperation('query', {
-    key: 2,
-    query: queryUnrelated,
-  });
-
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      if (forwardOp.key === 1) {
-        return { operation: opOne, data: queryOneData };
-      } else if (forwardOp.key === 2) {
-        return { operation: opUnrelated, data: queryUnrelatedData };
-      }
-
-      return undefined as any;
-    }
-  );
-
-  const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
-  const result = jest.fn();
-
-  pipe(cacheExchange({})({ forward, client })(ops$), tap(result), publish);
-
-  next(opOne);
-  expect(response).toHaveBeenCalledTimes(1);
-
-  next(opUnrelated);
-  expect(response).toHaveBeenCalledTimes(2);
-
-  expect(reexec).not.toHaveBeenCalled();
-  expect(result).toHaveBeenCalledTimes(2);
-});
-
-it('writes optimistic mutations to the cache', () => {
-  jest.useFakeTimers();
-
-  const mutation = gql`
-    mutation {
-      concealAuthor {
-        id
-        name
-      }
-    }
-  `;
-
-  const optimisticMutationData = {
-    __typename: 'Mutation',
-    concealAuthor: {
-      __typename: 'Author',
-      id: '123',
-      name: '[REDACTED OFFLINE]',
-    },
-  };
-
-  const mutationData = {
-    __typename: 'Mutation',
-    concealAuthor: {
-      __typename: 'Author',
-      id: '123',
-      name: '[REDACTED ONLINE]',
-    },
-  };
-
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const { source: ops$, next } = makeSubject<Operation>();
-
-  const reexec = jest
-    .spyOn(client, 'reexecuteOperation')
-    .mockImplementation(next);
-
-  const opOne = client.createRequestOperation('query', {
-    key: 1,
-    query: queryOne,
-  });
-
-  const opMutation = client.createRequestOperation('mutation', {
-    key: 2,
-    query: mutation,
-  });
-
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      if (forwardOp.key === 1) {
-        return { operation: opOne, data: queryOneData };
-      } else if (forwardOp.key === 2) {
-        return { operation: opMutation, data: mutationData };
-      }
-
-      return undefined as any;
-    }
-  );
-
-  const result = jest.fn();
-  const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
-
-  const optimistic = {
-    concealAuthor: jest.fn(() => optimisticMutationData.concealAuthor) as any,
-  };
-
-  pipe(
-    cacheExchange({ optimistic })({ forward, client })(ops$),
-    tap(result),
-    publish
-  );
-
-  next(opOne);
-  jest.runAllTimers();
-  expect(response).toHaveBeenCalledTimes(1);
-
-  next(opMutation);
-  expect(response).toHaveBeenCalledTimes(1);
-  expect(optimistic.concealAuthor).toHaveBeenCalledTimes(1);
-  expect(reexec).toHaveBeenCalledTimes(1);
-
-  jest.runAllTimers();
-  expect(response).toHaveBeenCalledTimes(2);
-  expect(result).toHaveBeenCalledTimes(4);
-});
-
-it('correctly clears on error', () => {
-  jest.useFakeTimers();
-
-  const authorsQuery = gql`
-    query {
-      authors {
-        id
-        name
-      }
-    }
-  `;
-
-  const authorsQueryData = {
-    __typename: 'Query',
-    authors: [
-      {
+    const queryByIdDataA = {
+      __typename: 'Query',
+      author: {
         __typename: 'Author',
         id: '1',
-        name: 'Author',
-      },
-    ],
-  };
-
-  const mutation = gql`
-    mutation {
-      addAuthor {
-        id
-        name
-      }
-    }
-  `;
-
-  const optimisticMutationData = {
-    __typename: 'Mutation',
-    addAuthor: {
-      __typename: 'Author',
-      id: '123',
-      name: '[REDACTED OFFLINE]',
-    },
-  };
-
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const { source: ops$, next } = makeSubject<Operation>();
-
-  const reexec = jest
-    .spyOn(client, 'reexecuteOperation')
-    .mockImplementation(next);
-
-  const opOne = client.createRequestOperation('query', {
-    key: 1,
-    query: authorsQuery,
-  });
-
-  const opMutation = client.createRequestOperation('mutation', {
-    key: 2,
-    query: mutation,
-  });
-
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      if (forwardOp.key === 1) {
-        return { operation: opOne, data: authorsQueryData };
-      } else if (forwardOp.key === 2) {
-        return {
-          operation: opMutation,
-          error: 'error' as any,
-          data: { __typename: 'Mutation', addAuthor: null },
-        };
-      }
-
-      return undefined as any;
-    }
-  );
-
-  const result = jest.fn();
-  const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
-
-  const optimistic = {
-    addAuthor: jest.fn(() => optimisticMutationData.addAuthor) as any,
-  };
-
-  const updates = {
-    Mutation: {
-      addAuthor: jest.fn((data, _, cache) => {
-        cache.updateQuery({ query: authorsQuery }, (prevData: any) => ({
-          ...prevData,
-          authors: [...prevData.authors, data.addAuthor],
-        }));
-      }),
-    },
-  };
-
-  pipe(
-    cacheExchange({ optimistic, updates })({ forward, client })(ops$),
-    tap(result),
-    publish
-  );
-
-  next(opOne);
-  jest.runAllTimers();
-  expect(response).toHaveBeenCalledTimes(1);
-
-  next(opMutation);
-  expect(response).toHaveBeenCalledTimes(1);
-  expect(optimistic.addAuthor).toHaveBeenCalledTimes(1);
-  expect(updates.Mutation.addAuthor).toHaveBeenCalledTimes(1);
-  expect(reexec).toHaveBeenCalledTimes(1);
-
-  jest.runAllTimers();
-  expect(updates.Mutation.addAuthor).toHaveBeenCalledTimes(2);
-  expect(response).toHaveBeenCalledTimes(2);
-  expect(result).toHaveBeenCalledTimes(4);
-});
-
-it('follows resolvers on initial write', () => {
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const { source: ops$, next } = makeSubject<Operation>();
-
-  const opOne = client.createRequestOperation('query', {
-    key: 1,
-    query: queryOne,
-  });
-
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      if (forwardOp.key === 1) {
-        return { operation: opOne, data: queryOneData };
-      }
-
-      return undefined as any;
-    }
-  );
-
-  const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
-
-  const result = jest.fn();
-  const fakeResolver = jest.fn();
-
-  pipe(
-    cacheExchange({
-      resolvers: {
-        Author: {
-          name: () => {
-            fakeResolver();
-            return 'newName';
-          },
+        name: 'Author 1',
+        balance: {
+          __typename: 'Balance',
+          amount: 100,
         },
       },
-    })({ forward, client })(ops$),
-    tap(result),
-    publish
-  );
+    };
 
-  next(opOne);
-  expect(response).toHaveBeenCalledTimes(1);
-  expect(fakeResolver).toHaveBeenCalledTimes(1);
-  expect(result).toHaveBeenCalledTimes(1);
-  expect(result.mock.calls[0][0].data).toEqual({
-    __typename: 'Query',
-    author: {
-      __typename: 'Author',
-      id: '123',
-      name: 'newName',
-    },
-  });
-});
-
-it('follows resolvers for mutations', () => {
-  jest.useFakeTimers();
-
-  const mutation = gql`
-    mutation {
-      concealAuthor {
-        id
-        name
-        __typename
-      }
-    }
-  `;
-
-  const mutationData = {
-    __typename: 'Mutation',
-    concealAuthor: {
-      __typename: 'Author',
-      id: '123',
-      name: '[REDACTED ONLINE]',
-    },
-  };
-
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const { source: ops$, next } = makeSubject<Operation>();
-
-  const opOne = client.createRequestOperation('query', {
-    key: 1,
-    query: queryOne,
-  });
-
-  const opMutation = client.createRequestOperation('mutation', {
-    key: 2,
-    query: mutation,
-  });
-
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      if (forwardOp.key === 1) {
-        return { operation: opOne, data: queryOneData };
-      } else if (forwardOp.key === 2) {
-        return { operation: opMutation, data: mutationData };
-      }
-
-      return undefined as any;
-    }
-  );
-
-  const result = jest.fn();
-  const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
-
-  const fakeResolver = jest.fn();
-
-  pipe(
-    cacheExchange({
-      resolvers: {
-        Author: {
-          name: () => {
-            fakeResolver();
-            return 'newName';
-          },
+    const queryByIdDataB = {
+      __typename: 'Query',
+      author: {
+        __typename: 'Author',
+        id: '2',
+        name: 'Author 2',
+        balance: {
+          __typename: 'Balance',
+          amount: 200,
         },
       },
-    })({ forward, client })(ops$),
-    tap(result),
-    publish
-  );
+    };
 
-  next(opOne);
-  jest.runAllTimers();
-  expect(response).toHaveBeenCalledTimes(1);
-
-  next(opMutation);
-  expect(response).toHaveBeenCalledTimes(1);
-  expect(fakeResolver).toHaveBeenCalledTimes(1);
-
-  jest.runAllTimers();
-  expect(result.mock.calls[1][0].data).toEqual({
-    __typename: 'Mutation',
-    concealAuthor: {
-      __typename: 'Author',
-      id: '123',
-      name: 'newName',
-    },
-  });
-});
-
-it('follows nested resolvers for mutations', () => {
-  jest.useFakeTimers();
-
-  const mutation = gql`
-    mutation {
-      concealAuthors {
-        id
-        name
-        book {
-          id
-          title
-          __typename
+    const mutation = gql`
+      mutation($userId: ID!, $amount: Int!) {
+        updateBalance(userId: $userId, amount: $amount) {
+          userId
+          balance {
+            amount
+          }
         }
-        __typename
       }
-    }
-  `;
+    `;
 
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const { source: ops$, next } = makeSubject<Operation>();
+    const mutationData = {
+      __typename: 'Mutation',
+      updateBalance: {
+        __typename: 'UpdateBalanceResult',
+        userId: '1',
+        balance: {
+          __typename: 'Balance',
+          amount: 1000,
+        },
+      },
+    };
 
-  const query = gql`
-    query {
-      authors {
-        id
-        name
-        book {
-          id
-          title
-          __typename
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    const reexec = jest
+      .spyOn(client, 'reexecuteOperation')
+      .mockImplementation(next);
+
+    const opOne = client.createRequestOperation('query', {
+      key: 1,
+      query: queryById,
+      variables: { id: 1 },
+    });
+
+    const opTwo = client.createRequestOperation('query', {
+      key: 2,
+      query: queryById,
+      variables: { id: 2 },
+    });
+
+    const opMutation = client.createRequestOperation('mutation', {
+      key: 3,
+      query: mutation,
+      variables: { userId: '1', amount: 1000 },
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: opOne, data: queryByIdDataA };
+        } else if (forwardOp.key === 2) {
+          return { operation: opTwo, data: queryByIdDataB };
+        } else if (forwardOp.key === 3) {
+          return { operation: opMutation, data: mutationData };
         }
-        __typename
+
+        return undefined as any;
       }
-    }
-  `;
+    );
 
-  const queryOperation = client.createRequestOperation('query', {
-    key: 1,
-    query,
+    const result = jest.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+
+    const updates = {
+      Mutation: {
+        updateBalance: jest.fn((result, _args, cache) => {
+          const {
+            updateBalance: { userId, balance },
+          } = result;
+          cache.writeFragment(balanceFragment, { id: userId, balance });
+        }),
+      },
+    };
+
+    const keys = {
+      Balance: () => null,
+    };
+
+    pipe(
+      cacheExchange({ updates, keys })({ forward, client })(ops$),
+      tap(result),
+      publish
+    );
+
+    next(opTwo);
+    jest.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(1);
+
+    next(opOne);
+    jest.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(2);
+
+    next(opMutation);
+    jest.runAllTimers();
+
+    expect(response).toHaveBeenCalledTimes(3);
+    expect(updates.Mutation.updateBalance).toHaveBeenCalledTimes(1);
+
+    expect(reexec).toHaveBeenCalledTimes(1);
+    expect(reexec.mock.calls[0][0].key).toBe(1);
+
+    expect(result.mock.calls[2][0]).toHaveProperty(
+      'data.author.balance.amount',
+      1000
+    );
   });
 
-  const mutationOperation = client.createRequestOperation('mutation', {
-    key: 2,
-    query: mutation,
-  });
-
-  const mutationData = {
-    __typename: 'Mutation',
-    concealAuthors: [
+  it('does nothing when no related queries have changed', () => {
+    const queryUnrelated = gql`
       {
+        user {
+          id
+          name
+        }
+      }
+    `;
+
+    const queryUnrelatedData = {
+      __typename: 'Query',
+      user: {
+        __typename: 'User',
+        id: 'me',
+        name: 'Me',
+      },
+    };
+
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
+    const reexec = jest
+      .spyOn(client, 'reexecuteOperation')
+      .mockImplementation(next);
+
+    const opOne = client.createRequestOperation('query', {
+      key: 1,
+      query: queryOne,
+    });
+    const opUnrelated = client.createRequestOperation('query', {
+      key: 2,
+      query: queryUnrelated,
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: opOne, data: queryOneData };
+        } else if (forwardOp.key === 2) {
+          return { operation: opUnrelated, data: queryUnrelatedData };
+        }
+
+        return undefined as any;
+      }
+    );
+
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+    const result = jest.fn();
+
+    pipe(cacheExchange({})({ forward, client })(ops$), tap(result), publish);
+
+    next(opOne);
+    expect(response).toHaveBeenCalledTimes(1);
+
+    next(opUnrelated);
+    expect(response).toHaveBeenCalledTimes(2);
+
+    expect(reexec).not.toHaveBeenCalled();
+    expect(result).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('optimistic updates', () => {
+  it('writes optimistic mutations to the cache', () => {
+    jest.useFakeTimers();
+
+    const mutation = gql`
+      mutation {
+        concealAuthor {
+          id
+          name
+        }
+      }
+    `;
+
+    const optimisticMutationData = {
+      __typename: 'Mutation',
+      concealAuthor: {
         __typename: 'Author',
         id: '123',
-        book: null,
-        name: '[REDACTED ONLINE]',
+        name: '[REDACTED OFFLINE]',
       },
-      {
-        __typename: 'Author',
-        id: '456',
-        name: 'Formidable',
-        book: {
-          id: '1',
-          title: 'AwesomeGQL',
-          __typename: 'Book',
-        },
-      },
-    ],
-  };
+    };
 
-  const queryData = {
-    __typename: 'Query',
-    authors: [
-      {
+    const mutationData = {
+      __typename: 'Mutation',
+      concealAuthor: {
         __typename: 'Author',
         id: '123',
         name: '[REDACTED ONLINE]',
-        book: null,
       },
-      {
-        __typename: 'Author',
-        id: '456',
-        name: 'Formidable',
-        book: {
-          id: '1',
-          title: 'AwesomeGQL',
-          __typename: 'Book',
-        },
-      },
-    ],
-  };
+    };
 
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      if (forwardOp.key === 1) {
-        return { operation: queryOperation, data: queryData };
-      } else if (forwardOp.key === 2) {
-        return { operation: mutationOperation, data: mutationData };
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    const reexec = jest
+      .spyOn(client, 'reexecuteOperation')
+      .mockImplementation(next);
+
+    const opOne = client.createRequestOperation('query', {
+      key: 1,
+      query: queryOne,
+    });
+
+    const opMutation = client.createRequestOperation('mutation', {
+      key: 2,
+      query: mutation,
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: opOne, data: queryOneData };
+        } else if (forwardOp.key === 2) {
+          return { operation: opMutation, data: mutationData };
+        }
+
+        return undefined as any;
       }
+    );
 
-      return undefined as any;
-    }
-  );
+    const result = jest.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
 
-  const result = jest.fn();
-  const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const optimistic = {
+      concealAuthor: jest.fn(() => optimisticMutationData.concealAuthor) as any,
+    };
 
-  const fakeResolver = jest.fn();
-  const called: any[] = [];
+    pipe(
+      cacheExchange({ optimistic })({ forward, client })(ops$),
+      tap(result),
+      publish
+    );
 
-  pipe(
-    cacheExchange({
-      resolvers: {
-        Author: {
-          name: parent => {
-            called.push(parent.name);
-            fakeResolver();
-            return 'Secret Author';
-          },
-        },
-        Book: {
-          title: parent => {
-            called.push(parent.title);
-            fakeResolver();
-            return 'Secret Book';
-          },
-        },
-      },
-    })({ forward, client })(ops$),
-    tap(result),
-    publish
-  );
+    next(opOne);
+    jest.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(1);
 
-  next(queryOperation);
-  jest.runAllTimers();
-  expect(response).toHaveBeenCalledTimes(1);
-  expect(fakeResolver).toHaveBeenCalledTimes(3);
+    next(opMutation);
+    expect(response).toHaveBeenCalledTimes(1);
+    expect(optimistic.concealAuthor).toHaveBeenCalledTimes(1);
+    expect(reexec).toHaveBeenCalledTimes(1);
 
-  next(mutationOperation);
-  jest.runAllTimers();
-  expect(response).toHaveBeenCalledTimes(2);
-  expect(fakeResolver).toHaveBeenCalledTimes(6);
-  expect(result.mock.calls[1][0].data).toEqual({
-    __typename: 'Mutation',
-    concealAuthors: [
-      {
-        __typename: 'Author',
-        id: '123',
-        book: null,
-        name: 'Secret Author',
-      },
-      {
-        __typename: 'Author',
-        id: '456',
-        name: 'Secret Author',
-        book: {
-          id: '1',
-          title: 'Secret Book',
-          __typename: 'Book',
-        },
-      },
-    ],
+    jest.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(2);
+    expect(result).toHaveBeenCalledTimes(4);
   });
 
-  expect(called).toEqual([
-    // Query
-    '[REDACTED ONLINE]',
-    'Formidable',
-    'AwesomeGQL',
-    // Mutation
-    '[REDACTED ONLINE]',
-    'Formidable',
-    'AwesomeGQL',
-  ]);
+  it('correctly clears on error', () => {
+    jest.useFakeTimers();
+
+    const authorsQuery = gql`
+      query {
+        authors {
+          id
+          name
+        }
+      }
+    `;
+
+    const authorsQueryData = {
+      __typename: 'Query',
+      authors: [
+        {
+          __typename: 'Author',
+          id: '1',
+          name: 'Author',
+        },
+      ],
+    };
+
+    const mutation = gql`
+      mutation {
+        addAuthor {
+          id
+          name
+        }
+      }
+    `;
+
+    const optimisticMutationData = {
+      __typename: 'Mutation',
+      addAuthor: {
+        __typename: 'Author',
+        id: '123',
+        name: '[REDACTED OFFLINE]',
+      },
+    };
+
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    const reexec = jest
+      .spyOn(client, 'reexecuteOperation')
+      .mockImplementation(next);
+
+    const opOne = client.createRequestOperation('query', {
+      key: 1,
+      query: authorsQuery,
+    });
+
+    const opMutation = client.createRequestOperation('mutation', {
+      key: 2,
+      query: mutation,
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: opOne, data: authorsQueryData };
+        } else if (forwardOp.key === 2) {
+          return {
+            operation: opMutation,
+            error: 'error' as any,
+            data: { __typename: 'Mutation', addAuthor: null },
+          };
+        }
+
+        return undefined as any;
+      }
+    );
+
+    const result = jest.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+
+    const optimistic = {
+      addAuthor: jest.fn(() => optimisticMutationData.addAuthor) as any,
+    };
+
+    const updates = {
+      Mutation: {
+        addAuthor: jest.fn((data, _, cache) => {
+          cache.updateQuery({ query: authorsQuery }, (prevData: any) => ({
+            ...prevData,
+            authors: [...prevData.authors, data.addAuthor],
+          }));
+        }),
+      },
+    };
+
+    pipe(
+      cacheExchange({ optimistic, updates })({ forward, client })(ops$),
+      tap(result),
+      publish
+    );
+
+    next(opOne);
+    jest.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(1);
+
+    next(opMutation);
+    expect(response).toHaveBeenCalledTimes(1);
+    expect(optimistic.addAuthor).toHaveBeenCalledTimes(1);
+    expect(updates.Mutation.addAuthor).toHaveBeenCalledTimes(1);
+    expect(reexec).toHaveBeenCalledTimes(1);
+
+    jest.runAllTimers();
+    expect(updates.Mutation.addAuthor).toHaveBeenCalledTimes(2);
+    expect(response).toHaveBeenCalledTimes(2);
+    expect(result).toHaveBeenCalledTimes(4);
+  });
 });
 
-it('reexecutes query and returns data on partial result', () => {
-  jest.useFakeTimers();
-  const client = createClient({ url: 'http://0.0.0.0' });
-  const { source: ops$, next } = makeSubject<Operation>();
-  const reexec = jest
-    .spyOn(client, 'reexecuteOperation')
-    // Empty mock to avoid going in an endless loop, since we would again return
-    // partial data.
-    .mockImplementation(() => undefined);
+describe('custom resolvers', () => {
+  it('follows resolvers on initial write', () => {
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
 
-  const initialQuery = gql`
-    query {
-      todos {
-        id
-        text
-        __typename
+    const opOne = client.createRequestOperation('query', {
+      key: 1,
+      query: queryOne,
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: opOne, data: queryOneData };
+        }
+
+        return undefined as any;
       }
-    }
-  `;
+    );
 
-  const query = gql`
-    query {
-      todos {
-        id
-        text
-        complete
-        author {
+    const forward: ExchangeIO = ops$ => pipe(ops$, map(response));
+
+    const result = jest.fn();
+    const fakeResolver = jest.fn();
+
+    pipe(
+      cacheExchange({
+        resolvers: {
+          Author: {
+            name: () => {
+              fakeResolver();
+              return 'newName';
+            },
+          },
+        },
+      })({ forward, client })(ops$),
+      tap(result),
+      publish
+    );
+
+    next(opOne);
+    expect(response).toHaveBeenCalledTimes(1);
+    expect(fakeResolver).toHaveBeenCalledTimes(1);
+    expect(result).toHaveBeenCalledTimes(1);
+    expect(result.mock.calls[0][0].data).toEqual({
+      __typename: 'Query',
+      author: {
+        __typename: 'Author',
+        id: '123',
+        name: 'newName',
+      },
+    });
+  });
+
+  it('follows resolvers for mutations', () => {
+    jest.useFakeTimers();
+
+    const mutation = gql`
+      mutation {
+        concealAuthor {
           id
           name
           __typename
         }
-        __typename
       }
-    }
-  `;
+    `;
 
-  const initialQueryOperation = client.createRequestOperation('query', {
-    key: 1,
-    query: initialQuery,
-  });
-
-  const queryOperation = client.createRequestOperation('query', {
-    key: 2,
-    query,
-  });
-
-  const queryData = {
-    __typename: 'Query',
-    todos: [
-      {
-        __typename: 'Todo',
+    const mutationData = {
+      __typename: 'Mutation',
+      concealAuthor: {
+        __typename: 'Author',
         id: '123',
-        text: 'Learn',
+        name: '[REDACTED ONLINE]',
       },
-      {
-        __typename: 'Todo',
-        id: '456',
-        text: 'Teach',
-      },
-    ],
-  };
+    };
 
-  const response = jest.fn(
-    (forwardOp: Operation): OperationResult => {
-      if (forwardOp.key === 1) {
-        return { operation: initialQueryOperation, data: queryData };
-      } else if (forwardOp.key === 2) {
-        return { operation: queryOperation, data: queryData };
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    const opOne = client.createRequestOperation('query', {
+      key: 1,
+      query: queryOne,
+    });
+
+    const opMutation = client.createRequestOperation('mutation', {
+      key: 2,
+      query: mutation,
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: opOne, data: queryOneData };
+        } else if (forwardOp.key === 2) {
+          return { operation: opMutation, data: mutationData };
+        }
+
+        return undefined as any;
       }
+    );
 
-      return undefined as any;
-    }
-  );
+    const result = jest.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
 
-  const result = jest.fn();
-  const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+    const fakeResolver = jest.fn();
 
-  pipe(
-    cacheExchange({
-      // eslint-disable-next-line
-      schema: require('./test-utils/simple_schema.json'),
-    })({ forward, client })(ops$),
-    tap(result),
-    publish
-  );
+    pipe(
+      cacheExchange({
+        resolvers: {
+          Author: {
+            name: () => {
+              fakeResolver();
+              return 'newName';
+            },
+          },
+        },
+      })({ forward, client })(ops$),
+      tap(result),
+      publish
+    );
 
-  next(initialQueryOperation);
-  jest.runAllTimers();
-  expect(response).toHaveBeenCalledTimes(1);
-  expect(reexec).toHaveBeenCalledTimes(0);
-  expect(result.mock.calls[0][0].data).toEqual({
-    __typename: 'Query',
-    todos: [
-      {
-        __typename: 'Todo',
+    next(opOne);
+    jest.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(1);
+
+    next(opMutation);
+    expect(response).toHaveBeenCalledTimes(1);
+    expect(fakeResolver).toHaveBeenCalledTimes(1);
+
+    jest.runAllTimers();
+    expect(result.mock.calls[1][0].data).toEqual({
+      __typename: 'Mutation',
+      concealAuthor: {
+        __typename: 'Author',
         id: '123',
-        text: 'Learn',
+        name: 'newName',
       },
-      {
-        __typename: 'Todo',
-        id: '456',
-        text: 'Teach',
-      },
-    ],
+    });
   });
 
-  expect(result.mock.calls[0][0]).toHaveProperty(
-    'operation.context.meta',
-    undefined
-  );
+  it('follows nested resolvers for mutations', () => {
+    jest.useFakeTimers();
 
-  next(queryOperation);
-  jest.runAllTimers();
-  expect(result).toHaveBeenCalledTimes(2);
-  expect(reexec).toHaveBeenCalledTimes(1);
-  expect(result.mock.calls[1][0].stale).toBe(true);
-  expect(result.mock.calls[1][0].data).toEqual({
-    __typename: 'Query',
-    todos: [
-      {
-        __typename: 'Todo',
-        author: null,
-        complete: null,
-        id: '123',
-        text: 'Learn',
-      },
-      {
-        __typename: 'Todo',
-        author: null,
-        complete: null,
-        id: '456',
-        text: 'Teach',
-      },
-    ],
+    const mutation = gql`
+      mutation {
+        concealAuthors {
+          id
+          name
+          book {
+            id
+            title
+            __typename
+          }
+          __typename
+        }
+      }
+    `;
+
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    const query = gql`
+      query {
+        authors {
+          id
+          name
+          book {
+            id
+            title
+            __typename
+          }
+          __typename
+        }
+      }
+    `;
+
+    const queryOperation = client.createRequestOperation('query', {
+      key: 1,
+      query,
+    });
+
+    const mutationOperation = client.createRequestOperation('mutation', {
+      key: 2,
+      query: mutation,
+    });
+
+    const mutationData = {
+      __typename: 'Mutation',
+      concealAuthors: [
+        {
+          __typename: 'Author',
+          id: '123',
+          book: null,
+          name: '[REDACTED ONLINE]',
+        },
+        {
+          __typename: 'Author',
+          id: '456',
+          name: 'Formidable',
+          book: {
+            id: '1',
+            title: 'AwesomeGQL',
+            __typename: 'Book',
+          },
+        },
+      ],
+    };
+
+    const queryData = {
+      __typename: 'Query',
+      authors: [
+        {
+          __typename: 'Author',
+          id: '123',
+          name: '[REDACTED ONLINE]',
+          book: null,
+        },
+        {
+          __typename: 'Author',
+          id: '456',
+          name: 'Formidable',
+          book: {
+            id: '1',
+            title: 'AwesomeGQL',
+            __typename: 'Book',
+          },
+        },
+      ],
+    };
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: queryOperation, data: queryData };
+        } else if (forwardOp.key === 2) {
+          return { operation: mutationOperation, data: mutationData };
+        }
+
+        return undefined as any;
+      }
+    );
+
+    const result = jest.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+
+    const fakeResolver = jest.fn();
+    const called: any[] = [];
+
+    pipe(
+      cacheExchange({
+        resolvers: {
+          Author: {
+            name: parent => {
+              called.push(parent.name);
+              fakeResolver();
+              return 'Secret Author';
+            },
+          },
+          Book: {
+            title: parent => {
+              called.push(parent.title);
+              fakeResolver();
+              return 'Secret Book';
+            },
+          },
+        },
+      })({ forward, client })(ops$),
+      tap(result),
+      publish
+    );
+
+    next(queryOperation);
+    jest.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(1);
+    expect(fakeResolver).toHaveBeenCalledTimes(3);
+
+    next(mutationOperation);
+    jest.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(2);
+    expect(fakeResolver).toHaveBeenCalledTimes(6);
+    expect(result.mock.calls[1][0].data).toEqual({
+      __typename: 'Mutation',
+      concealAuthors: [
+        {
+          __typename: 'Author',
+          id: '123',
+          book: null,
+          name: 'Secret Author',
+        },
+        {
+          __typename: 'Author',
+          id: '456',
+          name: 'Secret Author',
+          book: {
+            id: '1',
+            title: 'Secret Book',
+            __typename: 'Book',
+          },
+        },
+      ],
+    });
+
+    expect(called).toEqual([
+      // Query
+      '[REDACTED ONLINE]',
+      'Formidable',
+      'AwesomeGQL',
+      // Mutation
+      '[REDACTED ONLINE]',
+      'Formidable',
+      'AwesomeGQL',
+    ]);
   });
-
-  expect(result.mock.calls[1][0]).toHaveProperty(
-    'operation.context.meta.cacheOutcome',
-    'partial'
-  );
 });
 
-it('applies results that come in out-of-order commutatively and consistently', () => {
-  jest.useFakeTimers();
+describe('schema awareness', () => {
+  it('reexecutes query and returns data on partial result', () => {
+    jest.useFakeTimers();
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
+    const reexec = jest
+      .spyOn(client, 'reexecuteOperation')
+      // Empty mock to avoid going in an endless loop, since we would again return
+      // partial data.
+      .mockImplementation(() => undefined);
 
-  let data: any;
+    const initialQuery = gql`
+      query {
+        todos {
+          id
+          text
+          __typename
+        }
+      }
+    `;
 
-  const client = createClient({
-    url: 'http://0.0.0.0',
-    requestPolicy: 'cache-and-network',
-  });
-  const { source: ops$, next: next } = makeSubject<Operation>();
-  const query = gql`
-    {
-      index
-    }
-  `;
+    const query = gql`
+      query {
+        todos {
+          id
+          text
+          complete
+          author {
+            id
+            name
+            __typename
+          }
+          __typename
+        }
+      }
+    `;
 
-  const result = (operation: Operation): Source<OperationResult> =>
-    pipe(
-      fromValue({
-        operation,
-        data: {
-          __typename: 'Query',
-          index: operation.key,
+    const initialQueryOperation = client.createRequestOperation('query', {
+      key: 1,
+      query: initialQuery,
+    });
+
+    const queryOperation = client.createRequestOperation('query', {
+      key: 2,
+      query,
+    });
+
+    const queryData = {
+      __typename: 'Query',
+      todos: [
+        {
+          __typename: 'Todo',
+          id: '123',
+          text: 'Learn',
         },
-      }),
-      delay(operation.key === 2 ? 5 : operation.key * 10)
+        {
+          __typename: 'Todo',
+          id: '456',
+          text: 'Teach',
+        },
+      ],
+    };
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: initialQueryOperation, data: queryData };
+        } else if (forwardOp.key === 2) {
+          return { operation: queryOperation, data: queryData };
+        }
+
+        return undefined as any;
+      }
     );
 
-  const output = jest.fn(result => {
-    data = result.data;
-  });
+    const result = jest.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
 
-  const forward = (ops$: Source<Operation>): Source<OperationResult> =>
     pipe(
-      ops$,
-      filter(op => op.operationName !== 'teardown'),
-      mergeMap(result)
+      cacheExchange({
+        // eslint-disable-next-line
+        schema: require('./test-utils/simple_schema.json'),
+      })({ forward, client })(ops$),
+      tap(result),
+      publish
     );
 
-  pipe(cacheExchange()({ forward, client })(ops$), tap(output), publish);
+    next(initialQueryOperation);
+    jest.runAllTimers();
+    expect(response).toHaveBeenCalledTimes(1);
+    expect(reexec).toHaveBeenCalledTimes(0);
+    expect(result.mock.calls[0][0].data).toEqual({
+      __typename: 'Query',
+      todos: [
+        {
+          __typename: 'Todo',
+          id: '123',
+          text: 'Learn',
+        },
+        {
+          __typename: 'Todo',
+          id: '456',
+          text: 'Teach',
+        },
+      ],
+    });
 
-  next(client.createRequestOperation('query', { key: 1, query }));
-  next(client.createRequestOperation('query', { key: 2, query }));
+    expect(result.mock.calls[0][0]).toHaveProperty(
+      'operation.context.meta',
+      undefined
+    );
 
-  // This shouldn't have any effect:
-  next(client.createRequestOperation('teardown', { key: 2, query }));
+    next(queryOperation);
+    jest.runAllTimers();
+    expect(result).toHaveBeenCalledTimes(2);
+    expect(reexec).toHaveBeenCalledTimes(1);
+    expect(result.mock.calls[1][0].stale).toBe(true);
+    expect(result.mock.calls[1][0].data).toEqual({
+      __typename: 'Query',
+      todos: [
+        {
+          __typename: 'Todo',
+          author: null,
+          complete: null,
+          id: '123',
+          text: 'Learn',
+        },
+        {
+          __typename: 'Todo',
+          author: null,
+          complete: null,
+          id: '456',
+          text: 'Teach',
+        },
+      ],
+    });
 
-  next(client.createRequestOperation('query', { key: 3, query }));
+    expect(result.mock.calls[1][0]).toHaveProperty(
+      'operation.context.meta.cacheOutcome',
+      'partial'
+    );
+  });
+});
 
-  jest.advanceTimersByTime(5);
-  expect(output).toHaveBeenCalledTimes(1);
-  expect(data.index).toBe(2);
+describe('commutativity', () => {
+  it('applies results that come in out-of-order commutatively and consistently', () => {
+    jest.useFakeTimers();
 
-  jest.advanceTimersByTime(10);
-  expect(output).toHaveBeenCalledTimes(2);
-  expect(data.index).toBe(2);
+    let data: any;
 
-  jest.advanceTimersByTime(30);
-  expect(output).toHaveBeenCalledTimes(3);
-  expect(data.index).toBe(3);
+    const client = createClient({
+      url: 'http://0.0.0.0',
+      requestPolicy: 'cache-and-network',
+    });
+    const { source: ops$, next: next } = makeSubject<Operation>();
+    const query = gql`
+      {
+        index
+      }
+    `;
+
+    const result = (operation: Operation): Source<OperationResult> =>
+      pipe(
+        fromValue({
+          operation,
+          data: {
+            __typename: 'Query',
+            index: operation.key,
+          },
+        }),
+        delay(operation.key === 2 ? 5 : operation.key * 10)
+      );
+
+    const output = jest.fn(result => {
+      data = result.data;
+    });
+
+    const forward = (ops$: Source<Operation>): Source<OperationResult> =>
+      pipe(
+        ops$,
+        filter(op => op.operationName !== 'teardown'),
+        mergeMap(result)
+      );
+
+    pipe(cacheExchange()({ forward, client })(ops$), tap(output), publish);
+
+    next(client.createRequestOperation('query', { key: 1, query }));
+    next(client.createRequestOperation('query', { key: 2, query }));
+
+    // This shouldn't have any effect:
+    next(client.createRequestOperation('teardown', { key: 2, query }));
+
+    next(client.createRequestOperation('query', { key: 3, query }));
+
+    jest.advanceTimersByTime(5);
+    expect(output).toHaveBeenCalledTimes(1);
+    expect(data.index).toBe(2);
+
+    jest.advanceTimersByTime(10);
+    expect(output).toHaveBeenCalledTimes(2);
+    expect(data.index).toBe(2);
+
+    jest.advanceTimersByTime(30);
+    expect(output).toHaveBeenCalledTimes(3);
+    expect(data.index).toBe(3);
+  });
 });

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1086,7 +1086,7 @@ describe('commutativity', () => {
 
   it('applies optimistic updates on top of commutative queries', () => {
     let data: any;
-    const client = createClient({ url: 'http://0.0.0.0', });
+    const client = createClient({ url: 'http://0.0.0.0' });
     const { source: ops$, next: nextOp } = makeSubject<Operation>();
     const { source: res$, next: nextRes } = makeSubject<OperationResult>();
 
@@ -1114,7 +1114,10 @@ describe('commutativity', () => {
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
       merge([
-        pipe(ops$, filter(() => false)) as any,
+        pipe(
+          ops$,
+          filter(() => false)
+        ) as any,
         res$,
       ]);
 
@@ -1123,7 +1126,7 @@ describe('commutativity', () => {
         __typename: 'Node',
         id: 'node',
         name: 'optimistic',
-      })
+      }),
     };
 
     pipe(
@@ -1137,7 +1140,10 @@ describe('commutativity', () => {
     );
 
     const queryOpA = client.createRequestOperation('query', { key: 1, query });
-    const mutationOp = client.createRequestOperation('mutation', { key: 2, query: mutation });
+    const mutationOp = client.createRequestOperation('mutation', {
+      key: 2,
+      query: mutation,
+    });
     const queryOpB = client.createRequestOperation('query', { key: 3, query });
 
     expect(data).toBe(undefined);
@@ -1152,8 +1158,8 @@ describe('commutativity', () => {
           __typename: 'Node',
           id: 'node',
           name: 'query a',
-        }
-      }
+        },
+      },
     });
 
     expect(data).toHaveProperty('node.name', 'query a');
@@ -1171,8 +1177,8 @@ describe('commutativity', () => {
           __typename: 'Node',
           id: 'node',
           name: 'query b',
-        }
-      }
+        },
+      },
     });
 
     expect(data).toHaveProperty('node.name', 'query b');
@@ -1180,7 +1186,7 @@ describe('commutativity', () => {
 
   it('applies mutation results on top of commutative queries', () => {
     let data: any;
-    const client = createClient({ url: 'http://0.0.0.0', });
+    const client = createClient({ url: 'http://0.0.0.0' });
     const { source: ops$, next: nextOp } = makeSubject<Operation>();
     const { source: res$, next: nextRes } = makeSubject<OperationResult>();
 
@@ -1208,7 +1214,10 @@ describe('commutativity', () => {
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
       merge([
-        pipe(ops$, filter(() => false)) as any,
+        pipe(
+          ops$,
+          filter(() => false)
+        ) as any,
         res$,
       ]);
 
@@ -1223,7 +1232,10 @@ describe('commutativity', () => {
     );
 
     const queryOpA = client.createRequestOperation('query', { key: 1, query });
-    const mutationOp = client.createRequestOperation('mutation', { key: 2, query: mutation });
+    const mutationOp = client.createRequestOperation('mutation', {
+      key: 2,
+      query: mutation,
+    });
     const queryOpB = client.createRequestOperation('query', { key: 3, query });
 
     expect(data).toBe(undefined);
@@ -1240,8 +1252,8 @@ describe('commutativity', () => {
           __typename: 'Node',
           id: 'node',
           name: 'query a',
-        }
-      }
+        },
+      },
     });
 
     expect(data).toHaveProperty('node.name', 'query a');
@@ -1254,8 +1266,8 @@ describe('commutativity', () => {
           __typename: 'Node',
           id: 'node',
           name: 'mutation',
-        }
-      }
+        },
+      },
     });
 
     expect(reexec).toHaveBeenCalledTimes(1);
@@ -1269,8 +1281,8 @@ describe('commutativity', () => {
           __typename: 'Node',
           id: 'node',
           name: 'query b',
-        }
-      }
+        },
+      },
     });
 
     expect(reexec).toHaveBeenCalledTimes(2);
@@ -1279,13 +1291,11 @@ describe('commutativity', () => {
 
   it('applies optimistic updates on top of commutative queries', () => {
     let data: any;
-    const client = createClient({ url: 'http://0.0.0.0', });
+    const client = createClient({ url: 'http://0.0.0.0' });
     const { source: ops$, next: nextOp } = makeSubject<Operation>();
     const { source: res$, next: nextRes } = makeSubject<OperationResult>();
 
-    jest
-      .spyOn(client, 'reexecuteOperation')
-      .mockImplementation(nextOp);
+    jest.spyOn(client, 'reexecuteOperation').mockImplementation(nextOp);
 
     const query = gql`
       {
@@ -1308,7 +1318,10 @@ describe('commutativity', () => {
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
       merge([
-        pipe(ops$, filter(() => false)) as any,
+        pipe(
+          ops$,
+          filter(() => false)
+        ) as any,
         res$,
       ]);
 
@@ -1317,7 +1330,7 @@ describe('commutativity', () => {
         __typename: 'Node',
         id: 'node',
         name: 'optimistic',
-      })
+      }),
     };
 
     pipe(
@@ -1331,7 +1344,10 @@ describe('commutativity', () => {
     );
 
     const queryOp = client.createRequestOperation('query', { key: 1, query });
-    const mutationOp = client.createRequestOperation('mutation', { key: 2, query: mutation });
+    const mutationOp = client.createRequestOperation('mutation', {
+      key: 2,
+      query: mutation,
+    });
 
     expect(data).toBe(undefined);
 
@@ -1346,8 +1362,8 @@ describe('commutativity', () => {
           __typename: 'Node',
           id: 'node',
           name: 'query a',
-        }
-      }
+        },
+      },
     });
 
     expect(data).toHaveProperty('node.name', 'optimistic');
@@ -1360,8 +1376,8 @@ describe('commutativity', () => {
           __typename: 'Node',
           id: 'node',
           name: 'mutation',
-        }
-      }
+        },
+      },
     });
 
     expect(data).toHaveProperty('node.name', 'mutation');
@@ -1369,13 +1385,11 @@ describe('commutativity', () => {
 
   it('allows subscription results to be commutative when necessary', () => {
     let data: any;
-    const client = createClient({ url: 'http://0.0.0.0', });
+    const client = createClient({ url: 'http://0.0.0.0' });
     const { source: ops$, next: nextOp } = makeSubject<Operation>();
     const { source: res$, next: nextRes } = makeSubject<OperationResult>();
 
-    jest
-      .spyOn(client, 'reexecuteOperation')
-      .mockImplementation(nextOp);
+    jest.spyOn(client, 'reexecuteOperation').mockImplementation(nextOp);
 
     const query = gql`
       {
@@ -1397,7 +1411,10 @@ describe('commutativity', () => {
 
     const forward = (ops$: Source<Operation>): Source<OperationResult> =>
       merge([
-        pipe(ops$, filter(() => false)) as any,
+        pipe(
+          ops$,
+          filter(() => false)
+        ) as any,
         res$,
       ]);
 
@@ -1412,7 +1429,10 @@ describe('commutativity', () => {
     );
 
     const queryOpA = client.createRequestOperation('query', { key: 1, query });
-    const subscriptionOp = client.createRequestOperation('subscription', { key: 3, query: subscription });
+    const subscriptionOp = client.createRequestOperation('subscription', {
+      key: 3,
+      query: subscription,
+    });
 
     nextOp(queryOpA);
     // Force commutative layers to be created:
@@ -1427,8 +1447,8 @@ describe('commutativity', () => {
           __typename: 'Node',
           id: 'node',
           name: 'query a',
-        }
-      }
+        },
+      },
     });
 
     nextRes({
@@ -1438,10 +1458,9 @@ describe('commutativity', () => {
           __typename: 'Node',
           id: 'node',
           name: 'subscription',
-        }
-      }
+        },
+      },
     });
-
 
     expect(data).toHaveProperty('node.name', 'subscription');
   });

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -231,6 +231,7 @@ describe('commutative changes', () => {
 
     // Actively clearing out layer 2
     InMemoryData.clearLayer(data, 2);
+    InMemoryData.noopDataState(data, 2);
 
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(undefined);

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -103,13 +103,8 @@ export const clearDataState = () => {
     // Squash all layers in reverse order (low priority upwards) that have
     // been written already
     let i = data.optimisticOrder.length;
-    while (--i >= commutativeIndex) {
-      if (data.refLock[data.optimisticOrder[i]]) {
-        squashLayer(data.optimisticOrder[i]);
-      } else {
-        break;
-      }
-    }
+    while (--i >= commutativeIndex && data.refLock[data.optimisticOrder[i]])
+      squashLayer(data.optimisticOrder[i]);
   }
 
   currentData = null;

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -111,11 +111,12 @@ export const clearDataState = () => {
     // Squash all layers in reverse order (low priority upwards) that have
     // been written already
     let i = data.optimisticOrder.length;
-    while (--i >= commutativeIndex && data.refLock[data.optimisticOrder[i]]) {
-      // We ignore optimistic layers here
-      if (data.commutativeKeys.has(data.optimisticOrder[i])) {
-        squashLayer(data.optimisticOrder[i]);
-      }
+    while (
+      --i >= commutativeIndex &&
+      data.refLock[data.optimisticOrder[i]] &&
+      data.commutativeKeys.has(data.optimisticOrder[i])
+    ) {
+      squashLayer(data.optimisticOrder[i]);
     }
   }
 

--- a/scripts/rollup/settings.js
+++ b/scripts/rollup/settings.js
@@ -47,4 +47,4 @@ export const hasReact = externalModules.includes('react');
 export const hasPreact = externalModules.includes('preact');
 export const hasSvelte = externalModules.includes('svelte');
 export const mayReexport = hasReact || hasPreact || hasSvelte;
-export const isCI = !!process.env.CI;
+export const isCI = !!process.env.CIRCLECI;


### PR DESCRIPTION
## Summary

This will now apply mutations (including optimistic updates for mutations) commutatively. Before the ordering was a little confusing in that overlapping queries and mutations would have data from the queries always take precedence, which isn't always expected.

## Changes

- Remove direct `clearLayer` calls and instead have `initDataState` clean up optimistic updates.
- Let `commutativeKeys` in `data.ts` keep track of commutative query layers, while optimistic layers are only added to `optimisticOrder`
- Add consistent ordering of `optimisticOrder` instead of prioritising optimistic updates
- Prevent squashing layers when a layer has only optimistic results