### PR TITLE
(docs) - Add docs for the retryExchange

### DIFF
--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -14,4 +14,5 @@ chapter.](../concepts/README.md)
 - [**Server-side Rendering**](./server-side-rendering.md) guides us through how to set up server-side rendering and rehydration.
 - [**Auto-populate Mutations**](./auto-populate-mutations.md) presents the `populateExchange` addon which can make it easier to
   update normalized data after mutations.
+- [**Retrying operations**](./retry-operations.md) shows the `retryExchange` which allows you to retry operations when they've failed.
 - [**Testing**](./testing.md) covers how to test components that use `urql` particularly in React.

--- a/docs/advanced/retry-operations.md
+++ b/docs/advanced/retry-operations.md
@@ -1,0 +1,92 @@
+---
+title: Retrying operations
+order: 4
+---
+
+# Retrying operations
+
+The `retryExchange` lets us retry specific operation, by default it will
+retry only `network errors` but we can specify additional options to add
+functionality.
+
+## Installation and Setup
+
+First install `@urql/exchange-retry` alongside `urql`:
+
+```sh
+yarn add @urql/exchange-retry
+# or
+npm install --save @urql/exchange-retry
+```
+
+You'll then need to add the `retryExchange`, exposed by this package, to your `urql` Client:
+
+```js
+import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql';
+import { retryExchange } from '@urql/exchange-retry';
+
+// None of these options have to be added, these are the default values.
+const options = {
+  initialDelayMs: 1000,
+  maxDelayMs: 15000,
+  randomDelay: true,
+  maxNumberAttempts: 2,
+  retryIf: err => err && err.networkError,
+};
+
+const client = createClient({
+  url: 'http://localhost:1234/graphql',
+  exchanges: [
+    dedupExchange,
+    cacheExchange,
+    fetchExchange,
+    retryExchange(options), // Use the retryExchange factory to add a new exchange
+  ],
+});
+```
+
+We want to place the `retryExchange` after the `fetchExchange` so that retries are only performed _after_ the operation has passed through the cache and has attempted to fetch.
+
+## The options
+
+We have a set of options allowing us to control the `retry` mechanism, let's take a look, we have the `initialDelayMs` to
+specify at what interval the `retrying` should start, this means that if we specify `1000` that when our `operation` fails
+we'll wait 1 second and then retry it.
+
+Next up is the `maxDelayMs`, our `retryExchange` will keep increasing the time between retries so we don't spam our server with
+requests it can't complete, this option ensures we don't exceed a certain threshold. This time between requests
+will increase with a random `back-off` factor multiplied by the `initialDelayMs`, read more about the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem).
+
+Talking about increasing the `delay` randomly, `randomDelay` allows us to disable this. When this option is set to `false` we'll only increase
+the time between attempts with the `initialDelayMs`. This means if we fail the first time we'll have 1 second wait, next fail we'll have 2 seconds and so on.
+
+We don't want to infinitley attempt an `operation`, we can declare how many times it should attempt the `operation` with `maxNumberAttempts`.
+
+## Reacting to different errors
+
+We can introduce specific triggers for the `retryExchange` to start retrying operations,
+let's look at an example:
+
+```js
+import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql';
+import { retryExchange } from '@urql/exchange-retry';
+
+const client = createClient({
+  url: 'http://localhost:1234/graphql',
+  exchanges: [
+    dedupExchange,
+    cacheExchange,
+    fetchExchange,
+    retryExchange({
+      retryIf: error => {
+        if ((error && error.graphQLErrors.length > 0) || error.networkError) {
+          return true;
+        }
+      },
+    }),
+  ],
+});
+```
+
+In the above example we'll retry when we have `graphQLErrors` or a `networkError`, we can go
+more granular and check for certain errors in `graphQLErrors`.

--- a/docs/advanced/retry-operations.md
+++ b/docs/advanced/retry-operations.md
@@ -6,7 +6,7 @@ order: 4
 # Retrying Operations
 
 The `retryExchange` lets us retry specific operation, by default it will
-retry only `network errors` but we can specify additional options to add
+retry only network errors but we can specify additional options to add
 functionality.
 
 ## Installation and Setup
@@ -61,7 +61,7 @@ Talking about increasing the `delay` randomly, `randomDelay` allows us to disabl
 
 We don't want to infinitley attempt an `operation`, we can declare how many times it should attempt the `operation` with `maxNumberAttempts`.
 
-[For more information on the available options check out the API Docs.](../api/retryExchange.md)
+[For more information on the available options check out the API Docs.](../api/retry-exchange.md)
 
 ## Reacting to Different Errors
 

