### PR TITLE
(fix) - Fix internal and graphcache/extras main path

### DIFF
--- a/.changeset/loud-doors-think.md
+++ b/.changeset/loud-doors-think.md
@@ -1,5 +1,6 @@
 ---
 '@urql/core': patch
+'@urql/exchange-graphcache': patch
 ---
 
-Make the extension of the main export unknown, this way a resolver will pick one from itself"
+Make the extension of the main export unknown, which fixes a Webpack issue where the resolver won't pick `module` fields in `package.json` files once it's importing from another `.mjs` file.

--- a/.changeset/loud-doors-think.md
+++ b/.changeset/loud-doors-think.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Make the extension of the main export unknown, this way a resolver will pick one from itself"

--- a/exchanges/graphcache/extras/package.json
+++ b/exchanges/graphcache/extras/package.json
@@ -1,7 +1,7 @@
 {
   "name": "urql-exchange-graphcache-extras",
   "private": true,
-  "main": "../dist/urql-exchange-graphcache-extras.js",
+  "main": "../dist/urql-exchange-graphcache-extras",
   "module": "../dist/urql-exchange-graphcache-extras.mjs",
   "types": "../dist/types/extras/index.d.ts",
   "source": "../src/extras/index.ts",

--- a/packages/core/internal/package.json
+++ b/packages/core/internal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "urql-core-internal",
   "private": true,
-  "main": "../dist/urql-core-internal.js",
+  "main": "../dist/urql-core-internal",
   "module": "../dist/urql-core-internal.mjs",
   "types": "../dist/types/internal/index.d.ts",
   "source": "../src/internal/index.ts",


### PR DESCRIPTION
Make the extension unknown so it can decide for itself what it likes the most, this is similar to https://github.com/FormidableLabs/urql/blob/master/packages/core/package.json#L21

Fixes: https://github.com/FormidableLabs/urql/issues/732