### PR TITLE
Fix a typo in docs

### DIFF
--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -79,7 +79,7 @@ the "Queries" page in the "Basics" section.](../basics/queries.md)
 
 Its usage is extremely similar in that it accepts options, which may contain `query` and
 `variables`. However, it also accepts a second argument, which is a reducer function, similar to
-what you would pass to `Array.prootype.reduce`.
+what you would pass to `Array.prototype.reduce`.
 
 It receives the previous set of data that this function has returned or `undefined`.
 As the second argument, it receives the event that has come in from the subscription.


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

This PR fixes a small typo found on [this documentation page](https://formidable.com/open-source/urql/docs/advanced/subscriptions/#react--preact).

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

```diff
- what you would pass to `Array.prootype.reduce`.
+ what you would pass to `Array.prototype.reduce`.
```