### PR TITLE
Fix node-resolution for Webpack

### DIFF
--- a/.changeset/rich-camels-hunt.md
+++ b/.changeset/rich-camels-hunt.md
@@ -1,0 +1,15 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/exchange-multipart-fetch': patch
+'@urql/exchange-populate': patch
+'@urql/exchange-retry': patch
+'@urql/exchange-suspense': patch
+'@urql/core': patch
+'next-urql': patch
+'@urql/preact': patch
+'urql': patch
+'urql-docs': patch
+'@urql/svelte': patch
+---
+
+This fixes node-resolution when using Webpack, this bugged out when resolving nested modules since it would start to use pkg.json[main] instead of module.

--- a/.changeset/rich-camels-hunt.md
+++ b/.changeset/rich-camels-hunt.md
@@ -12,4 +12,5 @@
 '@urql/svelte': patch
 ---
 
-This fixes node-resolution when using Webpack, this bugged out when resolving nested modules since it would start to use pkg.json[main] instead of module.
+Fix node resolution when using Webpack, which experiences a bug where it only resolves
+`package.json:main` instead of `module` when an `.mjs` file imports a package.

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -19,20 +19,20 @@
     "formidablelabs",
     "exchanges"
   ],
-  "main": "dist/urql-exchange-graphcache.cjs.js",
-  "module": "dist/urql-exchange-graphcache.esm.mjs",
+  "main": "dist/urql-exchange-graphcache",
+  "module": "dist/urql-exchange-graphcache.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-graphcache.esm.mjs",
-      "require": "./dist/urql-exchange-graphcache.cjs.js",
+      "import": "./dist/urql-exchange-graphcache.mjs",
+      "require": "./dist/urql-exchange-graphcache.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     },
     "./extras": {
-      "import": "./dist/urql-exchange-graphcache-extras.esm.mjs",
-      "require": "./dist/urql-exchange-graphcache-extras.cjs.js",
+      "import": "./dist/urql-exchange-graphcache-extras.mjs",
+      "require": "./dist/urql-exchange-graphcache-extras.js",
       "types": "./dist/types/extras/index.d.ts",
       "source": "./src/extras/index.ts"
     }

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -57,9 +57,9 @@
     "preset": "../../scripts/jest/preset"
   },
   "dependencies": {
-    "wonka": "^4.0.8",
     "@urql/core": ">=1.10.3",
-    "@urql/exchange-populate": ">=0.1.2"
+    "@urql/exchange-populate": ">=0.1.2",
+    "wonka": "^4.0.9"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -16,14 +16,14 @@
     "formidablelabs",
     "exchanges"
   ],
-  "main": "dist/urql-exchange-multipart-fetch.cjs.js",
-  "module": "dist/urql-exchange-multipart-fetch.esm.mjs",
+  "main": "dist/urql-exchange-multipart-fetch",
+  "module": "dist/urql-exchange-multipart-fetch.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-multipart-fetch.esm.mjs",
-      "require": "./dist/urql-exchange-multipart-fetch.cjs.js",
+      "import": "./dist/urql-exchange-multipart-fetch.mjs",
+      "require": "./dist/urql-exchange-multipart-fetch.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     }

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@urql/core": ">=1.10.3",
     "extract-files": "^7.0.0",
-    "wonka": "^4.0.8"
+    "wonka": "^4.0.9"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -16,14 +16,14 @@
     "formidablelabs",
     "exchanges"
   ],
-  "main": "dist/urql-exchange-populate.cjs.js",
-  "module": "dist/urql-exchange-populate.esm.mjs",
+  "main": "dist/urql-exchange-populate",
+  "module": "dist/urql-exchange-populate.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-populate.esm.mjs",
-      "require": "./dist/urql-exchange-populate.cjs.js",
+      "import": "./dist/urql-exchange-populate.mjs",
+      "require": "./dist/urql-exchange-populate.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     }

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -48,8 +48,8 @@
     "preset": "../../scripts/jest/preset"
   },
   "dependencies": {
-    "wonka": "^4.0.8",
-    "@urql/core": ">=1.10.3"
+    "@urql/core": ">=1.10.3",
+    "wonka": "^4.0.9"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -19,14 +19,14 @@
     "react",
     "retry"
   ],
