### PR TITLE
Add workaround for minification quirk in Metro Bundler

### DIFF
--- a/.changeset/afraid-flies-matter.md
+++ b/.changeset/afraid-flies-matter.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Hoist variables in unminified build output for Metro Bundler builds which otherwise fails for `process.env.NODE_ENV` if-clauses.

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -112,6 +112,9 @@ const terserPretty = terser({
   keep_fnames: true,
   ie8: false,
   compress: {
+    // We need to hoist vars for process.env.NODE_ENV if-clauses for Metro:
+    hoist_vars: true,
+    hoist_funs: true,
     pure_getters: true,
     toplevel: true,
     booleans_as_integers: false,


### PR DESCRIPTION
Fix #736 

Work around a quirk in Metro Bundler which leads to incorrect minification due to a missing hoisted variable when a `process.env.NODE_ENV` if-clause is removed.

This happens due to variable re-use, and Metro isn't equipped to hoist variables itself.