### PR TITLE
(graphcache) - Expose data on write and writeOptimistic results

### DIFF
--- a/.changeset/metal-otters-mate.md
+++ b/.changeset/metal-otters-mate.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Expose generated result data on writeOptimistic and passthrough data on write operations.

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -37,6 +37,7 @@ import {
 } from './shared';
 
 export interface WriteResult {
+  data: null | Data;
   dependencies: Set<string>;
 }
 
@@ -59,7 +60,7 @@ export const startWrite = (
   data: Data
 ) => {
   const operation = getMainOperation(request.query);
-  const result: WriteResult = { dependencies: getCurrentDependencies() };
+  const result: WriteResult = { data, dependencies: getCurrentDependencies() };
   const operationName = store.rootFields[operation.operation];
 
   const ctx = makeContext(
@@ -75,7 +76,6 @@ export const startWrite = (
   }
 
   writeSelection(ctx, operationName, getSelectionSet(operation), data);
-
   return result;
 };
 
@@ -87,7 +87,10 @@ export const writeOptimistic = (
   initDataState(store.data, key, true);
 
   const operation = getMainOperation(request.query);
-  const result: WriteResult = { dependencies: getCurrentDependencies() };
+  const result: WriteResult = {
+    data: makeDict(),
+    dependencies: getCurrentDependencies(),
+  };
   const operationName = store.rootFields[operation.operation];
 
   invariant(
@@ -110,8 +113,7 @@ export const writeOptimistic = (
     true
   );
 
-  const data = makeDict();
-  writeSelection(ctx, operationName, getSelectionSet(operation), data);
+  writeSelection(ctx, operationName, getSelectionSet(operation), result.data!);
   clearDataState();
   return result;
 };


### PR DESCRIPTION
This is potentially a missing piece to use Graphcache to fully simulate a schema.
When simulating queries, they can be written using `write` and queried using `query`.

To simulate mutations we currently only have `writeOptimistic` + `opts.optimistic` + `opts.updates` to generate a mutation result from scratch. To get around this one would need the `writeOptimistic` result.

This can then be enriched, e.g.:

```js
import { createRequest } from '@urql/core';
import { writeOptimistic, query, write } from '@urql/exchange-graphcache';

const store = new Store(/* ... */);

/** This would fully simulate a mutation using optimistic updates, queries so that resolvers can update the data, then writes it back permanently, assuming that the resolvers return serialisable data. */
const mutation = (query, variables) => {
  const request = createRequest(query, variables);
  const result = writeOptimistic(store, request, request.key);
  result.data = query(store, request, result.data).data;
  result.data = write(store, request, result.data).data;
  return result;
};
```