### PR TITLE
Add debugEvent dispatches for retryExchange and graphcacheExchange

### DIFF
--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -352,7 +352,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
             (policy === 'cache-first' && outcome === 'partial')
           ) {
             debugMessage +=
-              ' but is being retried due to the policy or outcome';
+              outcome === 'partial' && policy === 'cache-first' ? ' but is being retried due to the result being partial.' : ' but is being retried due to "cache-and-network.';
             result.stale = true;
             client.reexecuteOperation(
               toRequestPolicy(operation, 'network-only')

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -322,7 +322,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
       map(res => {
         client.debugTarget!.dispatchEvent({
           type: 'graphcacheMiss',
-          message: 'The operation could not be queried from the cache',
+          message: 'The result could not be retrieved from the cache',
           operation: res.operation,
         });
         return addCacheOutcome(res.operation, res.outcome);

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -287,7 +287,6 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
   };
 
   return ops$ => {
-    const dispatchEvent = client.debugTarget!.dispatchEvent;
     const sharedOps$ = pipe(ops$, share);
 
     // Buffer operations while waiting on hydration to finish
@@ -321,7 +320,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
       cache$,
       filter(res => res.outcome === 'miss'),
       map(res => {
-        dispatchEvent({
+        client.debugTarget!.dispatchEvent({
           type: 'graphcacheMiss',
           message: 'The operation could not be queried from the cache',
           operation: res.operation,
@@ -352,14 +351,16 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
             (policy === 'cache-first' && outcome === 'partial')
           ) {
             debugMessage +=
-              outcome === 'partial' && policy === 'cache-first' ? ' but is being retried due to the result being partial.' : ' but is being retried due to "cache-and-network.';
+              outcome === 'partial' && policy === 'cache-first'
+                ? ' but is being retried due to the result being partial.'
+                : ' but is being retried due to "cache-and-network".';
             result.stale = true;
             client.reexecuteOperation(
               toRequestPolicy(operation, 'network-only')
             );
           }
 
-          dispatchEvent({
+          client.debugTarget!.dispatchEvent({
             type: 'graphcacheHit',
             message: debugMessage,
             operation: res.operation,

--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -41,7 +41,7 @@ export const retryExchange = ({
   const retryIf =
     retryIfOption || ((err: CombinedError) => err && err.networkError);
 
-  return ({ forward }) => ops$ => {
+  return ({ forward, client }) => ops$ => {
     const sharedOps$ = pipe(ops$, share);
     const { source: retry$, next: nextRetryOperation } = makeSubject<
       Operation
@@ -51,7 +51,7 @@ export const retryExchange = ({
       retry$,
       mergeMap((op: Operation) => {
         const { key, context } = op;
-        const retryCount = context.retryCount || 0;
+        const retryCount = context.retryCount++ || 1;
         let delayAmount = context.retryDelay || MIN_DELAY;
 
         const backoffFactor = Math.random() + 1.5;
@@ -75,6 +75,15 @@ export const retryExchange = ({
           })
         );
 
+        client.debugTarget!.dispatchEvent({
+          type: 'retryRetrying',
+          message: 'Retrying the operation',
+          operation: op,
+          data: {
+            retryCount,
+          },
+        });
+
         // Add new retryDelay and retryCount to operation
         return pipe(
           fromValue({
@@ -82,7 +91,7 @@ export const retryExchange = ({
             context: {
               ...op.context,
               retryDelay: delayAmount,
-              retryCount: retryCount + 1,
+              retryCount,
             },
           }),
           delay(delayAmount),
@@ -97,18 +106,30 @@ export const retryExchange = ({
       forward,
       share,
       filter(res => {
-        const maxNumberAttemptsExceeded =
-          (res.operation.context.retryCount || 0) >= MAX_ATTEMPTS - 1;
         // Only retry if the error passes the conditional retryIf function (if passed)
         // or if the error contains a networkError
-        if (res.error && retryIf(res.error) && !maxNumberAttemptsExceeded) {
+        if (!res.error || !retryIf(res.error)) {
+          return true;
+        }
+
+        const maxNumberAttemptsExceeded =
+          (res.operation.context.retryCount || 0) >= MAX_ATTEMPTS - 1;
+
+        if (!maxNumberAttemptsExceeded) {
           // Send failed responses to be retried by calling next on the retry$ subject
           // Exclude operations that have been retried more than the specified max
           nextRetryOperation(res.operation);
           return false;
-        } else {
-          return true;
         }
+
+        client.debugTarget!.dispatchEvent({
+          type: 'retryMaxAttemptsReached',
+          message:
+            'Maximum number of retries has been reached. No further retries will be performed.',
+          operation: res.operation,
+        });
+
+        return true;
       })
     ) as sourceT<OperationResult>;
 

--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -51,7 +51,7 @@ export const retryExchange = ({
       retry$,
       mergeMap((op: Operation) => {
         const { key, context } = op;
-        const retryCount = context.retryCount++ || 1;
+        const retryCount = (context.retryCount || 0) + 1;
         let delayAmount = context.retryDelay || MIN_DELAY;
 
         const backoffFactor = Math.random() + 1.5;

--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -77,7 +77,7 @@ export const retryExchange = ({
 
         client.debugTarget!.dispatchEvent({
           type: 'retryRetrying',
-          message: 'Retrying the operation',
+          message: `The operation has failed and a retry has been triggered (${retryCount} / ${MAX_ATTEMPTS})`,
           operation: op,
           data: {
             retryCount,
@@ -123,7 +123,7 @@ export const retryExchange = ({
         }
 
         client.debugTarget!.dispatchEvent({
-          type: 'retryMaxAttemptsReached',
+          type: 'retryExhausted',
           message:
             'Maximum number of retries has been reached. No further retries will be performed.',
           operation: res.operation,

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -58,14 +58,19 @@ export const cacheExchange: Exchange = ({ forward, client }) => {
       map(operation => {
         const cachedResult = resultCache.get(operation.key);
 
-        if (cachedResult) {
-          client.debugTarget!.dispatchEvent({
-            type: 'cacheHit',
-            message: 'A cache hit has occured',
-            data: { value: cachedResult },
-            operation,
-          });
-        }
+        client.debugTarget!.dispatchEvent({
+          operation,
+          ...(cachedResult
+            ? {
+                type: 'cacheHit',
+                message: 'The result was successfully retried from the cache',
+                data: { value: cachedResult },
+              }
+            : {
+                type: 'cacheMiss',
+                message: 'The result could not be retrieved from the cache',
+              }),
+        });
 
         const result: OperationResult = {
           ...cachedResult,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -109,6 +109,15 @@ export interface DebugEventTypes {
     fetchOptions: RequestInit;
     value: Error;
   };
+  // Retry exchange
+  retryRetrying: {
+    retryCount: number;
+  };
+  // Graphcache Exchnage
+  graphcacheHit: {
+    policy: RequestPolicy;
+    value: OperationResult;
+  };
 }
 
 export type DebugEvent<T extends keyof DebugEventTypes | string> = {


### PR DESCRIPTION
## Changes

- As above
- Change the `retryCount` increment logic

--- 

Do you think it would be useful to log any other graphcache events that I've missed? 
