### PR TITLE
Fix @urql/exchange-populate visitWithTypeInfo import

### DIFF
--- a/.changeset/few-trees-taste.md
+++ b/.changeset/few-trees-taste.md
@@ -1,0 +1,6 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/exchange-populate': patch
+---
+
+Fix @urql/exchange-populate visitWithTypeInfo import by bumping babel-plugin-modular-graphql

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",
     "babel-plugin-closure-elimination": "^1.3.0",
-    "babel-plugin-modular-graphql": "0.1.1",
+    "babel-plugin-modular-graphql": "0.1.3",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "dotenv": "^8.2.0",
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,10 +3035,10 @@ babel-plugin-macros@^2.6.1:
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
-babel-plugin-modular-graphql@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-modular-graphql/-/babel-plugin-modular-graphql-0.1.1.tgz#467b49c9141274e144cb2481ee98abdf292f5d63"
-  integrity sha512-xlv/XTp3FiTRIeuQYp07Avlt+n6+GGPw0dXSt7c+FTLS5q/NugY4DpOb4MMn+u5dw0Xs/3VlxU4oGDHdv+z3Zw==
+babel-plugin-modular-graphql@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-modular-graphql/-/babel-plugin-modular-graphql-0.1.3.tgz#23d474daab2278229bfc9a9f2491f3e1d9f555f1"
+  integrity sha512-13QBZm1sqPTHVBlG79p0jswR+FdNIIaxRrg1tNjpfGYU4U9M8bEDVQ51QK9+cZ6zUBQ0k2mh0iRvCjZt+856pg==
 
 "babel-plugin-styled-components@>= 1":
   version "1.10.7"


### PR DESCRIPTION
Fix #708 

Looks like we didn't sufficiently test #700 with `@urql/exchange-populate`, since it breaks in `graphql@<15`. This will be less risky in the future anyway, when populate is broken out of `@urql/exchange-graphcache` in the next major.