--- a/docs/advanced/retry-operations.md
+++ b/docs/advanced/retry-operations.md
@@ -51,14 +51,17 @@ We want to place the `retryExchange` after the `fetchExchange` so that retries a
 
 ## The Options
 
-There are a set of optional options that allow for fine-grained control over the `retry` mechanism:
+There are a set of optional options that allow for fine-grained control over the `retry` mechanism.
 
-- `initialDelayMs`: Specify at what interval the `retrying` should start, this means that if we specify `1000` that when our `operation` fails we'll wait 1 second and then retry it.
+We have the `initialDelayMs` to specify at what interval the `retrying` should start, this means that if we specify `1000` that when our `operation` fails we'll wait 1 second and then retry it.
 
-- `maxDelayMs`: The maximum delay between retries. The `retryExchange` will keep increasing the time between retries so that the server doesn't receive simultaneous requests it can't complete. This time between requests will increase with a random `back-off` factor applied to the `initialDelayMs`, read more about the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem).
-- `randomDelay`: Allows the randomized delay described above to be disabled. When this option is set to `false` there will be exactly a `initialDelayMs` wait between each retry.
-- `maxNumberAttempts`: Allows the max number of retries to be defined.
-- `retryIf`: Apply a custom test to the returned error to determine whether it should be retried.
+Next up is the `maxDelayMs`, our `retryExchange` will keep increasing the time between retries so we don't spam our server with requests it can't complete, this option ensures we don't exceed a certain threshold. This time between requests will increase with a random `back-off` factor multiplied by the `initialDelayMs`, read more about the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem).
+
+Talking about increasing the `delay` randomly, `randomDelay` allows us to disable this. When this option is set to `false` we'll only increase the time between attempts with the `initialDelayMs`. This means if we fail the first time we'll have 1 second wait, next fail we'll have 2 seconds and so on.
+
+We don't want to infinitley attempt an `operation`, we can declare how many times it should attempt the `operation` with `maxNumberAttempts`.
+
+[For more information on the available options check out the API Docs.](../api/retryExchange.md)
 
 ## Reacting to Different Errors
 

--- a/docs/advanced/retry-operations.md
+++ b/docs/advanced/retry-operations.md
@@ -34,13 +34,15 @@ const options = {
   retryIf: err => err && err.networkError,
 };
 
