### PR TITLE
Fix non-2xx GraphQL responses on fetch exchanges

### DIFF
--- a/.changeset/rotten-jobs-count.md
+++ b/.changeset/rotten-jobs-count.md
@@ -1,0 +1,6 @@
+---
+'@urql/exchange-multipart-fetch': patch
+'@urql/core': patch
+---
+
+Fix non-2xx results never being parsed as GraphQL results. This can result in valid GraphQLErrors being hidden, which should take precedence over generic HTTP NetworkErrors.

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
@@ -121,7 +121,7 @@ describe('on error', () => {
   beforeEach(() => {
     fetch.mockResolvedValue({
       status: 400,
-      json: jest.fn().mockResolvedValue(response),
+      json: jest.fn().mockResolvedValue({}),
     });
   });
 
@@ -151,6 +151,21 @@ describe('on error', () => {
     );
 
     expect(data).toMatchSnapshot();
+  });
+
+  it('ignores the error when a result is available', async () => {
+    fetch.mockResolvedValue({
+      status: 400,
+      json: jest.fn().mockResolvedValue(response),
+    });
+
+    const data = await pipe(
+      fromValue(queryOperation),
+      multipartFetchExchange(exchangeArgs),
+      toPromise
+    );
+
+    expect(data.data).toEqual(response.data);
   });
 });
 

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -178,7 +178,7 @@ const executeFetch = (
       return res.json();
     })
     .then((result: any) => {
-      if (!('data' in result) || !('errors' in result)) {
+      if (!('data' in result) && !('errors' in result)) {
         throw new Error('No Content');
       }
 

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -166,24 +166,27 @@ const executeFetch = (
   opts: RequestInit
 ): Promise<OperationResult> => {
   const { url, fetch: fetcher } = operation.context;
-  let response: Response | undefined;
+
+  let response: Response;
 
   return (fetcher || fetch)(url, opts)
-    .then(res => {
+    .then((res: Response) => {
       const { status } = res;
       const statusRangeEnd = opts.redirect === 'manual' ? 400 : 300;
       response = res;
 
-      if (status < 200 || status >= statusRangeEnd) {
-        throw new Error(res.statusText);
-      } else {
-        return res.json();
-      }
+      return res.json().catch((error: Error) => {
+        return Promise.reject(
+          status < 200 || status >= statusRangeEnd
+            ? new Error(response.statusText)
+            : error
+        );
+      });
     })
-    .then(result => makeResult(operation, result, response))
-    .catch(err => {
-      if (err.name !== 'AbortError') {
-        return makeErrorResult(operation, err, response);
+    .then((result: object) => makeResult(operation, result, response))
+    .catch((error: Error) => {
+      if (error.name !== 'AbortError') {
+        return makeErrorResult(operation, error, response);
       }
     });
 };

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -166,27 +166,31 @@ const executeFetch = (
   opts: RequestInit
 ): Promise<OperationResult> => {
   const { url, fetch: fetcher } = operation.context;
-
+  let statusNotOk = false;
   let response: Response;
 
   return (fetcher || fetch)(url, opts)
     .then((res: Response) => {
-      const { status } = res;
-      const statusRangeEnd = opts.redirect === 'manual' ? 400 : 300;
       response = res;
-
-      return res.json().catch((error: Error) => {
-        return Promise.reject(
-          status < 200 || status >= statusRangeEnd
-            ? new Error(response.statusText)
-            : error
-        );
-      });
+      statusNotOk =
+        res.status < 200 ||
+        res.status >= (opts.redirect === 'manual' ? 400 : 300);
+      return res.json();
     })
-    .then((result: object) => makeResult(operation, result, response))
+    .then((result: any) => {
+      if (!('data' in result) || !('errors' in result)) {
+        throw new Error('No Content');
+      }
+
+      return makeResult(operation, result, response);
+    })
     .catch((error: Error) => {
       if (error.name !== 'AbortError') {
-        return makeErrorResult(operation, error, response);
+        return makeErrorResult(
+          operation,
+          statusNotOk ? new Error(response.statusText) : error,
+          response
+        );
       }
     });
 };

--- a/packages/core/src/exchanges/fetch.test.ts
+++ b/packages/core/src/exchanges/fetch.test.ts
@@ -76,7 +76,7 @@ describe('on error', () => {
   beforeEach(() => {
     fetch.mockResolvedValue({
       status: 400,
-      json: jest.fn().mockResolvedValue(response),
+      json: jest.fn().mockResolvedValue({}),
     });
   });
 
@@ -106,6 +106,21 @@ describe('on error', () => {
     );
 
     expect(data).toMatchSnapshot();
+  });
+
+  it('ignores the error when a result is available', async () => {
+    fetch.mockResolvedValue({
+      status: 400,
+      json: jest.fn().mockResolvedValue(response),
+    });
+
+    const data = await pipe(
+      fromValue(queryOperation),
+      fetchExchange(exchangeArgs),
+      toPromise
+    );
+
+    expect(data.data).toEqual(response.data);
   });
 });
 

--- a/packages/core/src/exchanges/fetch.ts
+++ b/packages/core/src/exchanges/fetch.ts
@@ -153,7 +153,7 @@ const executeFetch = (
       return res.json();
     })
     .then((result: any) => {
-      if (!('data' in result) || !('errors' in result)) {
+      if (!('data' in result) && !('errors' in result)) {
         throw new Error('No Content');
       }
 


### PR DESCRIPTION
## Summary

This always parses JSON data in all fetch exchanges and falls back to generating errors when it's safe to do so, i.e. when the data isn't GraphQL data. When we can't parse the response we also fall back to our previous error logic, but we also account for `new Error('No Content')` in case of success scenarios.

`4.43 kB -> 4.46kB`

## Set of changes

- Update `executeFetch` in `fetchExchange`
- Update `executeFetch` in `multipartFetchExchange`
