### PR TITLE
(graphcache) - Fix variables being filtered in operations

### DIFF
--- a/.changeset/lucky-hotels-scream.md
+++ b/.changeset/lucky-hotels-scream.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Prevent variables from being filtered and queries from being altered before they're forwarded, which prevented additional untyped variables from being used inside updater functions.

--- a/exchanges/graphcache/src/ast/index.ts
+++ b/exchanges/graphcache/src/ast/index.ts
@@ -1,4 +1,4 @@
-export { getFieldArguments, normalizeVariables } from './variables';
+export * from './variables';
 export * from './traversal';
 export * from './schemaPredicates';
 export * from './node';

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -29,6 +29,7 @@ import {
 import { query, write, writeOptimistic } from './operations';
 import { hydrateData } from './store/data';
 import { makeDict } from './helpers/dict';
+import { filterVariables, getMainOperation } from './ast';
 import { Store, noopDataState, reserveLayer } from './store';
 
 import {
@@ -143,6 +144,12 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
 
     return {
       ...operation,
+      variables: operation.variables
+        ? filterVariables(
+            getMainOperation(operation.query),
+            operation.variables
+          )
+        : operation.variables,
       query: formatDocument(operation.query),
     };
   };

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -25,12 +25,71 @@ const Todos = gql`
       text
       complete
       author {
+        __typename
         id
         name
       }
     }
   }
 `;
+
+const TodosWithoutTypename = gql`
+  query {
+    todos {
+      id
+      text
+      complete
+      author {
+        id
+        name
+      }
+    }
+  }
+`;
+
+const todosData = {
+  __typename: 'Query',
+  todos: [
+    {
+      id: '0',
+      text: 'Go to the shops',
+      complete: false,
+      __typename: 'Todo',
+      author: { id: '0', name: 'Jovi', __typename: 'Author' },
+    },
+    {
+      id: '1',
+      text: 'Pick up the kids',
+      complete: true,
+      __typename: 'Todo',
+      author: { id: '1', name: 'Phil', __typename: 'Author' },
+    },
+    {
+      id: '2',
+      text: 'Install urql',
+      complete: false,
+      __typename: 'Todo',
+      author: { id: '0', name: 'Jovi', __typename: 'Author' },
+    },
+  ],
+} as any;
+
+describe('Store', () => {
+  it('supports unformatted query documents', () => {
+    const store = new Store();
+
+    InMemoryData.initDataState(store.data, null);
+    // NOTE: This is the query without __typename annotations
+    write(store, { query: TodosWithoutTypename }, todosData);
+    InMemoryData.initDataState(store.data, null);
+
+    InMemoryData.initDataState(store.data, null);
+    const result = query(store, { query: TodosWithoutTypename });
+    InMemoryData.initDataState(store.data, null);
+
+    expect(result.data).toEqual(todosData);
+  });
+});
 
 describe('Store with KeyingConfig', () => {
   it('generates keys from custom keying function', () => {
@@ -52,7 +111,7 @@ describe('Store with KeyingConfig', () => {
 });
 
 describe('Store with OptimisticMutationConfig', () => {
-  let store, todosData;
+  let store;
 
   beforeEach(() => {
     store = new Store({
@@ -64,32 +123,6 @@ describe('Store with OptimisticMutationConfig', () => {
         },
       },
     });
-    todosData = {
-      __typename: 'Query',
-      todos: [
-        {
-          id: '0',
-          text: 'Go to the shops',
-          complete: false,
-          __typename: 'Todo',
-          author: { id: '0', name: 'Jovi', __typename: 'Author' },
-        },
-        {
-          id: '1',
-          text: 'Pick up the kids',
-          complete: true,
-          __typename: 'Todo',
-          author: { id: '1', name: 'Phil', __typename: 'Author' },
-        },
-        {
-          id: '2',
-          text: 'Install urql',
-          complete: false,
-          __typename: 'Todo',
-          author: { id: '0', name: 'Jovi', __typename: 'Author' },
-        },
-      ],
-    };
     InMemoryData.initDataState(store.data, null);
     write(store, { query: Todos }, todosData);
     InMemoryData.initDataState(store.data, null);


### PR DESCRIPTION
Resolve #559 
Resolve https://github.com/FormidableLabs/urql-exchange-graphcache/issues/146

## Summary

This allows untyped variables to be used inside operations and therefore inside updaters, which may be necessary to pass additional data to some updaters.

The filtering is preserved, it's moved to before the forwarding in `cacheExchange` however.

## Set of changes

- Refactor `cacheExchange` logic
- Add `filterVariables` and fix `normalizeVariables`
- Use `formatDocument` and `filterVariables` only when operation is forwarded
