### PR TITLE
(react-urql) - Fix React warning on cross-component updates

### DIFF
--- a/.changeset/rude-toes-chew.md
+++ b/.changeset/rude-toes-chew.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Avoid React v16.13.0's "Warning: Cannot update a component" by preventing cross-hook updates during render or initial mount.

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -47,7 +47,6 @@
     "@testing-library/react-hooks": "^3.2.1",
     "@types/react": "^16.9.19",
     "@types/react-test-renderer": "^16.9.2",
-    "@types/use-subscription": "^1.0.0",
     "graphql": "^14.6.0",
     "graphql-tag": "^2.10.1",
     "react": "^16.13.0",
@@ -62,7 +61,6 @@
   },
   "dependencies": {
     "@urql/core": "^1.10.1",
-    "use-subscription": "^1.4.0",
     "wonka": "^4.0.7"
   }
 }

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -51,22 +51,16 @@ export const useSource = <T>(source: Source<T>, init: T): T =>
         // set `hasUpdate` to avoid `getCurrentValue` trying to subscribe
         // again.
         subscribe(onValue: () => void): Unsubscribe {
-          const { unsubscribe } = pipe(
+          hasUpdate = true;
+          return pipe(
             source,
             subscribe(value => {
               if (currentSourceId === null) {
                 currentValue = value;
-                hasUpdate = true;
                 onValue();
-                hasUpdate = false;
               }
             })
-          );
-
-          return () => {
-            unsubscribe();
-            hasUpdate = false;
-          };
+          ).unsubscribe as () => void;
         },
       };
     }, [source])

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,10 +1883,6 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
 
-"@types/use-subscription@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/use-subscription/-/use-subscription-1.0.0.tgz#d146f8d834f70f50d48bd8246a481d096f11db19"
-
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -13047,13 +13043,6 @@ use-subscription@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.1.1.tgz#5509363e9bb152c4fb334151d4dceb943beaa7bb"
   integrity sha512-gk4fPTYvNhs6Ia7u8/+K7bM7sZ7O7AMfWtS+zPO8luH+zWuiGgGcrW0hL4MRWZSzXo+4ofNorf87wZwBKz2YdQ==
-
-use-subscription@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.4.0.tgz#c4e808cfed6fe6e1ac875df1369c63f3ddae9522"
-  integrity sha512-R7P7JWpeHp+dtEYsgDzIIgOmVqRfJjRjLOO0YIYk6twctUkUYe6Tz0pcabyTDGcMMRt9uMbFMfwBfxKHg9gCSw==
-  dependencies:
-    object-assign "^4.1.1"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Resolve #600 

## Summary

This prevents us from triggering updates across components in render by preventing `getCurrentValue` from being able to trigger updates in other subscriptions with a simple global flag.

## Set of changes

- Add global flag to `useSource`'s `getCurrentValue`
- Replace `use-subscription` with custom code