### PR TITLE
Fix the Node.js ESM import support for all packages

### DIFF
--- a/.changeset/thin-wombats-bake.md
+++ b/.changeset/thin-wombats-bake.md
@@ -1,0 +1,14 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/exchange-multipart-fetch': patch
+'@urql/exchange-populate': patch
+'@urql/exchange-retry': patch
+'@urql/exchange-suspense': patch
+'@urql/core': patch
+'next-urql': patch
+'@urql/preact': patch
+'urql': patch
+'@urql/svelte': patch
+---
+
+Add support for Node13

--- a/.changeset/thin-wombats-bake.md
+++ b/.changeset/thin-wombats-bake.md
@@ -11,4 +11,6 @@
 '@urql/svelte': patch
 ---
 
-Add support for Node13
+Fix Node.js Module support for v13 (experimental-modules) and v14. If your bundler doesn't support
+`.mjs` files and fails to resolve the new version, please double check your configuration for
+Webpack, or similar tools.

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -57,7 +57,7 @@
     "preset": "../../scripts/jest/preset"
   },
   "dependencies": {
-    "wonka": "^3.2.1 || ^4.0.0",
+    "wonka": "^4.0.8",
     "@urql/core": ">=1.10.2",
     "@urql/exchange-populate": ">=0.1.1"
   },

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -20,18 +20,18 @@
     "exchanges"
   ],
   "main": "dist/urql-exchange-graphcache.cjs.js",
-  "module": "dist/urql-exchange-graphcache.esm.js",
+  "module": "dist/urql-exchange-graphcache.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-graphcache.esm.js",
+      "import": "./dist/urql-exchange-graphcache.esm.mjs",
       "require": "./dist/urql-exchange-graphcache.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     },
     "./extras": {
-      "import": "./dist/urql-exchange-graphcache-extras.esm.js",
+      "import": "./dist/urql-exchange-graphcache-extras.esm.mjs",
       "require": "./dist/urql-exchange-graphcache-extras.cjs.js",
       "types": "./dist/types/extras/index.d.ts",
       "source": "./src/extras/index.ts"

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -25,16 +25,16 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "dist/urql-exchange-graphcache.esm.js",
-      "require": "dist/urql-exchange-graphcache.cjs.js",
-      "types": "dist/types/index.d.ts",
-      "source": "src/index.ts"
+      "import": "./dist/urql-exchange-graphcache.esm.js",
+      "require": "./dist/urql-exchange-graphcache.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
     },
     "./extras": {
-      "import": "dist/urql-exchange-graphcache-extras.esm.js",
-      "require": "dist/urql-exchange-graphcache-extras.cjs.js",
-      "types": "dist/types/extras/index.d.ts",
-      "source": "src/extras/index.ts"
+      "import": "./dist/urql-exchange-graphcache-extras.esm.js",
+      "require": "./dist/urql-exchange-graphcache-extras.cjs.js",
+      "types": "./dist/types/extras/index.d.ts",
+      "source": "./src/extras/index.ts"
     }
   },
   "files": [

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -22,10 +22,10 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "dist/urql-exchange-multipart-fetch.esm.js",
-      "require": "dist/urql-exchange-multipart-fetch.cjs.js",
-      "types": "dist/types/index.d.ts",
-      "source": "src/index.ts"
+      "import": "./dist/urql-exchange-multipart-fetch.esm.js",
+      "require": "./dist/urql-exchange-multipart-fetch.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
     }
   },
   "files": [

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@urql/core": ">=1.10.1",
     "extract-files": "^7.0.0",
-    "wonka": "^3.2.1 || ^4.0.0"
+    "wonka": "^4.0.8"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -17,12 +17,12 @@
     "exchanges"
   ],
   "main": "dist/urql-exchange-multipart-fetch.cjs.js",
-  "module": "dist/urql-exchange-multipart-fetch.esm.js",
+  "module": "dist/urql-exchange-multipart-fetch.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-multipart-fetch.esm.js",
+      "import": "./dist/urql-exchange-multipart-fetch.esm.mjs",
       "require": "./dist/urql-exchange-multipart-fetch.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -48,7 +48,7 @@
     "preset": "../../scripts/jest/preset"
   },
   "dependencies": {
-    "wonka": "^3.2.1 || ^4.0.0",
+    "wonka": "^4.0.8",
     "@urql/core": ">=1.9.2"
   },
   "peerDependencies": {

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -17,12 +17,12 @@
     "exchanges"
   ],
   "main": "dist/urql-exchange-populate.cjs.js",
-  "module": "dist/urql-exchange-populate.esm.js",
+  "module": "dist/urql-exchange-populate.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-populate.esm.js",
+      "import": "./dist/urql-exchange-populate.esm.mjs",
       "require": "./dist/urql-exchange-populate.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -22,10 +22,10 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "dist/urql-exchange-populate.esm.js",
