### PR TITLE
next-urql: Ensure ctx in clientOptions is available during all stages of SSR

### DIFF
--- a/.changeset/eighty-turkeys-jam.md
+++ b/.changeset/eighty-turkeys-jam.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Check if urqlClient exists in useMemo on the server side to prevent calling clientConfig and initUrqlClient multiple times. Ensure urqlClient is serialized to null to maintain separate server and client instances.

--- a/.changeset/eighty-turkeys-jam.md
+++ b/.changeset/eighty-turkeys-jam.md
@@ -2,4 +2,4 @@
 'next-urql': patch
 ---
 
-Check if urqlClient exists in useMemo on the server side to prevent calling clientConfig and initUrqlClient multiple times. Ensure urqlClient is serialized to null to maintain separate server and client instances.
+Ensure that the Next.js context is available during all stages of SSR. Previously a missing check in `useMemo` on the server-side caused `clientConfig` from being called repeatedly, and another issue may have caused the client from being serialized to initial props.

--- a/packages/core/src/utils/stringifyVariables.ts
+++ b/packages/core/src/utils/stringifyVariables.ts
@@ -22,11 +22,7 @@ const stringify = (x: any): string => {
 
   const keys = Object.keys(x).sort();
   if (!keys.length && x.constructor && x.constructor !== Object) {
-    const key =
-      cache.get(x) ||
-      Math.random()
-        .toString(36)
-        .slice(2);
+    const key = cache.get(x) || Math.random().toString(36).slice(2);
     cache.set(x, key);
     return `{"__key":"${key}"}`;
   }

--- a/packages/core/src/utils/stringifyVariables.ts
+++ b/packages/core/src/utils/stringifyVariables.ts
@@ -22,7 +22,11 @@ const stringify = (x: any): string => {
 
   const keys = Object.keys(x).sort();
   if (!keys.length && x.constructor && x.constructor !== Object) {
-    const key = cache.get(x) || Math.random().toString(36).slice(2);
+    const key =
+      cache.get(x) ||
+      Math.random()
+        .toString(36)
+        .slice(2);
     cache.set(x, key);
     return `{"__key":"${key}"}`;
   }

--- a/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
+++ b/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
@@ -66,9 +66,7 @@ describe('withUrqlClient', () => {
 
   describe('with ctx callback to create client options', () => {
     // Simulate a token that might be passed in a request to the server-rendered application.
-    const token = Math.random()
-      .toString(36)
-      .slice(-10);
+    const token = Math.random().toString(36).slice(-10);
 
     const mockContext: NextUrqlPageContext = {
       AppTree: MockAppTree,

--- a/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
+++ b/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
@@ -50,7 +50,7 @@ describe('withUrqlClient', () => {
       expect(spyInitUrqlClient).toHaveBeenCalledTimes(1);
     });
 
-    it('should create the urql client instance server-side inside getInitialProps and client-side in the component', async () => {
+    it('should create the urql client instance server-side inside getInitialProps', async () => {
       const props =
         Component.getInitialProps &&
         (await Component.getInitialProps(mockContext));
@@ -59,7 +59,6 @@ describe('withUrqlClient', () => {
       const tree = shallow(<Component {...props} />);
       const app = tree.find(MockApp);
 
-      expect(spyInitUrqlClient).toHaveBeenCalledTimes(2);
       expect(app.props().urqlClient).toBeInstanceOf(Client);
       expect(app.props().urqlClient.url).toEqual('http://localhost:3000');
     });
@@ -67,7 +66,9 @@ describe('withUrqlClient', () => {
 
   describe('with ctx callback to create client options', () => {
     // Simulate a token that might be passed in a request to the server-rendered application.
-    const token = Math.random().toString(36).slice(-10);
+    const token = Math.random()
+      .toString(36)
+      .slice(-10);
 
     const mockContext: NextUrqlPageContext = {
       AppTree: MockAppTree,


### PR DESCRIPTION
Resolves #707. 

## Summary

In #707, @nickrttn pointed out that `ctx` wasn't available during all stages of SSR with `next-urql`. After some investigation with `console.trace`, it was clear that `ctx` _was_ available during execution of `withUrql`'s `getInitialProps` function, but _not_ during the `useMemo` that gets executed as part of the server side render.

The steps to fix this are twofold:

1. Move the call to create the `clientOptions` _after_ the check for an existing `urqlClient`. If we receive `urqlClient` from `getInitialProps`, we return early from the `useMemo`. This saves us from having to call `initUrqlClient` twice on the server side (the first call being in `getInitialProps`, the second call being inside `useMemo`, where `ctx` is `undefined`).
2. The above requires that we return `urqlClient` in `getInitialProps` on the server side. To ensure that we don't use the same `urqlClient` instance in the browser, we use `toJSON` to ensure it gets serialized to `null`. That way, we don't mess with the separation b/t server and client. This is a trick I picked up from reading the [`next-with-apollo` source](https://github.com/lfades/next-with-apollo/blob/master/src/withApollo.tsx#L99-L105).

I don't envision there being regressions with this approach, since the serialization piece should still allow users to create different server and client `urqlClient` instances with `process.browser` or `typeof window` checks as before.

## Set of changes

**Packages effected:**
- `next-urql`

**Changes:**
- Check if `urqlClient` exists in `useMemo` on the server side to prevent calling `clientConfig` multiple times.
- Ensure `urqlClient` is serialized to `null` to maintain separate server and client instances.
