### PR TITLE
(GH) - update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,0 @@
-Please follow our issue templates:
-
-- https://github.com/FormidableLabs/urql/issues/new/choose

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Spectrum
+    url: https://spectrum.chat/urql
+    about: You can visit our Spectrum for usage questions.
+


### PR DESCRIPTION
GitHub doesn't seem to support a root `ISSUE_TEMPLATE` and a set of them in a folder so I followed [this](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) and made a community health file instead.

At this moment making an issue is bugged, it won't get to the bug/question part.