-      "require": "dist/urql-exchange-populate.cjs.js",
-      "types": "dist/types/index.d.ts",
-      "source": "src/index.ts"
+      "import": "./dist/urql-exchange-populate.esm.js",
+      "require": "./dist/urql-exchange-populate.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
     }
   },
   "files": [

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -23,6 +23,14 @@
   "module": "dist/urql-exchange-retry.esm.js",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql-exchange-retry.esm.js",
+      "require": "./dist/urql-exchange-retry.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    }
+  },
   "files": [
     "LICENSE",
     "CHANGELOG.md",

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -20,12 +20,12 @@
     "retry"
   ],
   "main": "dist/urql-exchange-retry.cjs.js",
-  "module": "dist/urql-exchange-retry.esm.js",
+  "module": "dist/urql-exchange-retry.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-retry.esm.js",
+      "import": "./dist/urql-exchange-retry.esm.mjs",
       "require": "./dist/urql-exchange-retry.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.10.1",
-    "wonka": "^4.0.7"
+    "wonka": "^4.0.8"
   },
   "publishConfig": {
     "access": "public"

--- a/exchanges/suspense/package.json
+++ b/exchanges/suspense/package.json
@@ -20,12 +20,12 @@
     "suspense"
   ],
   "main": "dist/urql-exchange-suspense.cjs.js",
-  "module": "dist/urql-exchange-suspense.esm.js",
+  "module": "dist/urql-exchange-suspense.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-suspense.esm.js",
+      "import": "./dist/urql-exchange-suspense.esm.mjs",
       "require": "./dist/urql-exchange-suspense.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"

--- a/exchanges/suspense/package.json
+++ b/exchanges/suspense/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.10.1",
-    "wonka": "^4.0.7"
+    "wonka": "^4.0.8"
   },
   "publishConfig": {
     "access": "public"

--- a/exchanges/suspense/package.json
+++ b/exchanges/suspense/package.json
@@ -23,6 +23,14 @@
   "module": "dist/urql-exchange-suspense.esm.js",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql-exchange-suspense.esm.js",
+      "require": "./dist/urql-exchange-suspense.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    }
+  },
   "files": [
     "LICENSE",
     "CHANGELOG.md",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,12 +19,12 @@
     "exchanges"
   ],
   "main": "dist/urql-core.cjs.js",
-  "module": "dist/urql-core.esm.js",
+  "module": "dist/urql-core.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-core.esm.js",
+      "import": "./dist/urql-core.esm.mjs",
       "require": "./dist/urql-core.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,14 @@
   "module": "dist/urql-core.esm.js",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql-core.esm.js",
+      "require": "./dist/urql-core.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    }
+  },
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
-    "wonka": "^4.0.7"
+    "wonka": "^4.0.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/next-urql/examples/3-with-custom-exchange/package.json
+++ b/packages/next-urql/examples/3-with-custom-exchange/package.json
@@ -11,6 +11,6 @@
     "graphql-tag": "^2.10.1",
     "isomorphic-unfetch": "^3.0.0",
     "next": "^9.2.0",
-    "wonka": "^4.0.7"
+    "wonka": "^4.0.8"
   }
 }

--- a/packages/next-urql/package.json
+++ b/packages/next-urql/package.json
@@ -12,12 +12,12 @@
     "directory": "packages/next-urql"
   },
   "main": "dist/next-urql.cjs.js",
-  "module": "dist/next-urql.esm.js",
+  "module": "dist/next-urql.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/next-urql.esm.js",
+      "import": "./dist/next-urql.esm.mjs",
       "require": "./dist/next-urql.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"

--- a/packages/next-urql/package.json
+++ b/packages/next-urql/package.json
@@ -15,6 +15,14 @@
   "module": "dist/next-urql.esm.js",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/next-urql.esm.js",
+      "require": "./dist/next-urql.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    }
+  },
   "files": [
     "LICENSE",
     "CHANGELOG.md",

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -23,6 +23,14 @@
   "module": "dist/urql-preact.esm.js",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql-preact.esm.js",
+      "require": "./dist/urql-preact.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    }
+  },
   "files": [
     "LICENSE",
     "CHANGELOG.md",

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -20,12 +20,12 @@
     "preact"
   ],
   "main": "dist/urql-preact.cjs.js",
-  "module": "dist/urql-preact.esm.js",
+  "module": "dist/urql-preact.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-preact.esm.js",
+      "import": "./dist/urql-preact.esm.mjs",
       "require": "./dist/urql-preact.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@urql/core": "^1.10.2",
