### PR TITLE
fix match usage

### DIFF
--- a/packages/site/src/components/scroll-to-top.js
+++ b/packages/site/src/components/scroll-to-top.js
@@ -2,14 +2,17 @@ import React, { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useMarkdownPage } from 'react-static-plugin-md-pages';
 
+const parsePathname = pathname => {
+  const match = pathname && pathname.match(/#[a-z|-]+/);
+  return match && match[1];
+};
+
 export const ScrollToTop = () => {
   const inputRef = useRef(null);
   const location = useLocation();
   const md = useMarkdownPage();
 
-  const hash =
-    location.hash ||
-    (location.pathname && location.pathname.match(/#[a-z|-]+/));
+  const hash = location.hash || parsePathname(location.pathname);
 
   useEffect(() => {
     if (hash && md) {


### PR DESCRIPTION
## Summary
I was solving a similar problem in the formidable.com rewrite, taking inspiration from this slick implementation and noticed that the value returned from `match` was not being treated as an array here.

## Set of changes
- add `parsePathname` function and handle returned value like an array
