### PR TITLE
(svelte) - Promise mutation result

### DIFF
--- a/.changeset/smart-adults-suffer.md
+++ b/.changeset/smart-adults-suffer.md
@@ -2,4 +2,4 @@
 '@urql/svelte': patch
 ---
 
-Return the promise from mutation instead of the promise-like object
+Update `mutate` helper to return a Promise directly rather than a lazy Promise-like object.

--- a/.changeset/smart-adults-suffer.md
+++ b/.changeset/smart-adults-suffer.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': patch
+---
+
+Return the promise from mutation instead of the promise-like object

--- a/packages/svelte-urql/src/operations/mutate.ts
+++ b/packages/svelte-urql/src/operations/mutate.ts
@@ -11,19 +11,6 @@ export interface MutationArguments<V> {
 
 export const mutate = <T = any, V = object>(
   args: MutationArguments<V>
-): PromiseLike<OperationResult<T>> => {
-  const client = getClient();
-  let promise: Promise<OperationResult<T>>;
-
-  return {
-    then(onValue) {
-      if (!promise) {
-        promise = client
-          .mutation(args.query, args.variables as any, args.context)
-          .toPromise();
-      }
-
-      return promise.then(onValue);
-    },
-  };
+): Promise<OperationResult<T>> => {
+  return getClient().mutation(args.query, args.variables as any, args.context).toPromise();
 };

--- a/packages/svelte-urql/src/operations/mutate.ts
+++ b/packages/svelte-urql/src/operations/mutate.ts
@@ -12,5 +12,7 @@ export interface MutationArguments<V> {
 export const mutate = <T = any, V = object>(
   args: MutationArguments<V>
 ): Promise<OperationResult<T>> => {
-  return getClient().mutation(args.query, args.variables as any, args.context).toPromise();
+  return getClient()
+    .mutation(args.query, args.variables as any, args.context)
+    .toPromise();
 };


### PR DESCRIPTION
Moves to a normal promise instead of the promise-like object. We'll probably have to look into a test-suite for this content before we go stable (and we're sure about the API)
