### PR TITLE
(core) - fix maskTypenames clauses

### DIFF
--- a/.changeset/red-candles-decide.md
+++ b/.changeset/red-candles-decide.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Add a guard to "maskTypenames" so a null value isn't considered an object.

--- a/packages/core/src/utils/maskTypename.ts
+++ b/packages/core/src/utils/maskTypename.ts
@@ -10,7 +10,7 @@ export const maskTypename = (data: any): any => {
       });
     } else if (Array.isArray(value)) {
       acc[key] = value.map(maskTypename);
-    } else if (typeof value === 'object' && '__typename' in value) {
+    } else if (value && typeof value === 'object' && '__typename' in value) {
       acc[key] = maskTypename(value);
     } else {
       acc[key] = value;


### PR DESCRIPTION
## Summary

Fixes https://github.com/FormidableLabs/urql/issues/620

`typeof null === 'object'` so we need to check if we have a truthy value before going into this branch.

## Set of changes

- add check for `maskTypenames` to see if we are dealing with a truthy value before checking the object properties.
