### PR TITLE
Take invalid statusCode with gqlErrors in account

### DIFF
--- a/packages/core/src/exchanges/fetch.ts
+++ b/packages/core/src/exchanges/fetch.ts
@@ -145,17 +145,20 @@ const executeFetch = (
 
   return (fetcher || fetch)(url, opts)
     .then(res => {
-      const { status } = res;
-      const statusRangeEnd = opts.redirect === 'manual' ? 400 : 300;
       response = res;
-
-      if (status < 200 || status >= statusRangeEnd) {
-        throw new Error(res.statusText);
+      return res.json();
+    })
+    .then(result => {
+      if (
+        response!.status < 200 ||
+        response!.status >= (opts.redirect === 'manual' ? 400 : 300)
+      ) {
+        response = result;
+        throw new Error(result.statusText);
       } else {
-        return res.json();
+        return makeResult(operation, result, response);
       }
     })
-    .then(result => makeResult(operation, result, response))
     .catch(err => {
       if (err.name !== 'AbortError') {
         return makeErrorResult(operation, err, response);

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -51,6 +51,7 @@ export class CombinedError extends Error {
   }: {
     networkError?: Error;
     graphQLErrors?: Array<string | Partial<GraphQLError> | Error>;
+    errors?: Array<string | Partial<GraphQLError> | Error>;
     response?: any;
   }) {
     const normalizedGraphQLErrors = (graphQLErrors || []).map(

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -10,7 +10,7 @@ export const makeResult = (
   data: result.data,
   error: Array.isArray(result.errors)
     ? new CombinedError({
-        graphQLErrors: result.errors,
+        graphQLErrors: response.errors || result.errors,
         response,
       })
     : undefined,
@@ -25,9 +25,16 @@ export const makeErrorResult = (
 ): OperationResult => ({
   operation,
   data: undefined,
-  error: new CombinedError({
-    networkError: error,
-    response,
-  }),
+  error: new CombinedError(
+    response.errors
+      ? {
+          graphQLErrors: response.errors,
+          response,
+        }
+      : {
+          networkError: error,
+          response,
+        }
+  ),
   extensions: undefined,
 });


### PR DESCRIPTION
## Summary

When passing invalid fields, ... the server will throw a `BadRequestError` meaning a 400 this results in a body being passed with the error. Invalid statusCodes were always regarded as `NetworkError` in our case since we assumed we would receive a 200 for that case. This PR clears this assumption.

## Set of changes

- remove assumption of > 200 being a networkError