-    "wonka": "^4.0.6"
+    "wonka": "^4.0.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -20,12 +20,12 @@
     "react"
   ],
   "main": "dist/urql.cjs.js",
-  "module": "dist/urql.esm.js",
+  "module": "dist/urql.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql.esm.js",
+      "import": "./dist/urql.esm.mjs",
       "require": "./dist/urql.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -69,6 +69,6 @@
   },
   "dependencies": {
     "@urql/core": "^1.10.2",
-    "wonka": "^4.0.7"
+    "wonka": "^4.0.8"
   }
 }

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -23,6 +23,14 @@
   "module": "dist/urql.esm.js",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql.esm.js",
+      "require": "./dist/urql.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    }
+  },
   "files": [
     "LICENSE",
     "CHANGELOG.md",

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@urql/core": "^1.10.2",
-    "wonka": "^4.0.7"
+    "wonka": "^4.0.8"
   },
   "devDependencies": {
     "graphql": "^14.5.8",

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -23,6 +23,14 @@
   "module": "dist/urql-svelte.esm.js",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql-svelte.esm.js",
+      "require": "./dist/urql-svelte.cjs.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    }
+  },
   "files": [
     "LICENSE",
     "CHANGELOG.md",

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -20,12 +20,12 @@
     "svelte"
   ],
   "main": "dist/urql-svelte.cjs.js",
-  "module": "dist/urql-svelte.esm.js",
+  "module": "dist/urql-svelte.esm.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-svelte.esm.js",
+      "import": "./dist/urql-svelte.esm.mjs",
       "require": "./dist/urql-svelte.cjs.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"

