### PR TITLE
Fix example not working without a page reload on first open.

### DIFF
--- a/packages/react-urql/examples/1-getting-started/src/index.tsx
+++ b/packages/react-urql/examples/1-getting-started/src/index.tsx
@@ -1,28 +1,38 @@
 import React, { FC, StrictMode } from 'react';
 import * as ReactDOM from 'react-dom';
-import { createClient, Provider, defaultExchanges } from 'urql';
+import { createClient, Provider, defaultExchanges, Client } from 'urql';
 import { devtoolsExchange } from '@urql/devtools';
 import { Home } from './pages';
 import './index.css';
 
-navigator.serviceWorker.register('./service-worker.ts', { scope: '/' });
+interface AppProps {
+  client: Client,
+}
 
-const client = createClient({
-  url: '/sw/graphql',
-  exchanges: [devtoolsExchange, ...defaultExchanges],
-});
-
-export const App: FC = () => (
-  <StrictMode>
-    <Provider value={client}>
-      <main>
-        <h1>Todos</h1>
-        <Home />
-      </main>
-    </Provider>
-  </StrictMode>
-);
+export const App: FC<AppProps> = ({client}) => {
+  return (
+    <StrictMode>
+      <Provider value={client}>
+        <main>
+          <h1>Todos</h1>
+          <Home />
+        </main>
+      </Provider>
+    </StrictMode>
+  );
+};
 
 App.displayName = 'App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+async function initPage() {
+  await navigator.serviceWorker.register('./service-worker.ts', { scope: '/' });
+
+  const client = createClient({
+    url: '/sw/graphql',
+    exchanges: [devtoolsExchange, ...defaultExchanges],
+  });
+
+  ReactDOM.render(<App client={client} />, document.getElementById('root'));
+}
+
+initPage();

--- a/packages/react-urql/examples/1-getting-started/src/service-worker.ts
+++ b/packages/react-urql/examples/1-getting-started/src/service-worker.ts
@@ -8,6 +8,10 @@ self.addEventListener('install', (event: any) => {
   event.waitUntil(self.skipWaiting());
 });
 
+self.addEventListener('activate', (event) => {
+  self.clients.claim();
+});
+
 self.addEventListener('fetch', (event: any) => {
   const request = event.request;
 


### PR DESCRIPTION
## Summary

Resolves #782.

## Set of changes

The crucial change is adding `self.clients.claim();`. Without this, overriding `fetch` in the service worker does not work until the page is reloaded.