### PR TITLE
(graphcache) - Shift mutation results to top layer

### DIFF
--- a/.changeset/long-rocks-give.md
+++ b/.changeset/long-rocks-give.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Adjust mutation results priority to always override query results as they arrive, similarly to subscriptions. This will prevent race conditions when mutations are slow to execute at the cost of some consistency.

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1545,7 +1545,7 @@ describe('commutativity', () => {
     });
 
     expect(reexec).toHaveBeenCalledTimes(2);
-    expect(data).toHaveProperty('node.name', 'query b');
+    expect(data).toHaveProperty('node.name', 'mutation');
   });
 
   it('applies optimistic updates on top of commutative queries', () => {

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -220,9 +220,9 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
         optimisticKeysToDependencies.get(key)
       );
       optimisticKeysToDependencies.delete(key);
+    } else {
+      reserveLayer(store.data, operation.key);
     }
-
-    reserveLayer(store.data, operation.key);
 
     let queryDependencies: Set<string> | void;
     if (result.data) {

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -170,15 +170,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
   const updateDependencies = (op: Operation, dependencies: Set<string>) => {
     dependencies.forEach(dep => {
       (deps[dep] || (deps[dep] = [])).push(op.key);
-
-      if (!ops.has(op.key)) {
-        ops.set(
-          op.key,
-          op.context.requestPolicy === 'network-only'
-            ? toRequestPolicy(op, 'cache-and-network')
-            : op
-        );
-      }
+      ops.set(op.key, op);
     });
   };
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -145,11 +145,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
       operation.context.requestPolicy !== 'network-only'
     ) {
       // This executes an optimistic update for mutations and registers it if necessary
-      const { dependencies } = writeOptimistic(
-        store,
-        operation,
-        operation.key
-      );
+      const { dependencies } = writeOptimistic(store, operation, operation.key);
       if (dependencies.size !== 0) {
         optimisticKeysToDependencies.set(operation.key, dependencies);
         const pendingOperations = new Set<number>();

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -230,11 +230,9 @@ const readSelection = (
       (result && result.__typename)
     : key;
 
-  if (
-    typeof typename !== 'string' ||
-    (result && typename !== result.__typename)
-  ) {
-    // TODO: This may be an invalid error for resolvers that return interfaces
+  if (typeof typename !== 'string') {
+    return;
+  } else if (result && typename !== result.__typename) {
     warn(
       'Invalid resolver data: The resolver at `' +
         entityKey +
@@ -243,7 +241,7 @@ const readSelection = (
       8
     );
 
-    return undefined;
+    return;
   }
 
   // The following closely mirrors readSelection, but differs only slightly for the

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -229,6 +229,7 @@ describe('commutative changes', () => {
     expect(InMemoryData.readRecord('Query', 'index')).toBe(2);
 
     // Actively clearing out layer 2
+    InMemoryData.reserveLayer(data, 2);
     InMemoryData.noopDataState(data, 2);
 
     InMemoryData.initDataState(data, null);
@@ -240,8 +241,39 @@ describe('commutative changes', () => {
 
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(1);
+    InMemoryData.clearDataState();
 
     expect(data.optimisticOrder).toEqual([]);
+  });
+
+  it.only('discards optimistic order when concrete data is written', () => {
+    InMemoryData.reserveLayer(data, 1);
+    InMemoryData.reserveLayer(data, 2);
+    InMemoryData.reserveLayer(data, 3);
+
+    InMemoryData.initDataState(data, 2, true);
+    InMemoryData.writeRecord('Query', 'index', 2);
+    InMemoryData.clearDataState();
+
+
+    InMemoryData.initDataState(data, 3);
+    InMemoryData.writeRecord('Query', 'index', 3);
+    InMemoryData.clearDataState();
+
+    // Expect Layer 3
+    expect(data.optimisticOrder).toEqual([3, 2, 1]);
+    InMemoryData.initDataState(data, null);
+    expect(InMemoryData.readRecord('Query', 'index')).toBe(3);
+
+    // Write 2 again
+    InMemoryData.initDataState(data, 2);
+    InMemoryData.writeRecord('Query', 'index', 2);
+    InMemoryData.clearDataState();
+
+    // 2 has moved in front of 3
+    expect(data.optimisticOrder).toEqual([2, 3, 1]);
+    InMemoryData.initDataState(data, null);
+    expect(InMemoryData.readRecord('Query', 'index')).toBe(2);
   });
 
   it('overrides data using optimistic layers', () => {

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -255,7 +255,6 @@ describe('commutative changes', () => {
     InMemoryData.writeRecord('Query', 'index', 2);
     InMemoryData.clearDataState();
 
-
     InMemoryData.initDataState(data, 3);
     InMemoryData.writeRecord('Query', 'index', 3);
     InMemoryData.clearDataState();

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -229,7 +229,6 @@ describe('commutative changes', () => {
     expect(InMemoryData.readRecord('Query', 'index')).toBe(2);
 
     // Actively clearing out layer 2
-    InMemoryData.reserveLayer(data, 2);
     InMemoryData.noopDataState(data, 2);
 
     InMemoryData.initDataState(data, null);
@@ -246,13 +245,14 @@ describe('commutative changes', () => {
     expect(data.optimisticOrder).toEqual([]);
   });
 
-  it.only('discards optimistic order when concrete data is written', () => {
+  it('discards optimistic order when concrete data is written', () => {
     InMemoryData.reserveLayer(data, 1);
     InMemoryData.reserveLayer(data, 2);
     InMemoryData.reserveLayer(data, 3);
 
     InMemoryData.initDataState(data, 2, true);
     InMemoryData.writeRecord('Query', 'index', 2);
+    InMemoryData.writeRecord('Query', 'optimistic', true);
     InMemoryData.clearDataState();
 
     InMemoryData.initDataState(data, 3);
@@ -263,6 +263,7 @@ describe('commutative changes', () => {
     expect(data.optimisticOrder).toEqual([3, 2, 1]);
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(3);
+    expect(InMemoryData.readRecord('Query', 'optimistic')).toBe(true);
 
     // Write 2 again
     InMemoryData.initDataState(data, 2);
@@ -273,6 +274,7 @@ describe('commutative changes', () => {
     expect(data.optimisticOrder).toEqual([2, 3, 1]);
     InMemoryData.initDataState(data, null);
     expect(InMemoryData.readRecord('Query', 'index')).toBe(2);
+    expect(InMemoryData.readRecord('Query', 'optimistic')).toBe(undefined);
   });
 
   it('overrides data using optimistic layers', () => {

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -92,6 +92,8 @@ export const initDataState = (
       clearLayer(data, layerKey);
       reserveLayer(data, layerKey);
     } else if (isOptimistic) {
+      // NOTE: This optimally shouldn't happen as it implies that an optimistic
+      // write is being performed after a concrete write.
       data.commutativeKeys.delete(layerKey);
     }
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -80,16 +80,11 @@ export const initDataState = (
 
   if (!layerKey) {
     currentOptimisticKey = null;
-  } else if (
-    isOptimistic ||
-    (data.optimisticOrder.length > 1 &&
-      data.optimisticOrder.indexOf(layerKey) > -1)
-  ) {
+  } else if (isOptimistic || data.optimisticOrder.length > 0) {
     // If this operation isn't optimistic and we see it for the first time,
     // then it must've been optimistic in the past, so we can proactively
     // clear the optimistic data before writing
     if (!isOptimistic && !data.commutativeKeys.has(layerKey)) {
-      clearLayer(data, layerKey);
       reserveLayer(data, layerKey);
     } else if (isOptimistic) {
       // NOTE: This optimally shouldn't happen as it implies that an optimistic

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -468,6 +468,9 @@ export const reserveLayer = (data: InMemoryData, layerKey: number) => {
     // keys but after all non-commutative keys (which are added by `forceUpdate`)
     data.optimisticOrder.unshift(layerKey);
   } else if (!data.commutativeKeys.has(layerKey)) {
+    // Protect optimistic layers from being turned into non-optimistic layers
+    // while preserving optimistic data
+    clearLayer(data, layerKey);
     // If the layer was an optimistic layer prior to this call, it'll be converted
     // to a new non-optimistic layer and shifted ahead
     data.optimisticOrder.splice(index, 1);


### PR DESCRIPTION
This makes a slight adjustment to the data layer reservation.
Optimistic Mutation layers are now not only cleared but will be
shifted to the front of the optimistic order queue when they're
written with a concrete result (non optimistic result).

The optimistic mutation layer is therefore still discarded but
the layer itself is reused, which allows for slight adjustments
in how layers are handled when they transition from being
optimistic to non-optimistic.

This also makes an adjustment that allows layers to transition
from being non-optimistic to optimistic. This shouldn't happen
in practice, but protects us from race-conditions.