### PR TITLE
Docs: Persist sidebar routes while loading

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -46,7 +46,7 @@
     "react-router-ga": "^1.2.3",
     "react-scroll": "^1.7.15",
     "react-static": "^7.2.3",
-    "react-static-plugin-md-pages": "^0.1.7",
+    "react-static-plugin-md-pages": "^0.2.0",
     "styled-components": "^5.0.1"
   },
   "devDependencies": {

--- a/packages/site/src/components/sidebar.js
+++ b/packages/site/src/components/sidebar.js
@@ -81,17 +81,16 @@ export const SidebarStyling = ({ children, sidebarOpen, closeSidebar }) => {
 
 const Sidebar = props => {
   const location = useLocation();
-  const currentPage = useMarkdownPage();
   const tree = useMarkdownTree();
 
   const sidebarItems = useMemo(() => {
-    if (!currentPage || !tree || !tree.children || !location) {
+    let pathname = location.pathname.match(/docs\/?(.+)?/);
+
+    if (!pathname || !tree || !tree.children || !location) {
       return null;
     }
-
-    const pathname = location.pathname.endsWith('/')
-      ? currentPage.path + '/'
-      : currentPage.path;
+    pathname = pathname[0];
+    const pathnameWithoutSlash = pathname.replace(/\/$/, '');
 
     let children = tree.children;
     if (tree.frontmatter && tree.originalPath) {
@@ -102,8 +101,8 @@ const Sidebar = props => {
       const pageChildren = page.children || [];
 
       const isActive = pageChildren.length
-        ? currentPage.path.startsWith(page.path)
-        : currentPage.path === page.path;
+        ? pathnameWithoutSlash.startsWith(page.path)
+        : !!page.path.match(new RegExp(`${pathnameWithoutSlash}$`, 'g'));
 
       return (
         <Fragment key={page.key}>
@@ -119,7 +118,11 @@ const Sidebar = props => {
             <SidebarNavSubItemWrapper>
               {pageChildren.map(childPage => (
                 <SidebarNavSubItem
-                  isActive={() => childPage.path === currentPage.path}
+                  isActive={() =>
+                    !!childPage.path.match(
+                      new RegExp(`${pathnameWithoutSlash}$`, 'g')
+                    )
+                  }
                   to={relative(pathname, childPage.path)}
                   key={childPage.key}
                 >
@@ -131,7 +134,7 @@ const Sidebar = props => {
         </Fragment>
       );
     });
-  }, [currentPage, tree, location]);
+  }, [location, tree]);
 
   return <SidebarStyling {...props}>{sidebarItems}</SidebarStyling>;
 };

--- a/packages/site/src/screens/docs/index.js
+++ b/packages/site/src/screens/docs/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import Article, { ArticleStyling } from './article';
 import Header from './header';
-import Sidebar, { SidebarStyling } from '../../components/sidebar';
+import Sidebar from '../../components/sidebar';
 
 import burger from '../../assets/burger.svg';
 import closeButton from '../../assets/close.svg';
@@ -51,19 +51,11 @@ const Docs = ({ isLoading, children }) => {
           onClick={() => setSidebarOpen(prev => !prev)}
         />
         {/* load just the styles if Suspense fallback in use */}
+        <Sidebar sidebarOpen={sidebarOpen} closeSidebar={closeSidebar} />
         {isLoading ? (
-          <>
-            <SidebarStyling
-              sidebarOpen={sidebarOpen}
-              closeSidebar={closeSidebar}
-            />
-            <ArticleStyling>{children}</ArticleStyling>
-          </>
+          <ArticleStyling>{children}</ArticleStyling>
         ) : (
-          <>
-            <Sidebar sidebarOpen={sidebarOpen} closeSidebar={closeSidebar} />
-            <Article>{children}</Article>
-          </>
+          <Article>{children}</Article>
         )}
       </Container>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11752,10 +11752,10 @@ react-ssr-prepass@^1.1.2:
   dependencies:
     object-is "^1.0.2"
 
-react-static-plugin-md-pages@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/react-static-plugin-md-pages/-/react-static-plugin-md-pages-0.1.7.tgz#13f3daf1ce32fef9a77d037600572aeb752340c8"
-  integrity sha512-Y17VFyrOBMi2FqfumB5a50RHu2TbckC9LL2GMotJjL0PhbdpJBhgL6vbjEdJXoJxjk2JR93/dyZZcJmXhSL5MA==
+react-static-plugin-md-pages@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/react-static-plugin-md-pages/-/react-static-plugin-md-pages-0.2.0.tgz#5d5b70dff9fbb276da4ac76680536fa093c0da3d"
+  integrity sha512-PtcKa48bJSMvKQSA/8Pz8rxL9ZgTXIvci/BCT6OKunC7iQimSWLv1XvLr88a54SY7xq9/pPe+UkmJGNl5w+egg==
   dependencies:
     "@mdx-js/mdx" "^1.5.5"
     "@mdx-js/react" "^1.5.5"


### PR DESCRIPTION
## Changes

- Bump react-static-plugin-md-pages
- Remove useMarkdownPage dependency from sidebar
- Loading sidebar now shows routes