### PR TITLE
(graphcache) - Fix edge cases in operation ordering

### DIFF
--- a/.changeset/happy-keys-type.md
+++ b/.changeset/happy-keys-type.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix critical ordering bug in commutative queries and mutations. Subscriptions and queries would ad-hoc be receiving an empty optimistic layer accidentally. This leads to subscription results potentially being cleared, queries from being erased on a second write, and layers from sticking around on every second write or indefinitely. This affects versions `> 2.2.2` so please upgrade!

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1504,4 +1504,125 @@ describe('commutativity', () => {
 
     expect(data).toHaveProperty('node.name', 'subscription');
   });
+
+  it('allows subscription results to be commutative above mutations', () => {
+    let data: any;
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next: nextOp } = makeSubject<Operation>();
+    const { source: res$, next: nextRes } = makeSubject<OperationResult>();
+
+    jest.spyOn(client, 'reexecuteOperation').mockImplementation(nextOp);
+
+    const query = gql`
+      {
+        node {
+          id
+          name
+        }
+      }
+    `;
+
+    const subscription = gql`
+      subscription {
+        node {
+          id
+          name
+        }
+      }
+    `;
+
+    const mutation = gql`
+      mutation {
+        node {
+          id
+          name
+        }
+      }
+    `;
+
+    const forward = (ops$: Source<Operation>): Source<OperationResult> =>
+      merge([
+        pipe(
+          ops$,
+          filter(() => false)
+        ) as any,
+        res$,
+      ]);
+
+    pipe(
+      cacheExchange()({ forward, client })(ops$),
+      tap(result => {
+        if (result.operation.operationName === 'query') {
+          data = result.data;
+        }
+      }),
+      publish
+    );
+
+    const queryOpA = client.createRequestOperation('query', { key: 1, query });
+
+    const subscriptionOp = client.createRequestOperation('subscription', {
+      key: 2,
+      query: subscription,
+    });
+
+    const mutationOp = client.createRequestOperation('mutation', {
+      key: 3,
+      query: mutation,
+    });
+
+    nextOp(queryOpA);
+    // Force commutative layers to be created:
+    nextOp(client.createRequestOperation('query', { key: 2, query }));
+    nextOp(subscriptionOp);
+
+    nextRes({
+      operation: queryOpA,
+      data: {
+        __typename: 'Query',
+        node: {
+          __typename: 'Node',
+          id: 'node',
+          name: 'query a',
+        },
+      },
+    });
+
+    nextOp(mutationOp);
+
+    nextRes({
+      operation: mutationOp,
+      data: {
+        node: {
+          __typename: 'Node',
+          id: 'node',
+          name: 'mutation',
+        },
+      },
+    });
+
+    nextRes({
+      operation: subscriptionOp,
+      data: {
+        node: {
+          __typename: 'Node',
+          id: 'node',
+          name: 'subscription a',
+        },
+      },
+    });
+
+    nextRes({
+      operation: subscriptionOp,
+      data: {
+        node: {
+          __typename: 'Node',
+          id: 'node',
+          name: 'subscription b',
+        },
+      },
+    });
+
+    expect(data).toHaveProperty('node.name', 'subscription b');
+  });
 });

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1206,7 +1206,9 @@ describe('commutativity', () => {
     expect(reexec).toHaveBeenCalledTimes(1);
     expect(data).toHaveProperty('node.name', 'optimistic');
 
-    nextOp(queryOpB);
+    // NOTE: We purposefully skip the following:
+    // nextOp(queryOpB);
+
     nextRes({
       operation: queryOpB,
       data: {

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -423,4 +423,21 @@ describe('commutative changes', () => {
       },
     ]);
   });
+
+  it('allows reserveLayer to be called repeatedly', () => {
+    InMemoryData.reserveLayer(data, 1);
+    InMemoryData.reserveLayer(data, 1);
+    expect(data.optimisticOrder).toEqual([1]);
+    expect([...data.commutativeKeys]).toEqual([1]);
+  });
+
+  it('allows reserveLayer to be called after registering an optimistc layer', () => {
+    InMemoryData.noopDataState(data, 1, true);
+    expect(data.optimisticOrder).toEqual([1]);
+    expect(data.commutativeKeys.size).toBe(0);
+
+    InMemoryData.reserveLayer(data, 1);
+    expect(data.optimisticOrder).toEqual([1]);
+    expect([...data.commutativeKeys]).toEqual([1]);
+  });
 });

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -473,12 +473,13 @@ export const writeLink = (
 
 /** Reserves an optimistic layer and preorders it */
 export const reserveLayer = (data: InMemoryData, layerKey: number) => {
-  if (!data.commutativeKeys.has(layerKey)) {
+  if (data.optimisticOrder.indexOf(layerKey) === -1) {
     // The new layer needs to be reserved in front of all other commutative
     // keys but after all non-commutative keys (which are added by `forceUpdate`)
     data.optimisticOrder.unshift(layerKey);
-    data.commutativeKeys.add(layerKey);
   }
+
+  data.commutativeKeys.add(layerKey);
 };
 
 /** Creates an optimistic layer of links and records */


### PR DESCRIPTION
Resolve #633 

## Summary

Previously the `cacheExchange` code had trouble with results coming in "spontaneously". It also erroneously created optimistic layers for queries and mutations at the wrong time. `createLayer` exacerbated the issue by not being idempotent.

On a side note, sorry for commutativity causing issues for some of you! But we believe that it'll eventually strengthen our caching guarantees and make all caching operations more predictable in the face of timing changes. So we hope that after ironing out its flaws and adding more tests that it'll be a great addition!

## Set of changes

- Move `optimisticUpdate` logic into the later `prepareForwardedOperation` to avoid further mistakes
- Fix `noopDataState(store.data, operation.key, true /* meaning optimistic */);` from being called for all queries and mutations and replace it with `reserveLayer`
- Call `reserveLayer` for results that came in without a reservation (subscriptions need this, but queries may also need it)
- Fix `createLayer` not being idempotent
