### PR TITLE
Svelte: Update mutate to have an options argument for consistency

### DIFF
--- a/.changeset/young-eyes-call.md
+++ b/.changeset/young-eyes-call.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': minor
+---
+
+Update `mutate()` API to accept an options argument, instead of separate arguments, to increase consistency

--- a/packages/svelte-urql/src/operations/mutate.ts
+++ b/packages/svelte-urql/src/operations/mutate.ts
@@ -3,10 +3,14 @@ import { DocumentNode } from 'graphql';
 
 import { getClient } from '../context';
 
+export interface MutationArguments<V> {
+  query: string | DocumentNode;
+  variables?: V;
+  context?: Partial<OperationContext>;
+}
+
 export const mutate = <T = any, V = object>(
-  query: string | DocumentNode,
-  variables?: V,
-  context?: Partial<OperationContext>
+  args: MutationArguments<V>
 ): PromiseLike<OperationResult<T>> => {
   const client = getClient();
   let promise: Promise<OperationResult<T>>;
@@ -14,7 +18,9 @@ export const mutate = <T = any, V = object>(
   return {
     then(onValue) {
       if (!promise) {
-        promise = client.mutation(query, variables as any, context).toPromise();
+        promise = client
+          .mutation(args.query, args.variables as any, args.context)
+          .toPromise();
       }
 
       return promise.then(onValue);


### PR DESCRIPTION
Resolve #703 

Change `@urql/svelte`'s `mutate(query, variables, context)` signature to: `mutate({ query, variables, context })`.