+// Note the position of the retryExchange - it should be placed prior to the
+// fetchExchange and after the cacheExchange for it to function correctly
 const client = createClient({
   url: 'http://localhost:1234/graphql',
   exchanges: [
     dedupExchange,
     cacheExchange,
-    fetchExchange,
     retryExchange(options), // Use the retryExchange factory to add a new exchange
+    fetchExchange,
   ],
 });
 ```

--- a/docs/advanced/retry-operations.md
+++ b/docs/advanced/retry-operations.md
@@ -49,18 +49,14 @@ We want to place the `retryExchange` after the `fetchExchange` so that retries a
 
 ## The Options
 
-We have a set of options allowing us to control the `retry` mechanism, let's take a look, we have the `initialDelayMs` to
-specify at what interval the `retrying` should start, this means that if we specify `1000` that when our `operation` fails
-we'll wait 1 second and then retry it.
+There are a set of optional options that allow for fine-grained control over the `retry` mechanism:
 
-Next up is the `maxDelayMs`, our `retryExchange` will keep increasing the time between retries so we don't spam our server with
-requests it can't complete, this option ensures we don't exceed a certain threshold. This time between requests
-will increase with a random `back-off` factor multiplied by the `initialDelayMs`, read more about the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem).
+- `initialDelayMs`: Specify at what interval the `retrying` should start, this means that if we specify `1000` that when our `operation` fails we'll wait 1 second and then retry it.
 
-Talking about increasing the `delay` randomly, `randomDelay` allows us to disable this. When this option is set to `false` we'll only increase
-the time between attempts with the `initialDelayMs`. This means if we fail the first time we'll have 1 second wait, next fail we'll have 2 seconds and so on.
-
-We don't want to infinitley attempt an `operation`, we can declare how many times it should attempt the `operation` with `maxNumberAttempts`.
+- `maxDelayMs`: The maximum delay between retries. The `retryExchange` will keep increasing the time between retries so that the server doesn't receive simultaneous requests it can't complete. This time between requests will increase with a random `back-off` factor applied to the `initialDelayMs`, read more about the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem).
+- `randomDelay`: Allows the randomized delay described above to be disabled. When this option is set to `false` there will be exactly a `initialDelayMs` wait between each retry.
+- `maxNumberAttempts`: Allows the max number of retries to be defined.
+- `retryIf`: Apply a custom test to the returned error to determine whether it should be retried.
 
 ## Reacting to Different Errors
 

--- a/docs/advanced/retry-operations.md
+++ b/docs/advanced/retry-operations.md
@@ -1,9 +1,9 @@
 ---
-title: Retrying operations
+title: Retrying Operations
 order: 4
 ---
 
-# Retrying operations
+# Retrying Operations
 
 The `retryExchange` lets us retry specific operation, by default it will
 retry only `network errors` but we can specify additional options to add
@@ -47,7 +47,7 @@ const client = createClient({
 
 We want to place the `retryExchange` after the `fetchExchange` so that retries are only performed _after_ the operation has passed through the cache and has attempted to fetch.
 
-## The options
+## The Options
 
 We have a set of options allowing us to control the `retry` mechanism, let's take a look, we have the `initialDelayMs` to
 specify at what interval the `retrying` should start, this means that if we specify `1000` that when our `operation` fails
@@ -62,7 +62,7 @@ the time between attempts with the `initialDelayMs`. This means if we fail the f
 
 We don't want to infinitley attempt an `operation`, we can declare how many times it should attempt the `operation` with `maxNumberAttempts`.
 
-## Reacting to different errors
+## Reacting to Different Errors
 
 We can introduce specific triggers for the `retryExchange` to start retrying operations,
 let's look at an example:

--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing
-order: 4
+order: 5
 ---
 
 # Testing

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -15,3 +15,4 @@ more about the core package on the "Core Package" page.](../concepts/core-packag
 - [`urql` React API docs](./urql.md)
 - [`@urql/preact` Preact API docs](./preact.md)
 - [`@urql/exchange-graphcache` API docs](./graphcache.md)
+- [`@urql/exchange-retry` API docs](./retry-exchange.md)

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -204,7 +204,7 @@ properties you'll likely see some options that exist on the `Client` as well.
 | meta                | `?OperationDebugMeta`                 | Metadata that is only available in development for devtools.                                                          |
 | suspense            | `?boolean`                            | Whether suspense is enabled.                                                                                          |
 | preferGetMethod     | `?number`                             | Instructs the `fetchExchange` to use HTTP GET for queries.                                                            |
-| additionalTypenames | `?number`                             | Allows you to tell the operation that it depends on certain typenames (used in document-cache.)              |
+| additionalTypenames | `?number`                             | Allows you to tell the operation that it depends on certain typenames (used in document-cache.)                       |
 
 It also accepts additional, untyped parameters that can be used to send more
 information to custom exchanges.

--- a/docs/api/retry-exchange.md
+++ b/docs/api/retry-exchange.md
@@ -5,7 +5,14 @@ order: 0
 
 # Retry Exchange
 
-## Available Options
+The `@urql/exchange-retry` package contains an addon `retryExchange` for `urql` that may be used to
+let failed operations be retried, typically when a previous operation has failed with a network
+error.
+
+[Read more about how to use and configure the `retryExchange` on the "Retry Operations"
+page.](../advanced/retry-operations.md)
+
+## Options
 
 | Option              | Description                                                                                                                                                                                                                                                                                                                                                                                      |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/api/retry-exchange.md
+++ b/docs/api/retry-exchange.md
@@ -1,6 +1,6 @@
 ---
 title: @urql/exchange-retry
-order: 0
+order: 4
 ---
 
 # Retry Exchange

--- a/docs/api/retryExchange.md
+++ b/docs/api/retryExchange.md
@@ -1,0 +1,16 @@
+---
+title: @urql/exchange-retry
+order: 0
+---
+
+# Retry Exchange
+
+## Available Options
+
+| Option              | Description                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `initialDelayMs`    | Specify at what interval the `retrying` should start, this means that if we specify `1000` that when our `operation` fails we'll wait 1 second and then retry it.                                                                                                                                                                                                                                |
+| `maxDelayMs`        | The maximum delay between retries. The `retryExchange` will keep increasing the time between retries so that the server doesn't receive simultaneous requests it can't complete. This time between requests will increase with a random `back-off` factor applied to the `initialDelayMs`, read more about the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem). |
+| `randomDelay`       | Allows the randomized delay described above to be disabled. When this option is set to `false` there will be exactly a `initialDelayMs` wait between each retry.                                                                                                                                                                                                                                 |
+| `maxNumberAttempts` | Allows the max number of retries to be defined.                                                                                                                                                                                                                                                                                                                                                  |
+| `retryIf`           | Apply a custom test to the returned error to determine whether it should be retried.                                                                                                                                                                                                                                                                                                             |

--- a/docs/concepts/exchanges.md
+++ b/docs/concepts/exchanges.md
@@ -20,6 +20,13 @@ The default set of exchanges that `@urql/core` contains and applies to a `Client
 - `cacheExchange`: The default caching logic with ["Document Caching"](../basics/document-caching.md)
 - `fetchExchange`: Sends an operation to the API using `fetch` and adds results to the output stream
 
