### PR TITLE
(core) - Fix ssrExchange not serializing extensions or path on GraphQLError

### DIFF
--- a/.changeset/green-owls-pump.md
+++ b/.changeset/green-owls-pump.md
@@ -1,5 +1,6 @@
 ---
 '@urql/core': patch
+'next-urql': patch
 ---
 
 Add missing GraphQLError serialization for extensions and path field to ssrExchange

--- a/.changeset/green-owls-pump.md
+++ b/.changeset/green-owls-pump.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Add missing GraphQLError serialization for extensions and path field to ssrExchange

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -50,7 +50,7 @@ export class CombinedError extends Error {
     response,
   }: {
     networkError?: Error;
-    graphQLErrors?: Array<string | GraphQLError | Error>;
+    graphQLErrors?: Array<string | Partial<GraphQLError> | Error>;
     response?: any;
   }) {
     const normalizedGraphQLErrors = (graphQLErrors || []).map(

--- a/packages/next-urql/src/types.ts
+++ b/packages/next-urql/src/types.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from 'graphql';
 import { NextPageContext } from 'next';
 import { ClientOptions, Exchange, Client } from 'urql';
 import { AppContext } from 'next/app';
@@ -38,8 +39,8 @@ export interface WithUrqlProps extends WithUrqlClient, WithUrqlState {
 export interface SerializedResult {
   data?: any;
   error?: {
+    graphQLErrors: Array<Partial<GraphQLError> | string>;
     networkError?: string;
-    graphQLErrors: string[];
   };
 }
 


### PR DESCRIPTION
Resolves #562

## Summary

This adds the missing serialization for `GraphQLError`s to the `ssrExchange` when the `GraphQLError` carries the `extensions` or `path` fields. These fields should be preserved even after server-side rendering so that it's possible to pass on metadata from the server-side to the client-side.

The `extensions` field is often used to carry error code or types.

## Set of changes

- Add conditional `GraphQLError` serialization to `ssrExchange`
- Allow `Partial<GraphQLError>` as input for `CombinedError`
