### PR TITLE
(graphcache) - Fix unkeyable warnings for introspection results

### DIFF
--- a/.changeset/weak-clocks-yawn.md
+++ b/.changeset/weak-clocks-yawn.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix Introspection Queries (or internal types in general) triggering lots of warnings for unkeyed entities.

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -291,6 +291,9 @@ const writeSelection = (
   }
 };
 
+// A pattern to match typenames of types that are likely never keyable
+const KEYLESS_TYPE_RE = /^__|PageInfo|(Connection|Edge)$/;
+
 const writeField = (
   ctx: Context,
   select: SelectionSet,
@@ -324,9 +327,7 @@ const writeField = (
     ctx.store.keys[data.__typename] === undefined &&
     entityKey === null &&
     typeof typename === 'string' &&
-    !typename.endsWith('Connection') &&
-    !typename.endsWith('Edge') &&
-    typename !== 'PageInfo'
+    !KEYLESS_TYPE_RE.test(typename)
   ) {
     warn(
       'Invalid key: The GraphQL query at the field at `' +


### PR DESCRIPTION
## Summary

This fixes the typical Graphcache warnings for unkeyable entities to be muted for internal types, like `__Type`, which by convention start with double-underscores and are only used for any kind of introspection query.

## Set of changes

- Replace "Invalid key" warning check with regex pattern
- Update regex pattern to include `^__`
