### PR TITLE
(graphache) - Fix query traversal for previous null fields

### DIFF
--- a/.changeset/slimy-chairs-sniff.md
+++ b/.changeset/slimy-chairs-sniff.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix traversal issue, where when a prior selection set has set a nested result field to `null`, a subsequent traversal of this field attempts to access `prevData` on `null`.

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -42,7 +42,7 @@ describe('Query', () => {
       }
     );
 
-    // jest.resetAllMocks();
+    jest.resetAllMocks();
   });
 
   it('test partial results', () => {
@@ -188,7 +188,7 @@ describe('Query', () => {
     });
   });
 
-  it.only('should allow subsequent read when first result was null', () => {
+  it('should allow subsequent read when first result was null', () => {
     const QUERY_WRITE = gql`
       query writeTodos {
         todos {
@@ -245,14 +245,7 @@ describe('Query', () => {
     ({ data } = query(store, { query: QUERY_READ }));
     expect(data).toEqual({
       __typename: 'query_root',
-      todos: [
-        {
-          __typename: 'Todo',
-          id: '0',
-          // TODO: By the spec this should actually be `null`
-          // text: null,
-        },
-      ],
+      todos: [null],
     });
   });
 });

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -187,4 +187,54 @@ describe('Query', () => {
       todos: [{ __typename: 'Todo', id: '0', text: 'Solve bug' }],
     });
   });
+
+  it('supports double-traversing null entities', () => {
+    const QUERY = gql`
+      query getTodos {
+        todos {
+          id
+          a: author {
+            id
+          }
+          b: author {
+            id
+          }
+        }
+      }
+    `;
+
+    const store = new Store({ schema: alteredRoot });
+
+    let { data } = query(store, { query: QUERY });
+    expect(data).toEqual(null);
+
+    write(
+      store,
+      { query: QUERY },
+      {
+        todos: [
+          {
+            __typename: 'Todo',
+            id: '0',
+            a: null,
+            b: null,
+          },
+        ],
+        __typename: 'query_root',
+      }
+    );
+
+    ({ data } = query(store, { query: QUERY }));
+    expect(data).toEqual({
+      __typename: 'query_root',
+      todos: [
+        {
+          __typename: 'Todo',
+          id: '0',
+          a: null,
+          b: null,
+        },
+      ],
+    });
+  });
 });

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -198,6 +198,7 @@ describe('Query', () => {
           }
           b: author {
             id
+            text
           }
         }
       }
@@ -216,7 +217,11 @@ describe('Query', () => {
           {
             __typename: 'Todo',
             id: '0',
-            a: null,
+            a: {
+              __typename: 'Author',
+              id: '1',
+            },
+            // Suppose the text field is missing but was required
             b: null,
           },
         ],
@@ -231,7 +236,7 @@ describe('Query', () => {
         {
           __typename: 'Todo',
           id: '0',
-          a: null,
+          a: null, // TODO: This should be fixed to not be null
           b: null,
         },
       ],

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -410,7 +410,7 @@ const resolveResolverResult = (
         joinKeys(key, `${i}`),
         select,
         // Get the inner previous data from prevData
-        prevData ? prevData[i] : undefined,
+        prevData != null ? prevData[i] : undefined,
         result[i]
       );
 
@@ -466,7 +466,7 @@ const resolveLink = (
         typename,
         fieldName,
         select,
-        prevData ? prevData[i] : undefined
+        prevData != null ? prevData[i] : undefined
       );
       if (childLink === undefined && !_isListNullable) {
         return undefined;

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -391,7 +391,7 @@ const resolveResolverResult = (
   fieldName: string,
   key: string,
   select: SelectionSet,
-  prevData: void | Data | Data[],
+  prevData: void | null | Data | Data[],
   result: void | DataField
 ): DataField | void => {
   if (Array.isArray(result)) {
@@ -410,7 +410,7 @@ const resolveResolverResult = (
         joinKeys(key, `${i}`),
         select,
         // Get the inner previous data from prevData
-        prevData !== undefined ? prevData[i] : undefined,
+        prevData ? prevData[i] : undefined,
         result[i]
       );
 
@@ -425,7 +425,7 @@ const resolveResolverResult = (
   } else if (result === null || result === undefined) {
     return result;
   } else if (isDataOrKey(result)) {
-    const data = (prevData === undefined ? {} : prevData) as Data;
+    const data = (prevData || {}) as Data;
     return typeof result === 'string'
       ? readSelection(ctx, result, select, data)
       : readSelection(ctx, key, select, data, result);
@@ -448,7 +448,7 @@ const resolveLink = (
   typename: string,
   fieldName: string,
   select: SelectionSet,
-  prevData: void | Data | Data[]
+  prevData: void | null | Data | Data[]
 ): DataField | undefined => {
   if (Array.isArray(link)) {
     const { store } = ctx;
@@ -462,7 +462,7 @@ const resolveLink = (
         typename,
         fieldName,
         select,
-        prevData !== undefined ? prevData[i] : undefined
+        prevData ? prevData[i] : undefined
       );
       if (childLink === undefined && !_isListNullable) {
         return undefined;
@@ -475,12 +475,7 @@ const resolveLink = (
   } else if (link === null) {
     return null;
   } else {
-    return readSelection(
-      ctx,
-      link,
-      select,
-      prevData === undefined ? ({} as any) : prevData
-    );
+    return readSelection(ctx, link, select, (prevData || {}) as Data);
   }
 };
 

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -424,6 +424,10 @@ const resolveResolverResult = (
     return data;
   } else if (result === null || result === undefined) {
     return result;
+  } else if (prevData === null) {
+    // If we've previously set this piece of data to be null,
+    // we skip it and return null immediately
+    return null;
   } else if (isDataOrKey(result)) {
     const data = (prevData || {}) as Data;
     return typeof result === 'string'
@@ -472,7 +476,9 @@ const resolveLink = (
     }
 
     return newLink;
-  } else if (link === null) {
+  } else if (link === null || prevData === null) {
+    // If the link is set to null or we previously set this piece of data to be null,
+    // we skip it and return null immediately
     return null;
   } else {
     return readSelection(ctx, link, select, (prevData || {}) as Data);


### PR DESCRIPTION
Fix #768

## Summary

This issue occurs when a previous selection determined a field to be `null`. A future selection that doesn't result in `null` is then forced to retrieved `prevData`, but isn't covering the `null` case.

This can happen with split selections on a single entity, e.g.

```
query Item {
  ...NullItem
  ...ValidItem
}

fragment NullItem {
  item {
    id
    invalid # Suppose this causes the item to become null, due to an invalid field
  }
}

fragment ValidItem {
  item {
    id
  }
}
```

- On the first traversal, the `NullItem` fragment hits `invalid` which causes `Query.item` to become `null`
- On the second traversal, the `Validitem` fragment hits `id` and tries to write it, but `Query.item` is already `null`

This can only happen with schema awareness most of the time.

## Set of changes

- Handle `prevData === null` by switching most of its uses to a truthy rather than an `undefined` check.
- Fix case where `prevData === null` leads to further traversal

## Outstanding edge cases

~The **read** edge case can be seen in this PR's test case, when a traversal fails and returns `undefined`, then the second traversal doesn't set the affected field to `null`.~