### PR TITLE
Fix cache-and-network/stale on client.reexecuteOperation queue

### DIFF
--- a/.changeset/curly-moons-kick.md
+++ b/.changeset/curly-moons-kick.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix oversight in edge case for #662. The operation queue wasn't marked as being active which caused `stale` results and `cache-and-network` operations from reissuing operations immediately (unqueued essentially) which would then be filtered out by the `dedupExchange`.

--- a/packages/core/src/__snapshots__/client.test.ts.snap
+++ b/packages/core/src/__snapshots__/client.test.ts.snap
@@ -6,7 +6,6 @@ Client {
   "createOperationContext": [Function],
   "createRequestOperation": [Function],
   "dispatchOperation": [Function],
-  "exchange": [Function],
   "executeMutation": [Function],
   "executeQuery": [Function],
   "executeSubscription": [Function],

--- a/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
+++ b/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { Client, defaultExchanges, composeExchanges } from 'urql';
+import { Client, defaultExchanges } from 'urql';
 
 import { withUrqlClient, NextUrqlPageContext } from '..';
 import * as init from '../init-urql-client';
@@ -122,9 +122,6 @@ describe('withUrqlClient', () => {
       const app = tree.find(MockApp);
 
       expect(app.props().urqlClient).toBeInstanceOf(Client);
-      expect(app.props().urqlClient.exchange.toString()).toEqual(
-        composeExchanges(defaultExchanges).toString()
-      );
       expect(mockMergeExchanges).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
Fix #668 

## Summary

This fixes an edge case that was missed in #662.

The queue wasn't marked as being started by the first `client.dispatchOperation`, which means that the queue is then emptied by the first `client.rexecuteOperation` call instead. This doesn't cause any issues usually, but with the `dedupExchange` we'll accidentally deduplicate reissued operations, which are usually used to implement fetching for `stale` results or `cache-and-network` operations.

## Set of changes

- Fix queuing behavior in `client.dispatchOperation`
- Add test for operation & result ordering
- Remove `client.exchange` (private variable)
