### PR TITLE
Fix missing package.json entry in exports field

### DIFF
--- a/.changeset/flat-buses-develop.md
+++ b/.changeset/flat-buses-develop.md
@@ -9,4 +9,4 @@
 '@urql/svelte': patch
 ---
 
-Add the package.json entry to the exports for Node 14
+Add a `"./package.json"` entry to the `package.json`'s `"exports"` field for Node 14. This seems to be required by packages like `rollup-plugin-svelte` to function properly.

--- a/.changeset/flat-buses-develop.md
+++ b/.changeset/flat-buses-develop.md
@@ -1,0 +1,12 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/exchange-multipart-fetch': patch
+'@urql/exchange-persisted-fetch': patch
+'@urql/exchange-populate': patch
+'@urql/exchange-retry': patch
+'@urql/core': patch
+'@urql/preact': patch
+'@urql/svelte': patch
+---
+
+Add the package.json entry to the exports for Node 14

--- a/.changeset/red-mails-mix.md
+++ b/.changeset/red-mails-mix.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-populate': patch
+---
+
+Fix `visitWithTypeInfo` import

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -30,6 +30,7 @@
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     },
+    "./package.json": "./package.json",
     "./extras": {
       "import": "./dist/urql-exchange-graphcache-extras.mjs",
       "require": "./dist/urql-exchange-graphcache-extras.js",

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -26,7 +26,8 @@
       "require": "./dist/urql-exchange-multipart-fetch.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "LICENSE",

--- a/exchanges/persisted-fetch/package.json
+++ b/exchanges/persisted-fetch/package.json
@@ -27,7 +27,8 @@
       "require": "./dist/urql-exchange-persisted-fetch.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "LICENSE",

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -26,7 +26,8 @@
       "require": "./dist/urql-exchange-populate.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "LICENSE",

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -29,7 +29,8 @@
       "require": "./dist/urql-exchange-retry.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "LICENSE",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     },
+    "./package.json": "./package.json",
     "./internal": {
       "import": "./dist/urql-core-internal.mjs",
       "require": "./dist/urql-core-internal.js",

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -29,7 +29,8 @@
       "require": "./dist/urql-preact.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "LICENSE",

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -29,7 +29,8 @@
       "require": "./dist/urql-svelte.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "LICENSE",

--- a/scripts/prepare/index.js
+++ b/scripts/prepare/index.js
@@ -101,9 +101,12 @@ if (hasReact) {
 } else {
   invariant(!!pkg.exports, 'package.json:exports must be added and have a "." entry');
   invariant(!!pkg.exports['.'], 'package.json:exports must have a "." entry');
+  invariant(!!pkg.exports['./package.json'], 'package.json:exports must have a "./package.json" entry')
 
   for (const key in pkg.exports) {
     const entry = pkg.exports[key];
+    if (entry === './package.json') continue;
+
     const entryName = normalize(key);
     const bundleName = entryName ? `${name}-${entryName}` : name;
     invariant(

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -24,7 +24,8 @@ const input = settings.sources.reduce((acc, source) => {
             require: join(rel, source.main),
             types: join(rel, source.types),
             source: join(rel, source.source),
-          }
+          },
+          './package.json': './package.json'
         }
       }
     }));

--- a/scripts/rollup/settings.js
+++ b/scripts/rollup/settings.js
@@ -14,6 +14,7 @@ export const name = normalize(pkg.name);
 
 export const sources = pkg.exports
   ? Object.keys(pkg.exports).map(entry => {
+    if (entry === './package.json') return undefined;
     const exports = pkg.exports[entry];
     const dir = normalize(entry);
     return {
@@ -24,7 +25,7 @@ export const sources = pkg.exports
       types: exports.types,
       source: exports.source,
     };
-  }) : [{
+  }).filter(Boolean) : [{
     name,
     source: pkg.source || './src/index.ts'
   }];


### PR DESCRIPTION
Fix #770 
Fix #708

## Summary

Adds the `./package.json` exports entry for Node 14.

## Set of changes

- add `./package.json` to exports