+Other available exchanges:
+
+- `retryExchange`: Allows operations to be retried
+- `devtoolsExchange`: Provides the ability to use the [urql-devtools](https://github.com/FormidableLabs/urql-devtools)
+- `multipartFetchExchange`: Provides multipart file upload capability
+- `suspenseExchange` (experimental): Allows the use of React Suspense on the client-side with `urql`'s built-in suspense mode
+
 It is also possible to apply custom exchanges to override the default logic.
 
 ## An Exchange Signature

--- a/exchanges/retry/README.md
+++ b/exchanges/retry/README.md
@@ -12,4 +12,4 @@ yarn add @urql/exchange-retry
 npm install --save @urql/exchange-retry
 ```
 
-Read more about the [exchange](https://formidable.com/open-source/urql/docs/advanced/retry-operations)
+Read more about the [retry exchange](https://formidable.com/open-source/urql/docs/advanced/retry-operations).

--- a/exchanges/retry/README.md
+++ b/exchanges/retry/README.md
@@ -2,18 +2,6 @@
 
 `@urql/exchange-retry` is an exchange for the [`urql`](../../README.md) GraphQL client that allows operations (queries, mutations, subscriptions) to be retried based on an `options` parameter.
 
-The `retryExchange` is of type `Options => Exchange`.
-
-It periodically retries requests that fail due to network errors. It accepts five optional options:
-
-- `initialDelayMs` - the minimum delay between retries, defaults to 1000
-- `maxDelayMs` - the maximum delay that can be applied to an operation, defaults to 15000
-- `randomDelay` - whether to apply a random delay to protect against thundering herd, defaults to true
-- `maxNumberAttempts` - the maximum number of attempts to retry any given operation, defaults to Infinity
-- `retryIf` - optional function to apply to errors to determine whether they should be retried
-
-The `retryExchange` will exponentially increase the delay from `minDelayMs` up to `maxDelayMs` with some random jitter added to avoid the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem).
-
 ## Quick Start Guide
 
 First install `@urql/exchange-retry` alongside `urql`:
@@ -24,52 +12,4 @@ yarn add @urql/exchange-retry
 npm install --save @urql/exchange-retry
 ```
 
-You'll then need to add the `retryExchange`, that this package exposes, to your
-`urql` Client:
-
-```js
-import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql';
-import { retryExchange } from '@urql/exchange-retry';
-
-const options = {
-  initialDelayMs: 50,
-  maxDelayMs: 500,
-  randomDelay: true,
-  maxNumberAttempts: 10,
-  retryIf: err => err.message === '[GraphQL] Error Message A',
-};
-
-const client = createClient({
-  url: 'http://localhost:1234/graphql',
-  exchanges: [
-    dedupExchange,
-    cacheExchange,
-    fetchExchange,
-    retryExchange(options), // Use the retryExchange factory to add a new exchange
-  ],
-});
-```
-
-You'll likely want to place the `retryExchange` after the `fetchExchange` so that retries are only performed _after_ the operation has passed through the cache and has attempted to fetch.
-
-## Usage
-
-After installing `@urql/exchange-retry` and adding it to your `urql` client, `urql` will retry operations based on the options passed to the `retryExchange`.
-
-```js
-import React from 'react';
-import { useQuery } from 'urql';
-
-const LoadingIndicator = () => <h1>Loading...</h1>;
-
-const YourContent = () => {
-  const [{ fetching, data }] = useQuery({ query: allPostsQuery });
-  // Unlike a normal query, if the first request resulted in an error,
-  // the query will be automatically retried based on the `retryExchange` options
-  return !fetching && <div>{data}</div>;
-};
-
-return <YourContent />;
-```
-
-<!-- TODO?: Add code sandbox demo -->
+Read more about the [exchange](https://formidable.com/open-source/urql/docs/advanced/retry-operations)


### PR DESCRIPTION
This made me realise that we maybe need a way to react to for instance `rate limiting`, example: `waitFor(err) => number` and maybe something to react to `unauthorized` so the user can refetch a token. What do you think?

We'll also need a page to put the exchanges that don't need a lot of words:
- devtools (can become a dedicated page if we move the readme in the docs but is a sep repo)
- multipart-fetch