### PR TITLE
(graphcache) - fix no selectionset mutation updates in optimistic phase

### DIFF
--- a/.changeset/tough-bats-sniff.md
+++ b/.changeset/tough-bats-sniff.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix case where a mutation-rootfield would cause an empty call to the cache.updates[mutationRootField].

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -414,9 +414,7 @@ describe('data dependencies', () => {
     const client = createClient({ url: 'http://0.0.0.0' });
     const { source: ops$, next } = makeSubject<Operation>();
 
-    jest
-      .spyOn(client, 'reexecuteOperation')
-      .mockImplementation(next);
+    jest.spyOn(client, 'reexecuteOperation').mockImplementation(next);
 
     const opMutation = client.createRequestOperation('mutation', {
       key: 1,
@@ -439,7 +437,7 @@ describe('data dependencies', () => {
     const updates = {
       Mutation: {
         concealAuthor: jest.fn(),
-      }
+      },
     };
 
     pipe(

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -396,6 +396,64 @@ describe('data dependencies', () => {
     expect(reexec).not.toHaveBeenCalled();
     expect(result).toHaveBeenCalledTimes(2);
   });
+
+  it('writes optimistic mutations to the cache', () => {
+    jest.useFakeTimers();
+
+    const mutation = gql`
+      mutation {
+        concealAuthor
+      }
+    `;
+
+    const mutationData = {
+      __typename: 'Mutation',
+      concealAuthor: true,
+    };
+
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    jest
+      .spyOn(client, 'reexecuteOperation')
+      .mockImplementation(next);
+
+    const opMutation = client.createRequestOperation('mutation', {
+      key: 1,
+      query: mutation,
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: opMutation, data: mutationData };
+        }
+
+        return undefined as any;
+      }
+    );
+
+    const result = jest.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+
+    const updates = {
+      Mutation: {
+        concealAuthor: jest.fn(),
+      }
+    };
+
+    pipe(
+      cacheExchange({ updates })({ forward, client })(ops$),
+      tap(result),
+      publish
+    );
+
+    next(opMutation);
+    expect(updates.Mutation.concealAuthor).toHaveBeenCalledTimes(0);
+
+    jest.runAllTimers();
+    expect(updates.Mutation.concealAuthor).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('optimistic updates', () => {

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -249,7 +249,7 @@ const writeSelection = (
       InMemoryData.writeRecord(entityKey || typename, fieldKey, fieldValue);
     }
 
-    if (isRoot) {
+    if (isRoot && (!ctx.optimistic || (ctx.optimistic && ctx.store.optimisticMutations[fieldName]))) {
       // We have to update the context to reflect up-to-date ResolveInfo
       updateContext(
         ctx,

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -247,9 +247,9 @@ const writeSelection = (
     } else if (entityKey && !isRoot) {
       // This is a leaf node, so we're setting the field's value directly
       InMemoryData.writeRecord(entityKey || typename, fieldKey, fieldValue);
-    }
+    } else if (ctx.optimistic && isRoot) continue;
 
-    if (isRoot && (!ctx.optimistic || (ctx.optimistic && ctx.store.optimisticMutations[fieldName]))) {
+    if (isRoot) {
       // We have to update the context to reflect up-to-date ResolveInfo
       updateContext(
         ctx,


### PR DESCRIPTION
## Summary

Their was a scenario where a mutation without selectionset would cause a call to its respective updater function.

```gql
mutation {
  someUpdate
}
```

As you can see the above has no selectionset, this would cause the `writeSelectionSet` not to check if there was an actual optimistic-entry for the current rootField

Fixes: https://github.com/FormidableLabs/urql/issues/653

## Set of changes

- fix no selectionset mutation updates in optimistic phase
