### PR TITLE
Add babel-plugin-modular-graphql to rewrite graphql imports

### DIFF
--- a/.changeset/eighty-plants-pump.md
+++ b/.changeset/eighty-plants-pump.md
@@ -1,0 +1,7 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/exchange-populate': patch
+'@urql/core': patch
+---
+
+Pick modules from graphql package, instead of importing from graphql/index.mjs

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",
     "babel-plugin-closure-elimination": "^1.3.0",
+    "babel-plugin-modular-graphql": "0.1.1",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "dotenv": "^8.2.0",
     "eslint": "^6.8.0",

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -71,6 +71,7 @@ export const makePlugins = ({ isProduction } = {}) => [
     plugins: [
       babelPluginTransformPipe,
       babelPluginTransformInvariant,
+      'babel-plugin-modular-graphql',
       'babel-plugin-closure-elimination',
       '@babel/plugin-transform-object-assign',
       settings.hasReact && ['@babel/plugin-transform-react-jsx', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,6 +3035,11 @@ babel-plugin-macros@^2.6.1:
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
+babel-plugin-modular-graphql@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-modular-graphql/-/babel-plugin-modular-graphql-0.1.1.tgz#467b49c9141274e144cb2481ee98abdf292f5d63"
+  integrity sha512-xlv/XTp3FiTRIeuQYp07Avlt+n6+GGPw0dXSt7c+FTLS5q/NugY4DpOb4MMn+u5dw0Xs/3VlxU4oGDHdv+z3Zw==
+
 "babel-plugin-styled-components@>= 1":
   version "1.10.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz#3494e77914e9989b33cc2d7b3b29527a949d635c"


### PR DESCRIPTION
Adds [`babel-plugin-modular-graphql`](https://github.com/kitten/babel-plugin-modular-graphql) to rewrite `graphql` imports to their modular variants.
