### PR TITLE
Fix typos in docs/concepts

### DIFF
--- a/docs/concepts/core-package.md
+++ b/docs/concepts/core-package.md
@@ -37,7 +37,7 @@ _Exchanges_ are discussed in more detail on the [next page](./exchanges.md).
 The largest part of `urql` itself and the core package is the aforementioned `Client`. It's often
 used directly when using `urql` in Node.js without any other integration.
 
-[We've previously seen how we can use the `Client`'s stream methods directly, in [Stream
+We've previously seen how we can use the `Client`'s stream methods directly, in [Stream
 Patterns](./stream-patterns.md). However, the [`Client`](../api/core.md#client) also has plenty of
 convenience methods that make interacting with the `Client` directly a lot easier.
 

--- a/docs/concepts/philosophy.md
+++ b/docs/concepts/philosophy.md
@@ -10,7 +10,7 @@ order: 1
 
 By default, we aim to provide features that allow you to build your app quickly with minimal
 configuration. `urql` is designed to be a client that grows with you. As you go from building your first
-GraphQL app to a utilising the full functionality, the toopls are available to extend and customize `urql` based on
+GraphQL app to a utilising the full functionality, the tools are available to extend and customize `urql` based on
 your needs.
 
 In this guide, we will walk through how `urql` is set up internally and how all pieces of the puzzle

--- a/docs/concepts/stream-patterns.md
+++ b/docs/concepts/stream-patterns.md
@@ -24,7 +24,7 @@ Internally the `Client` is an event hub. It defines a stream of operations as in
 through a layer that will ultimately send GraphQL requests to an API, and then send the corresponding results
 to another stream.
 
-As a user working with framewrk code we never interact with these streams directly, but it's helpful to know that they describe
+As a user working with framework code we never interact with these streams directly, but it's helpful to know that they describe
 every interaction between the declarative queries we write and the way that `urql` fulfills them.
 
 ## Streams in JavaScript


### PR DESCRIPTION
## Summary

Typo fix in docs

## Set of changes

```
- toopls
+ tools

- framewrk
+ framework

- [We've previously seen
+ We've previously seen
```