### PR TITLE
(chore) - Add issue template for RFCs

### DIFF
--- a/.github/ISSUE_TEMPLATE/RFC.md
+++ b/.github/ISSUE_TEMPLATE/RFC.md
@@ -17,8 +17,8 @@ labels: "future \U0001F52E"
 ## Summary
 
 <!--
-  Describe in a couple of words WHAT you're proposing.
-  If relevant, include WHY this should be addressed now.
+  Describe in a couple of words *what* you're proposing.
+  If relevant, include *why* this should be addressed now.
   The problem should be clearly stated and the solution
   should be summarised.
 -->
@@ -27,17 +27,16 @@ labels: "future \U0001F52E"
 
 <!--
   Explain the solution you're proposing in detail.
-  HOW will this change be implemented?
-  HOW does it work?
+  *How* will this change be implemented, and how does it work?
 -->
 
 ## Requirements
 
 <!--
-  This section is OPTIONAL.
+  This section is *optional*.
   But if your proposed solution has multiple ways
   of being implemented, you don't want to state how
   it may be implemented, or you don't know yet how
   it will be implemented, then:
-  List what the implementation needs to do at the very least.
+  *List* what the implementation needs to achieve to fulfil this RFC;
 -->

--- a/.github/ISSUE_TEMPLATE/RFC.md
+++ b/.github/ISSUE_TEMPLATE/RFC.md
@@ -1,6 +1,6 @@
 ---
 name: 'RFC'
-about: Create a proposal for an enhancement and start a discussion
+about: Propose an enhancement / feature and start a discussion
 title: 'RFC: Your Proposal'
 labels: "future \U0001F52E"
 ---

--- a/.github/ISSUE_TEMPLATE/RFC.md
+++ b/.github/ISSUE_TEMPLATE/RFC.md
@@ -1,0 +1,43 @@
+---
+name: 'RFC'
+about: Create a proposal for an enhancement and start a discussion
+title: 'RFC: Your Proposal'
+labels: "future \U0001F52E"
+---
+
+<!--
+  🚨 RFCs are for proposed changes (not bugs or questions)
+  Specifically they are whenever you'd like to see new features
+  being added to urql, or enable new use-cases.
+  They're also relevant whenever @urql/core is changed, since
+  changes to e.g. the `Client` or `Exchange` types are kept rare
+  and lean.
+-->
+
+## Summary
+
+<!--
+  Describe in a couple of words WHAT you're proposing.
+  If relevant, include WHY this should be addressed now.
+  The problem should be clearly stated and the solution
+  should be summarised.
+-->
+
+## Proposed Solution
+
+<!--
+  Explain the solution you're proposing in detail.
+  HOW will this change be implemented?
+  HOW does it work?
+-->
+
+## Requirements
+
+<!--
+  This section is OPTIONAL.
+  But if your proposed solution has multiple ways
+  of being implemented, you don't want to state how
+  it may be implemented, or you don't know yet how
+  it will be implemented, then:
+  List what the implementation needs to do at the very least.
+-->


### PR DESCRIPTION
Following from our other RFCs, this PR adds a template for RFCs based on:

- https://github.com/FormidableLabs/urql/issues/683
- https://github.com/FormidableLabs/urql/issues/747

And with instructions in comments of the template that also match:

- https://github.com/FormidableLabs/urql/issues/423
- https://github.com/FormidableLabs/urql/issues/472
- https://github.com/FormidableLabs/urql/issues/360

This will allow outside collaborators to also propose wide-ranging changes (be it breaking changes or vast enhancements / features that lead to dramatic `@urql/core` changes)

Putting RFCs and proposals out in the open will hopefully encourage more people to weigh in with arguments for/against proposals, to note on caveats early on, or to collaborate on opinions on and suggestions for an implementation.

Since not every RFC / proposal has a fixed solution, this also encourages us to fully discuss and inspect problems, before we arrive on a fixed conclusion and implementation plan.

It also gives us an opportunity to assign people other than the RFC author to an RFC, to work on the implementation as needed.