--- a/scripts/prepare/index.js
+++ b/scripts/prepare/index.js
@@ -80,24 +80,25 @@ if (pkg.exports) {
     const entry = pkg.exports[key];
     const entryName = normalize(key);
     const bundleName = entryName ? `${name}-${entryName}` : name;
-
+    console.log('bundle', bundleName)
     invariant(
       fs.existsSync(entry.source),
       `package.json:exports["${key}"].source must exist`
     );
 
+    console.log(path.normalize(entry.require), `dist/${bundleName}.cjs.js`)
     invariant(
-      path.normalize(entry.require) === `./dist/${bundleName}.cjs.js`,
+      path.normalize(entry.require) === `dist/${bundleName}.cjs.js`,
       `package.json:exports["${key}"].require must be valid`
     );
 
     invariant(
-      path.normalize(entry.import) === `./dist/${bundleName}.esm.mjs`,
+      path.normalize(entry.import) === `dist/${bundleName}.esm.mjs`,
       `package.json:exports["${key}"].import must be valid`
     );
 
     invariant(
-      path.normalize(entry.types) === './dist/types/'
+      path.normalize(entry.types) === 'dist/types/'
         + path.relative('src', entry.source).replace(/\.ts$/, '.d.ts'),
       'package.json:types path must be valid'
     );

--- a/scripts/prepare/index.js
+++ b/scripts/prepare/index.js
@@ -39,7 +39,7 @@ invariant(
 );
 
 invariant(
-  path.normalize(pkg.module) === `dist/${name}.esm.js`,
+  path.normalize(pkg.module) === `dist/${name}.esm.mjs`,
   'package.json:module path must be valid'
 );
 
@@ -87,17 +87,17 @@ if (pkg.exports) {
     );
 
     invariant(
-      path.normalize(entry.require) === `dist/${bundleName}.cjs.js`,
+      path.normalize(entry.require) === `./dist/${bundleName}.cjs.js`,
       `package.json:exports["${key}"].require must be valid`
     );
 
     invariant(
-      path.normalize(entry.import) === `dist/${bundleName}.esm.js`,
+      path.normalize(entry.import) === `./dist/${bundleName}.esm.mjs`,
       `package.json:exports["${key}"].import must be valid`
     );
 
     invariant(
-      path.normalize(entry.types) === 'dist/types/'
+      path.normalize(entry.types) === './dist/types/'
         + path.relative('src', entry.source).replace(/\.ts$/, '.d.ts'),
       'package.json:types path must be valid'
     );

--- a/scripts/prepare/index.js
+++ b/scripts/prepare/index.js
@@ -80,13 +80,11 @@ if (pkg.exports) {
     const entry = pkg.exports[key];
     const entryName = normalize(key);
     const bundleName = entryName ? `${name}-${entryName}` : name;
-    console.log('bundle', bundleName)
     invariant(
       fs.existsSync(entry.source),
       `package.json:exports["${key}"].source must exist`
     );
 
-    console.log(path.normalize(entry.require), `dist/${bundleName}.cjs.js`)
     invariant(
       path.normalize(entry.require) === `dist/${bundleName}.cjs.js`,
       `package.json:exports["${key}"].require must be valid`

--- a/scripts/prepare/index.js
+++ b/scripts/prepare/index.js
@@ -73,34 +73,33 @@ invariant(
   'package.json:files must include "dist" and "LICENSE"'
 );
 
-if (pkg.exports) {
-  invariant(!!pkg.exports['.'], 'package.json:exports must have a "." entry');
+invariant(!!pkg.exports, 'package.json:exports must be added and have a "." entry');
+invariant(!!pkg.exports['.'], 'package.json:exports must have a "." entry');
 
-  for (const key in pkg.exports) {
-    const entry = pkg.exports[key];
-    const entryName = normalize(key);
-    const bundleName = entryName ? `${name}-${entryName}` : name;
-    invariant(
-      fs.existsSync(entry.source),
-      `package.json:exports["${key}"].source must exist`
-    );
+for (const key in pkg.exports) {
+  const entry = pkg.exports[key];
+  const entryName = normalize(key);
+  const bundleName = entryName ? `${name}-${entryName}` : name;
+  invariant(
+    fs.existsSync(entry.source),
+    `package.json:exports["${key}"].source must exist`
+  );
 
-    invariant(
-      path.normalize(entry.require) === `dist/${bundleName}.cjs.js`,
-      `package.json:exports["${key}"].require must be valid`
-    );
+  invariant(
+    entry.require === `./dist/${bundleName}.cjs.js`,
+    `package.json:exports["${key}"].require must be valid`
+  );
 
-    invariant(
-      path.normalize(entry.import) === `dist/${bundleName}.esm.mjs`,
-      `package.json:exports["${key}"].import must be valid`
-    );
+  invariant(
+    entry.import === `./dist/${bundleName}.esm.mjs`,
+    `package.json:exports["${key}"].import must be valid`
+  );
 
-    invariant(
-      path.normalize(entry.types) === 'dist/types/'
-        + path.relative('src', entry.source).replace(/\.ts$/, '.d.ts'),
-      'package.json:types path must be valid'
-    );
-  }
+  invariant(
+    entry.types === './dist/types/'
+      + path.relative('src', entry.source).replace(/\.ts$/, '.d.ts'),
+    'package.json:types path must be valid'
+  );
 }
 
 fs.copyFileSync(

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -57,7 +57,7 @@ export default [
     plugins,
     output: [
       output('cjs', '.js'),
-      output('esm', '.js'),
+      output('esm', '.mjs'),
     ],
   },
   !settings.isCI && {
@@ -65,7 +65,7 @@ export default [
     plugins: makePlugins({ isProduction: true }),
     output: [
       output('cjs', '.min.js'),
-      output('esm', '.min.js'),
+      output('esm', '.min.mjs'),
     ],
   },
 ].filter(Boolean);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15033,11 +15033,6 @@ winston@0.8.x:
     pkginfo "0.3.x"
     stack-trace "0.0.x"
 
-"wonka@^3.2.1 || ^4.0.0", wonka@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.7.tgz#b4934685bd2449367bd72ce7770bfe3e6cc8a68b"
-  integrity sha512-Uhyl2cgWCUksYtU0Jt8MSzKUqK4BVUrewWxnn1YlKL3Zco4sDcCUDkbgH0i762HJs1rtsq03cfzsCWxJKaDgVg==
-
 wonka@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.8.tgz#edab5fb3bcb060242b7a47d2aaab57a45ef69c35"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15033,10 +15033,15 @@ winston@0.8.x:
     pkginfo "0.3.x"
     stack-trace "0.0.x"
 
-"wonka@^3.2.1 || ^4.0.0", wonka@^4.0.6, wonka@^4.0.7:
+"wonka@^3.2.1 || ^4.0.0", wonka@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.7.tgz#b4934685bd2449367bd72ce7770bfe3e6cc8a68b"
   integrity sha512-Uhyl2cgWCUksYtU0Jt8MSzKUqK4BVUrewWxnn1YlKL3Zco4sDcCUDkbgH0i762HJs1rtsq03cfzsCWxJKaDgVg==
+
+wonka@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.8.tgz#edab5fb3bcb060242b7a47d2aaab57a45ef69c35"
+  integrity sha512-7JHs16U9/OxkkoytluIRfxRLML7erwWuDkE5Qgw+12ctIBjUwq+wIifzTvJXi9NDSO+Hr9I6t/huiLaeWg89vA==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Fixes: https://github.com/FormidableLabs/urql/issues/636
~Depends on: https://github.com/kitten/wonka/pull/80~ Published

## Summary

Import maps in `Node 13` apparently need the full-path, to fully fix this we'll need to upgrade Wonka as well.
