### PR TITLE
(graphcache) - Fix inspectFields for uninitialized layers

### DIFF
--- a/.changeset/dull-zebras-burn.md
+++ b/.changeset/dull-zebras-burn.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix cache.inspectFields causing an undefined error for uninitialised or cleared commutative layers.

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -406,4 +406,21 @@ describe('commutative changes', () => {
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(2);
   });
+
+  it('prevents inspectFields from failing for uninitialised layers', () => {
+    InMemoryData.initDataState(data, null);
+    InMemoryData.writeRecord('Query', 'test', true);
+    InMemoryData.clearDataState();
+
+    InMemoryData.reserveLayer(data, 1);
+
+    InMemoryData.initDataState(data, null);
+    expect(InMemoryData.inspectFields('Query')).toEqual([
+      {
+        arguments: null,
+        fieldKey: 'test',
+        fieldName: 'test',
+      },
+    ]);
+  });
 });

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -312,7 +312,9 @@ const extractNodeMapFields = <T>(
   // Then extracts FieldInfo for the entity from the optimistic maps
   for (let i = 0, l = currentData!.optimisticOrder.length; i < l; i++) {
     const optimistic = map.optimistic[currentData!.optimisticOrder[i]];
-    extractNodeFields(fieldInfos, seenFieldKeys, optimistic.get(entityKey));
+    if (optimistic !== undefined) {
+      extractNodeFields(fieldInfos, seenFieldKeys, optimistic.get(entityKey));
+    }
   }
 };
 


### PR DESCRIPTION
## Summary

Resolve #625 

For any uninitialized layers, commutative or otherwise, `cache.inspectFields` would lead to an "of undefined" exception.

## Set of changes

- Fix undefined exception in `data.ts`
- Prevent regression with additional test
