### PR TITLE
(core) - Fix stringifyVariables (and thus operation keys) for Files

### DIFF
--- a/.changeset/wicked-cows-heal.md
+++ b/.changeset/wicked-cows-heal.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix stringifyVariables (and hence operation keys) for variables containing Files

--- a/.changeset/wicked-cows-heal.md
+++ b/.changeset/wicked-cows-heal.md
@@ -2,4 +2,4 @@
 '@urql/core': patch
 ---
 
-Fix stringifyVariables (and hence operation keys) for variables containing Files
+Add support for variables that contain non-plain objects without any enumerable keys, e.g. `File` or `Blob`. In this case `stringifyVariables` will now use a stable (but random) key, which means that mutations containing `File`s — or other objects like this — will now be distinct, as they should be.

--- a/packages/core/src/utils/stringifyVariables.test.ts
+++ b/packages/core/src/utils/stringifyVariables.test.ts
@@ -29,7 +29,19 @@ it('throws for circular structures', () => {
   }).toThrow();
 });
 
-it('stringifies date correctly', () => {
+it('stringifies dates correctly', () => {
   const date = new Date('2019-12-11T04:20:00');
   expect(stringifyVariables(date)).toBe(date.toJSON());
+});
+
+it('stringifies files correctly', () => {
+  const file = new File([0] as any, 'test.js');
+  Object.defineProperty(file, 'lastModified', { value: 123 });
+
+  expect(stringifyVariables(file)).toBe(
+    stringifyVariables({
+      name: 'test.js',
+      lastModified: 123,
+    })
+  );
 });

--- a/packages/core/src/utils/stringifyVariables.test.ts
+++ b/packages/core/src/utils/stringifyVariables.test.ts
@@ -34,14 +34,17 @@ it('stringifies dates correctly', () => {
   expect(stringifyVariables(date)).toBe(date.toJSON());
 });
 
+it('stringifies dictionaries (Object.create(null)) correctly', () => {
+  expect(stringifyVariables(Object.create(null))).toBe('{}');
+});
+
 it('stringifies files correctly', () => {
   const file = new File([0] as any, 'test.js');
   Object.defineProperty(file, 'lastModified', { value: 123 });
+  const str = stringifyVariables(file);
+  expect(str).toBe(stringifyVariables(file));
 
-  expect(stringifyVariables(file)).toBe(
-    stringifyVariables({
-      name: 'test.js',
-      lastModified: 123,
-    })
-  );
+  const otherFile = new File([0] as any, 'otherFile.js');
+  Object.defineProperty(otherFile, 'lastModified', { value: 234 });
+  expect(str).not.toBe(stringifyVariables(otherFile));
 });

--- a/packages/core/src/utils/stringifyVariables.ts
+++ b/packages/core/src/utils/stringifyVariables.ts
@@ -26,6 +26,8 @@ const stringify = (x: any): string => {
     return out;
   } else if (seen.has(x)) {
     throw new TypeError('Converting circular structure to JSON');
+  } else if (typeof File === 'function' && x instanceof File) {
+    return stringify({ name: x.name, lastModified: x.lastModified });
   }
 
   const keys = Object.keys(x).sort();

--- a/packages/core/src/utils/stringifyVariables.ts
+++ b/packages/core/src/utils/stringifyVariables.ts
@@ -1,4 +1,5 @@
 const seen = new Set();
+const cache = new WeakMap();
 
 const stringify = (x: any): string => {
   if (x === undefined) {
@@ -26,11 +27,18 @@ const stringify = (x: any): string => {
     return out;
   } else if (seen.has(x)) {
     throw new TypeError('Converting circular structure to JSON');
-  } else if (typeof File === 'function' && x instanceof File) {
-    return stringify({ name: x.name, lastModified: x.lastModified });
   }
 
   const keys = Object.keys(x).sort();
+  if (!keys.length && x.constructor && x.constructor !== Object) {
+    const key =
+      cache.get(x) ||
+      Math.random()
+        .toString(36)
+        .slice(2);
+    cache.set(x, key);
+    return `{"__key":"${key}"}`;
+  }
 
   seen.add(x);
   out = '{';


### PR DESCRIPTION
Resolve #649

## Summary

When two operations with a `File` in the variables are sent the operation key would likely be the same since we never take any `File` attributes into account.

We'd hence like to have special handling for objects without any enumerable keys that also aren't plain objects.

## Set of changes

- Add random (but stable) keying for objects without enumerable keys that aren't plain objects
