### PR TITLE
(fix) - Remove special character from persistence keys and sanitize

### DIFF
--- a/.changeset/honest-mangos-rule.md
+++ b/.changeset/honest-mangos-rule.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix persistence using special tab character in serialized keys and add sanitization to persistence key serializer.

--- a/exchanges/graphcache/examples/persisted-store/src/app/index.tsx
+++ b/exchanges/graphcache/examples/persisted-store/src/app/index.tsx
@@ -12,8 +12,16 @@ const storage = {
     db = await openDB('myApplication', 1, {
       upgrade: db => db.createObjectStore('keyval'),
     });
-    const result = (await db.getAll('keyval')) as SerializedEntries;
-    return result;
+
+    return Promise.all([
+      db.getAllKeys("keyval"),
+      db.getAll("keyval"),
+    ]).then(([keys, values]) => {
+      return keys.reduce((acc: SerializedEntries, key, i) => {
+        acc[key] = values[i];
+        return acc;
+      }, {});
+    });
   },
   write: async batch => {
     for (const key in batch) {

--- a/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
+++ b/exchanges/graphcache/src/store/__snapshots__/store.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`Store with storage should be able to store and rehydrate data 1`] = `
 Object {
-  "Appointment:1	__typename": "\\"Appointment\\"",
-  "Appointment:1	id": "\\"1\\"",
-  "Appointment:1	info": "\\"urql meeting\\"",
-  "Query	appointment({\\"id\\":\\"1\\"})": ":\\"Appointment:1\\"",
+  "Appointment:1.__typename": "\\"Appointment\\"",
+  "Appointment:1.id": "\\"1\\"",
+  "Appointment:1.info": "\\"urql meeting\\"",
+  "Query.appointment({\\"id\\":\\"1\\"})": ":\\"Appointment:1\\"",
 }
 `;

--- a/exchanges/graphcache/src/store/keys.ts
+++ b/exchanges/graphcache/src/store/keys.ts
@@ -1,8 +1,11 @@
 import { stringifyVariables } from '@urql/core';
-import { Variables, FieldInfo } from '../types';
+import { Variables, FieldInfo, KeyInfo } from '../types';
 
 export const keyOfField = (fieldName: string, args?: null | Variables) =>
   args ? `${fieldName}(${stringifyVariables(args)})` : fieldName;
+
+export const joinKeys = (parentKey: string, key: string) =>
+  `${parentKey}.${key}`;
 
 export const fieldInfoOfKey = (fieldKey: string): FieldInfo => {
   const parenIndex = fieldKey.indexOf('(');
@@ -21,9 +24,12 @@ export const fieldInfoOfKey = (fieldKey: string): FieldInfo => {
   }
 };
 
-export const joinKeys = (parentKey: string, key: string) =>
-  `${parentKey}.${key}`;
-
 export const serializeKeys = (entityKey: string, fieldKey: string) =>
-  `${entityKey}\t${fieldKey}`;
-export const indexOfSeparator = (key: string) => key.indexOf('\t');
+  `${entityKey.replace(/\./g, '\\.')}.${fieldKey}`;
+
+export const deserializeKeyInfo = (key: string): KeyInfo => {
+  const dotIndex = key.indexOf('.');
+  const entityKey = key.slice(0, dotIndex).replace(/\\\./g, '.');
+  const fieldKey = key.slice(dotIndex + 1);
+  return { entityKey, fieldKey };
+};

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -568,7 +568,7 @@ describe('Store with storage', () => {
     const serialisedStore = (storage.write as any).mock.calls[0][0];
 
     expect(serialisedStore).toEqual({
-      'Query\tbase': 'true',
+      'Query.base': 'true',
     });
 
     store = new Store();

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -45,6 +45,11 @@ export interface FieldInfo {
   arguments: Variables | null;
 }
 
+export interface KeyInfo {
+  entityKey: string;
+  fieldKey: string;
+}
+
 // This is an input operation
 export interface OperationRequest {
   query: DocumentNode;


### PR DESCRIPTION
## Summary

- ~Avoid illegal character \t which seems to be sometimes stripped in IDB~ (This turned out to be untrue and our example was simply broken. That being said, I think this is still a safer alternative)
- Move deserialization to keys.ts
- Add string sanitization
