### PR TITLE
(docs) - Restructure Debugging document

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - ⚙️ Fully **customisable** behaviour [via "exchanges"](https://formidable.com/open-source/urql/docs/concepts/exchanges)
 - 🗂 Logical but simple default behaviour and document caching
 - 🌱 Normalized caching via [`@urql/exchange-graphcache`](https://formidable.com/open-source/urql/docs/graphcache)
+- 🔬 Easy debugging with the [`urql` devtools browser extensions](https://formidable.com/open-source/urql/docs/advanced/debugging/)
 
 `urql` is a GraphQL client that exposes a set of helpers for several frameworks. It's built to be highly customisable and versatile so you can take it from getting started with your first GraphQL project all the way to building complex apps and experimenting with GraphQL clients.
 

--- a/docs/advanced/debugging.md
+++ b/docs/advanced/debugging.md
@@ -8,9 +8,9 @@ order: 6
 We've tried to make debugging in `urql` as seamless as possible by creating tools for users of `urql`
 and those creating their own exchanges.
 
-## Browser Devtools
+## Devtools
 
-The quickest way to debug `urql` is to use the [`urql` devtools Chrome and Firefox
+The quickest way to debug `urql` is to use the [`urql` devtools]
 extension.](https://github.com/FormidableLabs/urql-devtools/).
 
 It offers tools to inspect internal ["Debug Events"](#debug-events) as they happen, to explore data

--- a/docs/advanced/debugging.md
+++ b/docs/advanced/debugging.md
@@ -13,13 +13,8 @@ and those creating their own exchanges.
 The quickest way to debug `urql` is to use the [`urql` devtools Chrome and Firefox
 extension.](https://github.com/FormidableLabs/urql-devtools/).
 
-It displays consists of three tools, the "Explorer", the "Events" tab, and the "Request" tab, which
-allow you to:
-
-- visualize events on a timeline as they happen
-- filter and inspect events (which are more granular than Operations and Operation Results)
-- inspect all previously fetched data, as it would be seen by a cache exchange
-- trigger custom GraphQL queries on the running Client
+It offers tools to inspect internal ["Debug Events"](#debug-events) as they happen, to explore data
+as your app is seeing it, and to quickly trigger GraphQL queries.
 
 ![Urql Devtools Timeline](../assets/devtools-timeline.png)
 

--- a/docs/advanced/debugging.md
+++ b/docs/advanced/debugging.md
@@ -16,37 +16,10 @@ extension.](https://github.com/FormidableLabs/urql-devtools/).
 It offers tools to inspect internal ["Debug Events"](#debug-events) as they happen, to explore data
 as your app is seeing it, and to quickly trigger GraphQL queries.
 
+[For instructions on how to set up the devtools, check out `@urql/devtools`'s readme in its
+repository.](https://github.com/FormidableLabs/urql-devtools)
+
 ![Urql Devtools Timeline](../assets/devtools-timeline.png)
-
-### Installation and Setup
-
-First, we can add the devtools by installing either the [Chrome
-Extension](https://chrome.google.com/webstore/detail/urql-devtools/mcfphkbpmkbeofnkjehahlmidmceblmm)
-or the [Firefox Addon](https://addons.mozilla.org/en-GB/firefox/addon/urql-devtools/).
-
-Then we'll have to install the `@urql/devtools` package:
-
-```sh
-yarn add --dev @urql/devtools
-# or
-npm install --save-dev @urql/devtools
-```
-
-And lastly, we'll need to add the `devtoolsExchange` to our list of exchanges. Typically we'd want
-to add it as either the first exchange or at least in front of the `dedupExchange`:
-
-```js
-import { createClient, defaultExchanges } from 'urql';
-import { devtoolsExchange } from '@urql/devtools';
-
-const client = createClient({
-  url: 'http://localhost:3000/graphql',
-  // First `devtoolsExchange` then the rest:
-  exchanges: [devtoolsExchange, ...defaultExchanges],
-});
-```
-
-[Read more about the `urql` devtools setup on its repository.](https://github.com/FormidableLabs/urql-devtools)
 
 ## Debug events
 


### PR DESCRIPTION
- Put the "Browser Devtools" first, i.e. front and centre.
  Most people are likely to access the page to debug and not to create
  exchanges with debugging information, hence the Devtools should be
  at the top with immediately actionable installation instructions.
- The intro for devtools was split up into too many headings.
  Showing headings from `h1 > h2 > h3` in quick succession with only one
  paragraph each is hard to read, so they're now using more full sentences
  and bullet point lists instead.
- Devtools was nested in "consuming events". IMHO Consuming programmatically
  compared to the Browser Devtools is very different for our users. Either
  someone is reading this to *debug* or to *create a debugger* but never
  really for both at a time.
- Remove `h4`. We don't use them;
- Shorten tips and avoid `h4`.
- Add table for `DebugEvent` type.
