### PR TITLE
(graphcache) - optimistic support for mutations without selection

### DIFF
--- a/.changeset/twelve-trainers-sing.md
+++ b/.changeset/twelve-trainers-sing.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Support optimistic values for mutations without a selectionset

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -397,7 +397,7 @@ describe('data dependencies', () => {
     expect(result).toHaveBeenCalledTimes(2);
   });
 
-  it('writes optimistic mutations to the cache', () => {
+  it('does not reach updater when mutation has no selectionset in optimistic phase', () => {
     jest.useFakeTimers();
 
     const mutation = gql`
@@ -451,6 +451,67 @@ describe('data dependencies', () => {
 
     jest.runAllTimers();
     expect(updates.Mutation.concealAuthor).toHaveBeenCalledTimes(1);
+  });
+
+  it('does reach updater when mutation has no selectionset in optimistic phase with optimistic update', () => {
+    jest.useFakeTimers();
+
+    const mutation = gql`
+      mutation {
+        concealAuthor
+      }
+    `;
+
+    const mutationData = {
+      __typename: 'Mutation',
+      concealAuthor: true,
+    };
+
+    const client = createClient({ url: 'http://0.0.0.0' });
+    const { source: ops$, next } = makeSubject<Operation>();
+
+    jest.spyOn(client, 'reexecuteOperation').mockImplementation(next);
+
+    const opMutation = client.createRequestOperation('mutation', {
+      key: 1,
+      query: mutation,
+    });
+
+    const response = jest.fn(
+      (forwardOp: Operation): OperationResult => {
+        if (forwardOp.key === 1) {
+          return { operation: opMutation, data: mutationData };
+        }
+
+        return undefined as any;
+      }
+    );
+
+    const result = jest.fn();
+    const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
+
+    const updates = {
+      Mutation: {
+        concealAuthor: jest.fn(),
+      },
+    };
+
+    const optimistic = {
+      concealAuthor: jest.fn(() => true) as any,
+    };
+
+    pipe(
+      cacheExchange({ updates, optimistic })({ forward, client })(ops$),
+      tap(result),
+      publish
+    );
+
+    next(opMutation);
+    expect(optimistic.concealAuthor).toHaveBeenCalledTimes(1);
+    expect(updates.Mutation.concealAuthor).toHaveBeenCalledTimes(1);
+
+    jest.runAllTimers();
+    expect(updates.Mutation.concealAuthor).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -247,7 +247,16 @@ const writeSelection = (
     } else if (entityKey && !isRoot) {
       // This is a leaf node, so we're setting the field's value directly
       InMemoryData.writeRecord(entityKey || typename, fieldKey, fieldValue);
-    } else if (ctx.optimistic && isRoot) continue;
+    } else if (ctx.optimistic && isRoot) {
+      // We are dealing with a scalar root
+      const resolver = ctx.store.optimisticMutations[fieldName];
+      if (!resolver) continue;
+      // We have to update the context to reflect up-to-date ResolveInfo
+      updateContext(ctx, typename, typename, fieldKey, fieldName);
+      data[fieldName] = ensureData(
+        resolver(fieldArgs || makeDict(), ctx.store, ctx)
+      );
+    }
 
     if (isRoot) {
       // We have to update the context to reflect up-to-date ResolveInfo

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -190,7 +190,8 @@ const writeSelection = (
     const fieldName = getName(node);
     const fieldArgs = getFieldArguments(node, ctx.variables);
     const fieldKey = keyOfField(fieldName, fieldArgs);
-    let fieldValue = data[getFieldAlias(node)];
+    const fieldAlias = getFieldAlias(node);
+    let fieldValue = data[fieldAlias];
 
     if (process.env.NODE_ENV !== 'production') {
       if (!isRoot && fieldValue === undefined) {
@@ -224,7 +225,7 @@ const writeSelection = (
       if (!resolver) continue;
       // We have to update the context to reflect up-to-date ResolveInfo
       updateContext(ctx, typename, typename, fieldKey, fieldName);
-      fieldValue = data[fieldName] = ensureData(
+      fieldValue = data[fieldAlias] = ensureData(
         resolver(fieldArgs || makeDict(), ctx.store, ctx)
       );
     }
@@ -262,6 +263,7 @@ const writeSelection = (
       // so that the data is already available in-store if necessary
       const updater = ctx.store.updates[typename][fieldName];
       if (updater) {
+        data[fieldName] = fieldValue;
         updater(data, fieldArgs || makeDict(), ctx.store, ctx);
       }
     }


### PR DESCRIPTION
## Summary

This PR adds support for  adding optimistic values when there's no selectionSet for your mutation.

## Set of changes

- Add optimistic support for mutations without selectionset
