### PR TITLE
Implement new persistence logic compatible with commutativity

### DIFF
--- a/.changeset/sweet-ghosts-share.md
+++ b/.changeset/sweet-ghosts-share.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Reimplement persistence support to take commutative layers into account.

--- a/exchanges/graphcache/benchmark/suite.js
+++ b/exchanges/graphcache/benchmark/suite.js
@@ -1,6 +1,6 @@
 const gql = require('graphql-tag');
 const { InMemoryCache } = require('@apollo/client');
-const { Store, write, query } = require('../dist/urql-exchange-graphcache.cjs.min');
+const { Store, write, query } = require('../dist/urql-exchange-graphcache.min');
 
 const countries = ['UK', 'BE', 'ES', 'US'];
 

--- a/exchanges/graphcache/src/operations/invalidate.test.ts
+++ b/exchanges/graphcache/src/operations/invalidate.test.ts
@@ -42,7 +42,6 @@ describe('Query', () => {
       }
     );
 
-    InMemoryData.initDataState(store.data, null);
     jest.clearAllMocks();
   });
 
@@ -56,10 +55,17 @@ describe('Query', () => {
         }
       }
     `;
+
+    InMemoryData.initDataState(store.data, null);
     invalidate(store, { query: INVALID_TODO_QUERY });
+    InMemoryData.clearDataState();
     expect(console.warn).toHaveBeenCalledTimes(1);
+
+    InMemoryData.initDataState(store.data, null);
     invalidate(store, { query: INVALID_TODO_QUERY });
+    InMemoryData.clearDataState();
     expect(console.warn).toHaveBeenCalledTimes(1);
+
     expect((console.warn as any).mock.calls[0][0]).toMatch(/incomplete/);
   });
 
@@ -75,10 +81,17 @@ describe('Query', () => {
         }
       }
     `;
+
+    InMemoryData.initDataState(store.data, null);
     invalidate(store, { query: INVALID_TODO_QUERY });
+    InMemoryData.clearDataState();
     expect(console.warn).toHaveBeenCalledTimes(1);
+
+    InMemoryData.initDataState(store.data, null);
     invalidate(store, { query: INVALID_TODO_QUERY });
+    InMemoryData.clearDataState();
     expect(console.warn).toHaveBeenCalledTimes(1);
+
     expect((console.warn as any).mock.calls[0][0]).toMatch(/writer/);
   });
 });

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -18,7 +18,6 @@ export const invalidate = (store: Store, request: OperationRequest) => {
   });
 
   InMemoryData.unforkDependencies();
