### PR TITLE
(fix) - append query to the payload for multipart fetches

### DIFF
--- a/.changeset/ninety-starfishes-cross.md
+++ b/.changeset/ninety-starfishes-cross.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-multipart-fetch': patch
+---
+
+Include the query in our operation we send to the server in the multipartFetchExchange.

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -81,10 +81,7 @@ const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
     const { context } = operation;
     // We have to make sure the operation is fully spread in here so we don't lose the query on our cloned object.
     // Spreading operation.variables here in case someone made a variables with Object.create(null).
-    const { files, clone } = extractFiles({
-      query: print(operation.query),
-      variables: { ...operation.variables },
-    });
+    const { files, clone } = extractFiles({ ...operation.variables });
 
     const extraOptions =
       typeof context.fetchOptions === 'function'
@@ -119,7 +116,10 @@ const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
       // Make fetch auto-append this for correctness
       delete fetchOptions.headers['content-type'];
 
-      fetchOptions.body.append('operations', JSON.stringify({ ...clone }));
+      fetchOptions.body.append(
+        'operations',
+        JSON.stringify({ variables: clone, query: body.query })
+      );
 
       const map = {};
       let i = 0;

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -82,7 +82,7 @@ const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
     // We have to make sure the operation is fully spread in here so we don't lose the query on our cloned object.
     // Spreading operation.variables here in case someone made a variables with Object.create(null).
     const { files, clone } = extractFiles({
-      ...operation,
+      query: print(operation.query),
       variables: { ...operation.variables },
     });
 

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -79,8 +79,12 @@ const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
         : undefined;
 
     const { context } = operation;
+    // We have to make sure the operation is fully spread in here so we don't lose the query on our cloned object.
     // Spreading operation.variables here in case someone made a variables with Object.create(null).
-    const { files, clone } = extractFiles({ ...operation.variables });
+    const { files, clone } = extractFiles({
+      ...operation,
+      variables: { ...operation.variables },
+    });
 
     const extraOptions =
       typeof context.fetchOptions === 'function'
@@ -115,13 +119,7 @@ const createFetchSource = (operation: Operation, shouldUseGet: boolean) => {
       // Make fetch auto-append this for correctness
       delete fetchOptions.headers['content-type'];
 
-      fetchOptions.body.append(
-        'operations',
-        JSON.stringify({
-          ...body,
-          variables: clone,
-        })
-      );
+      fetchOptions.body.append('operations', JSON.stringify({ ...clone }));
 
       const map = {};
       let i = 0;

--- a/packages/core/src/exchanges/debug.ts
+++ b/packages/core/src/exchanges/debug.ts
@@ -2,7 +2,7 @@ import { pipe, tap } from 'wonka';
 import { Exchange } from '../types';
 
 export const debugExchange: Exchange = ({ forward }) => {
-  if (process.env && process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'production') {
     return ops$ => forward(ops$);
   } else {
     return ops$ =>

--- a/packages/core/src/exchanges/debug.ts
+++ b/packages/core/src/exchanges/debug.ts
@@ -2,7 +2,7 @@ import { pipe, tap } from 'wonka';
 import { Exchange } from '../types';
 
 export const debugExchange: Exchange = ({ forward }) => {
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env && process.env.NODE_ENV === 'production') {
     return ops$ => forward(ops$);
   } else {
     return ops$ =>


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

In an issue on [spectrum](https://spectrum.chat/urql/help/help-with-a-file-upload-mutation~08f3413a-0ba5-4577-9fd2-625e10b551cc) there was talk about the `query` getting lost on a multipart-fetch. This is because when using the `clone` we only include the `variables`.

## Set of changes

- Add `query` to the `payload`