-  "main": "dist/urql-exchange-retry.cjs.js",
-  "module": "dist/urql-exchange-retry.esm.mjs",
+  "main": "dist/urql-exchange-retry",
+  "module": "dist/urql-exchange-retry.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-retry.esm.mjs",
-      "require": "./dist/urql-exchange-retry.cjs.js",
+      "import": "./dist/urql-exchange-retry.mjs",
+      "require": "./dist/urql-exchange-retry.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     }

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.10.3",
-    "wonka": "^4.0.8"
+    "wonka": "^4.0.9"
   },
   "publishConfig": {
     "access": "public"

--- a/exchanges/suspense/package.json
+++ b/exchanges/suspense/package.json
@@ -19,14 +19,14 @@
     "react",
     "suspense"
   ],
-  "main": "dist/urql-exchange-suspense.cjs.js",
-  "module": "dist/urql-exchange-suspense.esm.mjs",
+  "main": "dist/urql-exchange-suspense",
+  "module": "dist/urql-exchange-suspense.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-suspense.esm.mjs",
-      "require": "./dist/urql-exchange-suspense.cjs.js",
+      "import": "./dist/urql-exchange-suspense.mjs",
+      "require": "./dist/urql-exchange-suspense.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     }

--- a/exchanges/suspense/package.json
+++ b/exchanges/suspense/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.10.3",
-    "wonka": "^4.0.8"
+    "wonka": "^4.0.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,14 +18,14 @@
     "formidablelabs",
     "exchanges"
   ],
-  "main": "dist/urql-core.cjs.js",
-  "module": "dist/urql-core.esm.mjs",
+  "main": "dist/urql-core",
+  "module": "dist/urql-core.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-core.esm.mjs",
-      "require": "./dist/urql-core.cjs.js",
+      "import": "./dist/urql-core.mjs",
+      "require": "./dist/urql-core.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
-    "wonka": "^4.0.8"
+    "wonka": "^4.0.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/next-urql/package.json
+++ b/packages/next-urql/package.json
@@ -11,14 +11,14 @@
     "url": "https://github.com/FormidableLabs/urql.git",
     "directory": "packages/next-urql"
   },
-  "main": "dist/next-urql.cjs.js",
-  "module": "dist/next-urql.esm.mjs",
+  "main": "dist/next-urql",
+  "module": "dist/next-urql.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/next-urql.esm.mjs",
-      "require": "./dist/next-urql.cjs.js",
+      "import": "./dist/next-urql.mjs",
+      "require": "./dist/next-urql.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     }

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -19,14 +19,14 @@
     "exchanges",
     "preact"
   ],
-  "main": "dist/urql-preact.cjs.js",
-  "module": "dist/urql-preact.esm.mjs",
+  "main": "dist/urql-preact",
+  "module": "dist/urql-preact.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-preact.esm.mjs",
-      "require": "./dist/urql-preact.cjs.js",
+      "import": "./dist/urql-preact.mjs",
+      "require": "./dist/urql-preact.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     }

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@urql/core": "^1.10.3",
-    "wonka": "^4.0.8"
+    "wonka": "^4.0.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -69,6 +69,6 @@
   },
   "dependencies": {
     "@urql/core": "^1.10.3",
-    "wonka": "^4.0.8"
+    "wonka": "^4.0.9"
   }
 }

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -19,14 +19,14 @@
     "exchanges",
     "react"
   ],