-  InMemoryData.gc(store.data);
 };
 
 interface PartialFieldInfo {

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -29,6 +29,7 @@ export const invalidateEntity = (
 export const invalidate = (store: Store, request: OperationRequest) => {
   const dependencies = InMemoryData.forkDependencies();
   read(store, request);
+  InMemoryData.unforkDependencies();
 
   dependencies.forEach(dependency => {
     if (dependency.startsWith(`${store.data.queryRootKey}.`)) {
@@ -40,6 +41,5 @@ export const invalidate = (store: Store, request: OperationRequest) => {
     }
   });
 
-  InMemoryData.unforkDependencies();
   InMemoryData.gc();
 };

--- a/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
+++ b/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`Store with storage should be able to store and rehydrate data 1`] = `
 Object {
-  "l|Query.appointment({\\"id\\":\\"1\\"})": "Appointment:1",
-  "r|Appointment:1.__typename": "Appointment",
-  "r|Appointment:1.id": "1",
-  "r|Appointment:1.info": "urql meeting",
+  "Appointment:1	__typename": "\\"Appointment\\"",
+  "Appointment:1	id": "\\"1\\"",
+  "Appointment:1	info": "\\"urql meeting\\"",
+  "Query	appointment({\\"id\\":\\"1\\"})": ":\\"Appointment:1\\"",
 }
 `;

--- a/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
+++ b/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
@@ -8,12 +8,3 @@ Object {
   "r|Appointment:1.info": "urql meeting",
 }
 `;
-
-exports[`Store with storage writes removals based on GC to storage 1`] = `
-Object {
-  "l|Query.appointment({\\"id\\":\\"1\\"})": undefined,
-  "r|Appointment:1.__typename": undefined,
-  "r|Appointment:1.id": undefined,
-  "r|Appointment:1.info": undefined,
-}
-`;

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -14,21 +14,20 @@ describe('garbage collection', () => {
     InMemoryData.writeRecord('Todo:1', 'id', '1');
     InMemoryData.writeRecord('Query', '__typename', 'Query');
     InMemoryData.writeLink('Query', 'todo', 'Todo:1');
+    InMemoryData.clearDataState();
 
     InMemoryData.gc(data);
 
+    InMemoryData.initDataState(data, null);
     expect(InMemoryData.readLink('Query', 'todo')).toBe('Todo:1');
-
     InMemoryData.writeLink('Query', 'todo', undefined);
+    InMemoryData.clearDataState();
+
     InMemoryData.gc(data);
 
+    InMemoryData.initDataState(data, null);
     expect(InMemoryData.readLink('Query', 'todo')).toBe(undefined);
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);
-
-    expect([...InMemoryData.getCurrentDependencies()]).toEqual([
-      'Todo:1',
-      'Query.todo',
-    ]);
   });
 
   it('keeps readopted entities', () => {
@@ -38,17 +37,19 @@ describe('garbage collection', () => {
     InMemoryData.writeLink('Query', 'todo', 'Todo:1');
     InMemoryData.writeLink('Query', 'todo', undefined);
     InMemoryData.writeLink('Query', 'newTodo', 'Todo:1');
+    InMemoryData.clearDataState();
 
     InMemoryData.gc(data);
 
+    InMemoryData.initDataState(data, null);
     expect(InMemoryData.readLink('Query', 'newTodo')).toBe('Todo:1');
     expect(InMemoryData.readLink('Query', 'todo')).toBe(undefined);
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe('1');
 
     expect([...InMemoryData.getCurrentDependencies()]).toEqual([
-      'Todo:1',
-      'Query.todo',
       'Query.newTodo',
+      'Query.todo',
+      'Todo:1',
     ]);
   });
 
@@ -60,16 +61,18 @@ describe('garbage collection', () => {
     InMemoryData.writeLink('Query', 'todoB', 'Todo:1');
     InMemoryData.writeLink('Query', 'todoA', undefined);
 
+    InMemoryData.clearDataState();
     InMemoryData.gc(data);
+    InMemoryData.initDataState(data, null);
 
     expect(InMemoryData.readLink('Query', 'todoA')).toBe(undefined);
     expect(InMemoryData.readLink('Query', 'todoB')).toBe('Todo:1');
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe('1');
 
     expect([...InMemoryData.getCurrentDependencies()]).toEqual([
-      'Todo:1',
       'Query.todoA',
       'Query.todoB',
+      'Todo:1',
     ]);
   });
 
@@ -83,18 +86,19 @@ describe('garbage collection', () => {
     InMemoryData.initDataState(data, 0, true);
 
     InMemoryData.writeLink('Query', 'todo', undefined);
+
+    InMemoryData.clearDataState();
     InMemoryData.gc(data);
 
+    InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe('1');
+    InMemoryData.clearDataState();
 
     InMemoryData.clearLayer(data, 1);
     InMemoryData.gc(data);
-    expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);
+    InMemoryData.initDataState(data, null);
 
-    expect([...InMemoryData.getCurrentDependencies()]).toEqual([
-      'Query.todo',
-      'Todo:1',
-    ]);
+    expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);
   });
 
   it('erases child entities that are orphaned', () => {
@@ -106,16 +110,13 @@ describe('garbage collection', () => {
     InMemoryData.writeLink('Query', 'todo', 'Todo:1');
 
     InMemoryData.writeLink('Query', 'todo', undefined);
+
+    InMemoryData.clearDataState();
     InMemoryData.gc(data);
+    InMemoryData.initDataState(data, null);
 
     expect(InMemoryData.readRecord('Todo:1', 'id')).toBe(undefined);
     expect(InMemoryData.readRecord('Author:1', 'id')).toBe(undefined);
-
-    expect([...InMemoryData.getCurrentDependencies()]).toEqual([
-      'Author:1',
-      'Todo:1',
-      'Query.todo',
-    ]);
   });
 });
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -1,3 +1,5 @@
+import { stringifyVariables } from '@urql/core';
+
 import {
   Link,
   EntityField,
@@ -6,14 +8,15 @@ import {
   SerializedEntries,
 } from '../types';
 
-import { makeDict } from '../helpers/dict';
-import { invariant, currentDebugStack } from '../helpers/help';
 import {
   fieldInfoOfKey,
   joinKeys,
   serializeKeys,
   indexOfSeparator,
 } from './keys';
+
+import { makeDict } from '../helpers/dict';
+import { invariant, currentDebugStack } from '../helpers/help';
 import { scheduleTask } from './defer';
 
 type Dict<T> = Record<string, T>;
@@ -546,9 +549,9 @@ export const persistData = () => {
         const fieldKey = key.slice(sepIndex + 1);
         let x: void | Link | EntityField;
         if ((x = readLink(entityKey, fieldKey)) !== undefined) {
-          entries[key] = `:${JSON.stringify(x)}`;
+          entries[key] = `:${stringifyVariables(x)}`;
         } else if ((x = readRecord(entityKey, fieldKey)) !== undefined) {
-          entries[key] = JSON.stringify(x);
+          entries[key] = stringifyVariables(x);
         } else {
           entries[key] = undefined;
         }

--- a/exchanges/graphcache/src/store/defer.ts
+++ b/exchanges/graphcache/src/store/defer.ts
@@ -1,4 +1,4 @@
-export const defer: (fn: () => void) => void =
+export const scheduleTask: (fn: () => void) => void =
   process.env.NODE_ENV === 'production' && typeof Promise !== 'undefined'
     ? Promise.prototype.then.bind(Promise.resolve())
     : fn => setTimeout(fn, 0);

--- a/exchanges/graphcache/src/store/keys.ts
+++ b/exchanges/graphcache/src/store/keys.ts
@@ -23,6 +23,3 @@ export const fieldInfoOfKey = (fieldKey: string): FieldInfo => {
 
 export const joinKeys = (parentKey: string, key: string) =>
   `${parentKey}.${key}`;
-
-/** Prefix key with its owner type Link / Record */
-export const prefixKey = (owner: 'l' | 'r', key: string) => `${owner}|${key}`;

--- a/exchanges/graphcache/src/store/keys.ts
+++ b/exchanges/graphcache/src/store/keys.ts
@@ -23,3 +23,7 @@ export const fieldInfoOfKey = (fieldKey: string): FieldInfo => {
 
 export const joinKeys = (parentKey: string, key: string) =>
   `${parentKey}.${key}`;
+
+export const serializeKeys = (entityKey: string, fieldKey: string) =>
+  `${entityKey}\t${fieldKey}`;
+export const indexOfSeparator = (key: string) => key.indexOf('\t');

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -453,7 +453,8 @@ describe('Store with OptimisticMutationConfig', () => {
   });
 });
 
-describe('Store with storage', () => {
+// TODO: Implement persistence
+describe.skip('Store with storage', () => {
   const expectedData = {
     __typename: 'Query',
     appointment: {
@@ -502,39 +503,5 @@ describe('Store with storage', () => {
     });
 
     expect(data).toEqual(expectedData);
-  });
-
-  it('writes removals based on GC to storage', () => {
-    const storage: StorageAdapter = {
-      read: jest.fn(),
-      write: jest.fn(),
-    };
-
-    const store = new Store();
-    InMemoryData.hydrateData(store.data, storage, Object.create(null));
-
-    write(
-      store,
-      {
-        query: Appointment,
-        variables: { id: '1' },
-      },
-      expectedData
-    );
-
-    InMemoryData.initDataState(store.data, null);
-    InMemoryData.writeLink(
-      'Query',
-      store.keyOfField('appointment', { id: '1' }),
-      undefined
-    );
-    InMemoryData.gc(store.data);
-    InMemoryData.clearDataState();
-
-    jest.runAllTimers();
-
-    expect(storage.write).toHaveBeenCalled();
-    const serialisedStore = (storage.write as any).mock.calls[0][0];
-    expect(serialisedStore).toMatchSnapshot();
   });
 });

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -453,8 +453,9 @@ describe('Store with OptimisticMutationConfig', () => {
   });
 });
 
-// TODO: Implement persistence
-describe.skip('Store with storage', () => {
+describe('Store with storage', () => {
+  let store: Store;
+
   const expectedData = {
     __typename: 'Query',
     appointment: {
@@ -465,7 +466,7 @@ describe.skip('Store with storage', () => {
   };
 
   beforeEach(() => {
-    jest.useFakeTimers();
+    store = new Store();
   });
 
   it('should be able to store and rehydrate data', () => {
@@ -474,8 +475,7 @@ describe.skip('Store with storage', () => {
       write: jest.fn(),
     };
 
-    let store = new Store();
-    InMemoryData.hydrateData(store.data, storage, Object.create(null));
+    store.data.storage = storage;
 
     write(
       store,
@@ -486,9 +486,10 @@ describe.skip('Store with storage', () => {
       expectedData
     );
 
-    expect(storage.write).not.toHaveBeenCalled();
+    InMemoryData.initDataState(store.data, null);
+    InMemoryData.persistData();
+    InMemoryData.clearDataState();
 
-    jest.runAllTimers();
     expect(storage.write).toHaveBeenCalled();
 
     const serialisedStore = (storage.write as any).mock.calls[0][0];

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -169,7 +169,7 @@ export interface KeyingConfig {
 export type SerializedEntry = EntityField | Connection[] | Link;
 
 export interface SerializedEntries {
-  [key: string]: SerializedEntry;
+  [key: string]: string | undefined;
 }
 
 export interface StorageAdapter {


### PR DESCRIPTION
## Summary

This contains a stable implementation of persistence that combines its run with the garbage collection run and takes commutativity into account using a new approach that squashes layers on-the-fly.

## Set of changes

- [x] Refactor to remove the old persistence logic
- [x] Refactor GC code to use data state
- [x] Add joined key batch to flag persistence
- [x] Implement new persistence deferred run next to `gc`
- [x] Implement new rehydration logic
