### PR TITLE
(persisted-fetch) - Fix hash not being sent after Not Found error

### DIFF
--- a/.changeset/little-years-cough.md
+++ b/.changeset/little-years-cough.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted-fetch': patch
+---
+
+Fix `persistedFetchExchange` not sending the SHA256 hash extension after a cache miss (`PersistedQueryNotFound` error)

--- a/exchanges/persisted-fetch/src/__snapshots__/persistedFetchExchange.test.ts.snap
+++ b/exchanges/persisted-fetch/src/__snapshots__/persistedFetchExchange.test.ts.snap
@@ -4,6 +4,6 @@ exports[`accepts successful persisted query responses 1`] = `"{\\"operationName\
 
 exports[`supports cache-miss persisted query errors 1`] = `"{\\"operationName\\":\\"getUser\\",\\"variables\\":{\\"name\\":\\"Clara\\"},\\"extensions\\":{\\"persistedQuery\\":{\\"version\\":1,\\"sha256Hash\\":\\"bfa84414672fe625d36f2d2a52e1d3c1e71c5a01e79599c320db7656d6f014d4\\"}}}"`;
 
-exports[`supports cache-miss persisted query errors 2`] = `"{\\"query\\":\\"query getUser($name: String) {\\\\n  user(name: $name) {\\\\n    id\\\\n    firstName\\\\n    lastName\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"getUser\\",\\"variables\\":{\\"name\\":\\"Clara\\"}}"`;
+exports[`supports cache-miss persisted query errors 2`] = `"{\\"query\\":\\"query getUser($name: String) {\\\\n  user(name: $name) {\\\\n    id\\\\n    firstName\\\\n    lastName\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"getUser\\",\\"variables\\":{\\"name\\":\\"Clara\\"},\\"extensions\\":{\\"persistedQuery\\":{\\"version\\":1,\\"sha256Hash\\":\\"bfa84414672fe625d36f2d2a52e1d3c1e71c5a01e79599c320db7656d6f014d4\\"}}}"`;
 
 exports[`supports unsupported persisted query errors 1`] = `"{\\"operationName\\":\\"getUser\\",\\"variables\\":{\\"name\\":\\"Clara\\"},\\"extensions\\":{\\"persistedQuery\\":{\\"version\\":1,\\"sha256Hash\\":\\"bfa84414672fe625d36f2d2a52e1d3c1e71c5a01e79599c320db7656d6f014d4\\"}}}"`;


### PR DESCRIPTION
Resolve #764

Previously the `persistedFetchExchange` wasn't correctly sending the SHA256 when a cache miss occurred.