### PR TITLE
(graphcache) - Add support for field-level invalidation to cache.invalidate

### DIFF
--- a/.changeset/khaki-jeans-report.md
+++ b/.changeset/khaki-jeans-report.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Allow a single field to be invalidated using cache.invalidate using two additional arguments, similar to store.resolve; This is a very small addition, so it's marked as a patch.

--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -355,16 +355,29 @@ page.](../graphcache/custom-updates.md#cacheupdatequery)
 The `cache.invalidate` method can be used to delete (i.e. "evict") an entity from the cache
 entirely. This will cause it to disappear from all queries in _Graphcache_.
 
+Its arguments are identical to [`cache.resolve`](#resolve).
+
 Since deleting an entity will lead to some queries containing missing and uncached data, calling
 `invalidate` may lead to additional GraphQL requests being sent, unless you're using [_Graphcache_'s
 "Schema Awareness" feature](../graphcache/schema-awareness.md), which takes optional fields into
 account.
 
-This method accepts a partial entity or an entity key as its only argument, similar to
+This method accepts a partial entity or an entity key as its first argument, similar to
 [`cache.resolve`](#resolve)'s first argument.
 
 ```js
 cache.invalidate({ __typename: 'Todo', id: 1 }); // Invalidates Todo:1
+```
+
+Additionally `cache.invalidate` may be used to delete specific fields only, which can be useful when
+for instance a list is supposed to be evicted from cache, where a full invalidation may be
+impossible. This is often the case when a field on the root `Query` needs to be deleted.
+
+This method therefore accepts two additional arguments, similar to [`cache.resolve`](#resolve).
+
+```js
+// Invalidates `Query.todos` with the `first: 10` argument:
+cache.invalidate('Query', 'todos', { first: 10 });
 ```
 
 ## Info

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -1,6 +1,6 @@
 import * as InMemoryData from '../store/data';
-import { OperationRequest } from '../types';
-import { Store } from '../store';
+import { Variables, OperationRequest } from '../types';
+import { Store, keyOfField } from '../store';
 import { read } from './query';
 
 export const invalidate = (store: Store, request: OperationRequest) => {
@@ -19,4 +19,27 @@ export const invalidate = (store: Store, request: OperationRequest) => {
 
   InMemoryData.unforkDependencies();
   InMemoryData.gc(store.data);
+};
+
+interface PartialFieldInfo {
+  fieldKey: string;
+}
+
+export const invalidateEntity = (
+  entityKey: string,
+  field?: string,
+  args?: Variables
+) => {
+  const fields: PartialFieldInfo[] = field
+    ? [{ fieldKey: keyOfField(field, args) }]
+    : InMemoryData.inspectFields(entityKey);
+
+  for (let i = 0, l = fields.length; i < l; i++) {
+    const { fieldKey } = fields[i];
+    if (InMemoryData.readLink(entityKey, fieldKey)) {
+      InMemoryData.writeLink(entityKey, fieldKey, undefined);
+    } else {
+      InMemoryData.writeRecord(entityKey, fieldKey, undefined);
+    }
+  }
 };

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -24,7 +24,7 @@ import { invariant } from '../helpers/help';
 
 import { read, readFragment } from '../operations/query';
 import { writeFragment, startWrite } from '../operations/write';
-import { invalidate } from '../operations/invalidate';
+import { invalidate, invalidateEntity } from '../operations/invalidate';
 import { keyOfField } from './keys';
 import * as InMemoryData from './data';
 
@@ -136,7 +136,7 @@ export class Store implements Cache {
     invalidate(this, createRequest(query, variables));
   }
 
-  invalidate(entity: Data | string) {
+  invalidate(entity: Data | string, field?: string, args?: Variables) {
     const entityKey =
       typeof entity === 'string' ? entity : this.keyOfEntity(entity);
 
@@ -151,18 +151,7 @@ export class Store implements Cache {
       19
     );
 
-    const fields = this.inspectFields(entityKey);
-    for (const field of fields) {
-      if (InMemoryData.readLink(entityKey as string, field.fieldKey)) {
-        InMemoryData.writeLink(entityKey as string, field.fieldKey, undefined);
-      } else {
-        InMemoryData.writeRecord(
-          entityKey as string,
-          field.fieldKey,
-          undefined
-        );
-      }
-    }
+    invalidateEntity(entityKey, field, args);
   }
 
   inspectFields(entity: Data | string | null): FieldInfo[] {

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -93,8 +93,8 @@ export interface Cache {
   /** @deprecated Use invalidate() instead */
   invalidateQuery(query: DocumentNode, variables?: Variables): void;
 
-  /** invalidate() invalidates an entity */
-  invalidate(entity: Data | string): void;
+  /** invalidate() invalidates an entity or a specific field of an entity */
+  invalidate(entity: Data | string, fieldName?: string, args?: Variables): void;
 
   /** updateQuery() can be used to update the data of a given query using an updater function */
   updateQuery(


### PR DESCRIPTION
## Summary

If a user wanted to quickly get rid of a list or another complex part of an entity, invalidating the entire entity may be overkill or impossible, especially if they're seeking to invalidate `Query.list` for instance.

This addition does not impact or increase the bundlesize as far as I can tell.

## Set of changes

- Move `invalidateEntity` to `operations/invalidate`
- Add support for invalidating a single field
