### PR TITLE
Fix resolver on React example (inline arguments)

### DIFF
--- a/packages/react-urql/examples/1-getting-started/src/graphql/index.ts
+++ b/packages/react-urql/examples/1-getting-started/src/graphql/index.ts
@@ -39,7 +39,7 @@ export const rootValue = {
       .objectStore('todos')
       .getAll();
   },
-  toggleTodo: async (root: any, { id }: any) => {
+  toggleTodo: async ({ id }: any) => {
     const db = await database;
     const txTodos = db.transaction(['todos'], 'readwrite').objectStore('todos');
 
@@ -51,7 +51,7 @@ export const rootValue = {
 
     return newTodo;
   },
-  addTodo: async (root: any, args: any) => {
+  addTodo: async (args: any) => {
     const db = await database;
     const txTodos = db.transaction(['todos'], 'readwrite').objectStore('todos');
 
@@ -61,7 +61,7 @@ export const rootValue = {
 
     return todo;
   },
-  deleteTodo: async (root: any, { id }: any) => {
+  deleteTodo: async ({ id }: any) => {
     const db = await database;
     const txTodos = db.transaction(['todos'], 'readwrite').objectStore('todos');
 


### PR DESCRIPTION
## About

Minor to fix parsing of inline arguments in mutations. Previously, the below would fail (tested in devtools)

```gql
# Type your query here then hit 'Ctrl+Enter' to execute it.
mutation AddTodo {
  addTodo(text: "Install devtools") {
    id
  }
}
```