-  "main": "dist/urql.cjs.js",
-  "module": "dist/urql.esm.mjs",
+  "main": "dist/urql",
+  "module": "dist/urql.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql.esm.mjs",
-      "require": "./dist/urql.cjs.js",
+      "import": "./dist/urql.mjs",
+      "require": "./dist/urql.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     }

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@urql/core": "^1.10.3",
-    "wonka": "^4.0.8"
+    "wonka": "^4.0.9"
   },
   "devDependencies": {
     "graphql": "^14.5.8",

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -19,14 +19,14 @@
     "exchanges",
     "svelte"
   ],
-  "main": "dist/urql-svelte.cjs.js",
-  "module": "dist/urql-svelte.esm.mjs",
+  "main": "dist/urql-svelte",
+  "module": "dist/urql-svelte.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-svelte.esm.mjs",
-      "require": "./dist/urql-svelte.cjs.js",
+      "import": "./dist/urql-svelte.mjs",
+      "require": "./dist/urql-svelte.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     }

--- a/scripts/prepare/index.js
+++ b/scripts/prepare/index.js
@@ -34,12 +34,12 @@ invariant(
 );
 
 invariant(
-  path.normalize(pkg.main) === `dist/${name}.cjs.js`,
+  path.normalize(pkg.main) === `dist/${name}.js`,
   'package.json:main path must be valid'
 );
 
 invariant(
-  path.normalize(pkg.module) === `dist/${name}.esm.mjs`,
+  path.normalize(pkg.module) === `dist/${name}.mjs`,
   'package.json:module path must be valid'
 );
 
@@ -86,12 +86,12 @@ for (const key in pkg.exports) {
   );
 
   invariant(
-    entry.require === `./dist/${bundleName}.cjs.js`,
+    entry.require === `./dist/${bundleName}.js`,
     `package.json:exports["${key}"].require must be valid`
   );
 
   invariant(
-    entry.import === `./dist/${bundleName}.esm.mjs`,
+    entry.import === `./dist/${bundleName}.mjs`,
     `package.json:exports["${key}"].import must be valid`
   );
 

--- a/scripts/prepare/index.js
+++ b/scripts/prepare/index.js
@@ -34,7 +34,7 @@ invariant(
 );
 
 invariant(
-  path.normalize(pkg.main) === `dist/${name}.js`,
+  path.normalize(pkg.main) === `dist/${name}`,
   'package.json:main path must be valid'
 );
 

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -37,8 +37,8 @@ const config = {
 };
 
 const output = (format = 'cjs', ext = '.js') => ({
-  chunkFileNames: '[hash].' + format + ext,
-  entryFileNames: '[name].' + format + ext,
+  chunkFileNames: '[hash].' + ext,
+  entryFileNames: '[name].' + ext,
   dir: './dist',
   exports: 'named',
   externalLiveBindings: false,

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -37,8 +37,8 @@ const config = {
 };
 
 const output = (format = 'cjs', ext = '.js') => ({
-  chunkFileNames: '[hash].' + ext,
-  entryFileNames: '[name].' + ext,
+  chunkFileNames: '[hash]' + ext,
+  entryFileNames: '[name]' + ext,
   dir: './dist',
   exports: 'named',
   externalLiveBindings: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15033,10 +15033,10 @@ winston@0.8.x:
     pkginfo "0.3.x"
     stack-trace "0.0.x"
 
-wonka@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.8.tgz#edab5fb3bcb060242b7a47d2aaab57a45ef69c35"
-  integrity sha512-7JHs16U9/OxkkoytluIRfxRLML7erwWuDkE5Qgw+12ctIBjUwq+wIifzTvJXi9NDSO+Hr9I6t/huiLaeWg89vA==
+wonka@^4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.9.tgz#b21d93621e1d5f3b45ca96d99d03711c7c1f7c55"
+  integrity sha512-he7Nn1254ToUN03zLbJok6QxKdRJd46/QHm8nUcJNViXQnCutCuUgAbZvzoxrX+VXzGb4sCFolC4XhkHsmvdaA==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Resolve #644 
Resolve #640 

This fixes a quirk in webpack when entering a module it would transition to using the `pkg.json[main]` for the rest of the resolution path.