### PR TITLE
(graphcache) - fix multipart/graphcache combination

### DIFF
--- a/.changeset/stale-plants-bow.md
+++ b/.changeset/stale-plants-bow.md
@@ -1,5 +1,6 @@
 ---
 '@urql/exchange-graphcache': patch
+'@urql/exchange-multipart-fetch': patch
 ---
 
 Fix multipart conversion, in the `extract-files` dependency (used by multipart-fetch) there is an explicit check for the constructor property of an object. This made the files unretrievable.

--- a/.changeset/stale-plants-bow.md
+++ b/.changeset/stale-plants-bow.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix multipart conversion, in the `extract-files` dependency (used by multipart-fetch) there is an explicit check for the constructor property of an object. This made the files unretrievable.

--- a/exchanges/graphcache/src/ast/variables.ts
+++ b/exchanges/graphcache/src/ast/variables.ts
@@ -53,7 +53,7 @@ export const normalizeVariables = (
   node: OperationDefinitionNode,
   input: void | object
 ): Variables => {
-  const vars = {};
+  const vars = makeDict();
   if (!input) return vars;
 
   if (node.variableDefinitions) {

--- a/exchanges/graphcache/src/ast/variables.ts
+++ b/exchanges/graphcache/src/ast/variables.ts
@@ -39,7 +39,7 @@ export const filterVariables = (
     return undefined;
   }
 
-  const vars = makeDict();
+  const vars = {};
   for (let i = 0, l = node.variableDefinitions.length; i < l; i++) {
     const name = getName(node.variableDefinitions[i].variable);
     vars[name] = input[name];
@@ -53,7 +53,7 @@ export const normalizeVariables = (
   node: OperationDefinitionNode,
   input: void | object
 ): Variables => {
-  const vars = makeDict();
+  const vars = {};
   if (!input) return vars;
 
   if (node.variableDefinitions) {

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -115,10 +115,13 @@ const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
       // Make fetch auto-append this for correctness
       delete fetchOptions.headers['content-type'];
 
-      fetchOptions.body.append('operations', JSON.stringify({
-        ...body,
-        variables: clone,
-      }));
+      fetchOptions.body.append(
+        'operations',
+        JSON.stringify({
+          ...body,
+          variables: clone,
+        })
+      );
 
       const map = {};
       let i = 0;

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -79,7 +79,8 @@ const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
         : undefined;
 
     const { context } = operation;
-    const { files } = extractFiles(operation.variables);
+    // Spreading operation.variables here in case someone made a variables with Object.create(null).
+    const { files, clone } = extractFiles({ ...operation.variables });
 
     const extraOptions =
       typeof context.fetchOptions === 'function'
@@ -114,7 +115,10 @@ const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
       // Make fetch auto-append this for correctness
       delete fetchOptions.headers['content-type'];
 
-      fetchOptions.body.append('operations', JSON.stringify(body));
+      fetchOptions.body.append('operations', JSON.stringify({
+        ...body,
+        variables: clone,
+      }));
 
       const map = {};
       let i = 0;


### PR DESCRIPTION
## Summary

The `extract-files` dependency has an explicit check for [an object](https://github.com/jaydenseric/extract-files/blob/master/src/extractFiles.mjs#L91) this makes our dictionary object not viable as a variables when combined with the multipart-fetch-exchange.

Fixes: https://github.com/FormidableLabs/urql/issues/635

## Set of changes

- Use a normal object instead of our dictionary
