### PR TITLE
(next-urql) - getStaticProps & getServerProps

### DIFF
--- a/.changeset/two-crews-share.md
+++ b/.changeset/two-crews-share.md
@@ -1,0 +1,5 @@
+---
+'next-urql': minor
+---
+
+Provide new argument to `withUrqlClient` that allows for not binding the component-tree with `getInitialProps` this to allow for users to use `getStaticProps`.

--- a/.changeset/two-crews-share.md
+++ b/.changeset/two-crews-share.md
@@ -1,5 +1,12 @@
 ---
-'next-urql': minor
+'next-urql': major
 ---
 
-Provide new argument to `withUrqlClient` that allows for not binding the component-tree with `getInitialProps` this to allow for users to use `getStaticProps`.
+change how `getInitialProps` is applied, this will now be applied when the page wrapped in `withUrqlClient` implements `getInitialProps` or when you
+pass it to the new second argument of `withUrqlClient`. This can be done like this:
+
+```js
+withUrqlClient(() => client, { ssr: true })(App);
+```
+
+This is to better support alternative methods like `getStaticProps`.

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -238,7 +238,6 @@ export default withUrqlClient(ssrExchange => ({
 }))(Index);
 ```
 
-The `withUrqlClient` higher-order component function accepts a third parameter in case you are using
-[`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation),
-this third `boolean` parameter allows you to opt-out of binding `getInitialProps` to the component-tree.
-This means that only the `client` will be provided.
+The `withUrqlClient` higher-order component function accepts a second parameter called the `options`,
+these have one option for now, `ssr`, we can use this when the wrapped `page` does not implement
+`getInitialProps` but children down the tree do.

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -238,6 +238,5 @@ export default withUrqlClient(ssrExchange => ({
 }))(Index);
 ```
 
-The `withUrqlClient` higher-order component function accepts a second parameter called the `options`,
-these have one option for now, `ssr`, we can use this when the wrapped `page` does not implement
-`getInitialProps` but children down the tree do.
+Unless the component that is being wrapped already has a `getInitialProps` method, `next-urql` won't add its own SSR logic, which automatically fetches queries during
+server-side rendering. This can be explicitly enabled by passing the `{ ssr: true }` option as a second argument to `withUrqlClient`.

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -238,7 +238,7 @@ export default withUrqlClient(ssrExchange => ({
 }))(Index);
 ```
 
-The `withUrqlClient` higher-order component function accepts a thirth parameter in case you are using
+The `withUrqlClient` higher-order component function accepts a third parameter in case you are using
 [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation),
-this thirth `boolean` parameter allows you to opt-out of binding `getInitialProps` to the component-tree.
+this third `boolean` parameter allows you to opt-out of binding `getInitialProps` to the component-tree.
 This means that only the `client` will be provided.

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -237,3 +237,8 @@ export default withUrqlClient(ssrExchange => ({
   exchanges: [dedupExchange, cacheExchange, ssrExchange, fetchExchange],
 }))(Index);
 ```
+
+The `withUrqlClient` higher-order component function accepts a thirth parameter in case you are using
+[`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation),
+this thirth `boolean` parameter allows you to opt-out of binding `getInitialProps` to the component-tree.
+This means that only the `client` will be provided.

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -127,6 +127,12 @@ When you're using `withUrqlClient` and you don't return an `exchanges` property 
 
 When you yourself want to pass exchanges don't forget to include the `ssrExchange` you received as the first argument.
 
+#### `withUrqlClientOptions`
+
+The second argument for `withUrqlClient` is an options object, this contains one `boolean` property named `ssr`, you can use this to tell
+`withUrqlClient` that the wrapped component does not use `getInitialProps` but the children of this wrapped component do. This opts you into
+`ssr` for these children.
+
 ### Different Client configurations on the client and the server
 
 There are use cases where you may need different configurations for your `urql` Client on the client-side and the server-side; for example, you may want to interact with one GraphQL endpoint on the server-side and another on the client-side. `next-urql` supports this as of v0.3.0. We recommend using `typeof window === 'undefined'` or a `process.browser` check.
@@ -205,4 +211,7 @@ You can see simple example projects using `next-urql` in the `examples` director
 
 ### Caveats
 
-`withUrqlClient` implements Next's unique `getInitialProps` method under the hood. This means that any page containing a component wrapped by `withUrqlClient` will be opted out of [automatic static optimization](https://nextjs.org/docs#automatic-static-optimization). Automatic static optimization was added in Next v9, so you shouldn't worry about this if using an earlier version of Next. This is **not** unique to `next-urql` – any implementation of `getInitialProps` by any component in your application will cause Next to opt out of automatic static optimization.
+Using `withUrqlClient` on a page that has `getInitialProps` will opt that component and it's children into a prepass that does a first pass of all queries, when that
+component has children using `getInitialProps` but that component itself is not and you want to opt in to this behavior you'll have to set the second argument of
+`withUrqlClient`, this means `withUrqlClient(() => clientOptiosn, { ssr:true })`.
+This measure is available so we can support `getStaticProps`, ...

--- a/packages/next-urql/src/types.ts
+++ b/packages/next-urql/src/types.ts
@@ -48,3 +48,7 @@ export interface SSRExchange extends Exchange {
   /** Extracts cached data */
   extractData(): SSRData;
 }
+
+export interface WithUrqlClientOptions {
+  ssr?: boolean;
+}

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -52,7 +52,13 @@ export function withUrqlClient(getClientConfig: NextUrqlClientConfig, ssr?: bool
     // Set the displayName to indicate use of withUrqlClient.
     withUrql.displayName = `withUrqlClient(${getDisplayName(AppOrPage)})`;
 
+<<<<<<< HEAD
     if (AppOrPage.getInitialProps || ssr) {
+=======
+    // TODO: this should probably become (AppOrPage.getInitialProps || ssr) in
+    // the next major bump.
+    if (AppOrPage.getInitialProps || !noSsr) {
+>>>>>>> add docs and changeset
       withUrql.getInitialProps = async (appOrPageCtx: NextUrqlContext) => {
         const { AppTree } = appOrPageCtx;
 

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -52,13 +52,7 @@ export function withUrqlClient(getClientConfig: NextUrqlClientConfig, ssr?: bool
     // Set the displayName to indicate use of withUrqlClient.
     withUrql.displayName = `withUrqlClient(${getDisplayName(AppOrPage)})`;
 
-<<<<<<< HEAD
     if (AppOrPage.getInitialProps || ssr) {
-=======
-    // TODO: this should probably become (AppOrPage.getInitialProps || ssr) in
-    // the next major bump.
-    if (AppOrPage.getInitialProps || !noSsr) {
->>>>>>> add docs and changeset
       withUrql.getInitialProps = async (appOrPageCtx: NextUrqlContext) => {
         const { AppTree } = appOrPageCtx;
 

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -11,13 +11,22 @@ import {
 } from 'urql';
 
 import { initUrqlClient } from './init-urql-client';
-import { NextUrqlClientConfig, NextUrqlContext, WithUrqlProps } from './types';
+import {
+  NextUrqlClientConfig,
+  NextUrqlContext,
+  WithUrqlProps,
+  WithUrqlClientOptions,
+} from './types';
 
 function getDisplayName(Component: React.ComponentType<any>) {
   return Component.displayName || Component.name || 'Component';
 }
 
-export function withUrqlClient(getClientConfig: NextUrqlClientConfig, ssr?: boolean) {
+export function withUrqlClient(
+  getClientConfig: NextUrqlClientConfig,
+  options?: WithUrqlClientOptions
+) {
+  if (!options) options = {};
   return (AppOrPage: NextPage<any> | typeof NextApp) => {
     const withUrql = ({ urqlClient, urqlState, ...rest }: WithUrqlProps) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -52,7 +61,7 @@ export function withUrqlClient(getClientConfig: NextUrqlClientConfig, ssr?: bool
     // Set the displayName to indicate use of withUrqlClient.
     withUrql.displayName = `withUrqlClient(${getDisplayName(AppOrPage)})`;
 
-    if (AppOrPage.getInitialProps || ssr) {
+    if (AppOrPage.getInitialProps || options!.ssr) {
       withUrql.getInitialProps = async (appOrPageCtx: NextUrqlContext) => {
         const { AppTree } = appOrPageCtx;
 

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -113,21 +113,6 @@ export function withUrqlClient(
           return null;
         };
 
-        // Check the window object to determine whether or not we are on the server.
-        // getInitialProps runs on the server for initial render, and on the client for navigation.
-        // We only want to run the prepass step on the server.
-        if (typeof window !== 'undefined') {
-          return { ...pageProps, urqlClient };
-        }
-
-        await ssrPrepass(<AppTree {...appTreeProps} />);
-
-        // Serialize the urqlClient to null on the client-side.
-        // This ensures we don't share client and server instances of the urqlClient.
-        (urqlClient as any).toJSON = () => {
-          return null;
-        };
-
         return {
           ...pageProps,
           urqlState: ssrCache ? ssrCache.extractData() : undefined,

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -17,7 +17,7 @@ function getDisplayName(Component: React.ComponentType<any>) {
   return Component.displayName || Component.name || 'Component';
 }
 
-export function withUrqlClient(getClientConfig: NextUrqlClientConfig) {
+export function withUrqlClient(getClientConfig: NextUrqlClientConfig, ssr?: boolean) {
   return (AppOrPage: NextPage<any> | typeof NextApp) => {
     const withUrql = ({ urqlClient, urqlState, ...rest }: WithUrqlProps) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -52,7 +52,7 @@ export function withUrqlClient(getClientConfig: NextUrqlClientConfig) {
     // Set the displayName to indicate use of withUrqlClient.
     withUrql.displayName = `withUrqlClient(${getDisplayName(AppOrPage)})`;
 
-    if (AppOrPage.getInitialProps) {
+    if (AppOrPage.getInitialProps || ssr) {
       withUrql.getInitialProps = async (appOrPageCtx: NextUrqlContext) => {
         const { AppTree } = appOrPageCtx;
 

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -52,63 +52,80 @@ export function withUrqlClient(getClientConfig: NextUrqlClientConfig) {
     // Set the displayName to indicate use of withUrqlClient.
     withUrql.displayName = `withUrqlClient(${getDisplayName(AppOrPage)})`;
 
-    withUrql.getInitialProps = async (appOrPageCtx: NextUrqlContext) => {
-      const { AppTree } = appOrPageCtx;
+    if (AppOrPage.getInitialProps) {
+      withUrql.getInitialProps = async (appOrPageCtx: NextUrqlContext) => {
+        const { AppTree } = appOrPageCtx;
 
-      // Determine if we are wrapping an App component or a Page component.
-      const isApp = !!(appOrPageCtx as AppContext).Component;
-      const ctx = isApp
-        ? (appOrPageCtx as AppContext).ctx
-        : (appOrPageCtx as NextPageContext);
+        // Determine if we are wrapping an App component or a Page component.
+        const isApp = !!(appOrPageCtx as AppContext).Component;
+        const ctx = isApp
+          ? (appOrPageCtx as AppContext).ctx
+          : (appOrPageCtx as NextPageContext);
 
-      const ssrCache = ssrExchange({ initialState: undefined });
-      const clientConfig = getClientConfig(ssrCache, ctx);
-      if (!clientConfig.exchanges) {
-        // When the user does not provide exchanges we make the default assumption.
-        clientConfig.exchanges = [
-          dedupExchange,
-          cacheExchange,
-          ssrCache,
-          fetchExchange,
-        ];
-      }
-      const urqlClient = initUrqlClient(clientConfig);
+        const ssrCache = ssrExchange({ initialState: undefined });
+        const clientConfig = getClientConfig(ssrCache, ctx);
+        if (!clientConfig.exchanges) {
+          // When the user does not provide exchanges we make the default assumption.
+          clientConfig.exchanges = [
+            dedupExchange,
+            cacheExchange,
+            ssrCache,
+            fetchExchange,
+          ];
+        }
+        const urqlClient = initUrqlClient(clientConfig);
 
-      if (urqlClient) {
-        (ctx as NextUrqlContext).urqlClient = urqlClient;
-      }
+        if (urqlClient) {
+          (ctx as NextUrqlContext).urqlClient = urqlClient;
+        }
 
-      // Run the wrapped component's getInitialProps function.
-      let pageProps = {} as any;
-      if (AppOrPage.getInitialProps) {
-        pageProps = await AppOrPage.getInitialProps(appOrPageCtx as any);
-      }
+        // Run the wrapped component's getInitialProps function.
+        let pageProps = {} as any;
+        if (AppOrPage.getInitialProps) {
+          pageProps = await AppOrPage.getInitialProps(appOrPageCtx as any);
+        }
 
-      // Check the window object to determine whether or not we are on the server.
-      // getInitialProps runs on the server for initial render, and on the client for navigation.
-      // We only want to run the prepass step on the server.
-      if (typeof window !== 'undefined') {
-        return { ...pageProps, urqlClient };
-      }
+        // Check the window object to determine whether or not we are on the server.
+        // getInitialProps runs on the server for initial render, and on the client for navigation.
+        // We only want to run the prepass step on the server.
+        if (typeof window !== 'undefined') {
+          return { ...pageProps, urqlClient };
+        }
 
-      const props = { ...pageProps, urqlClient };
-      const appTreeProps = isApp ? props : { pageProps: props };
+        const props = { ...pageProps, urqlClient };
+        const appTreeProps = isApp ? props : { pageProps: props };
 
-      // Run the prepass step on AppTree. This will run all urql queries on the server.
-      await ssrPrepass(<AppTree {...appTreeProps} />);
+        // Run the prepass step on AppTree. This will run all urql queries on the server.
+        await ssrPrepass(<AppTree {...appTreeProps} />);
 
-      // Serialize the urqlClient to null on the client-side.
-      // This ensures we don't share client and server instances of the urqlClient.
-      (urqlClient as any).toJSON = () => {
-        return null;
+        // Serialize the urqlClient to null on the client-side.
+        // This ensures we don't share client and server instances of the urqlClient.
+        (urqlClient as any).toJSON = () => {
+          return null;
+        };
+
+        // Check the window object to determine whether or not we are on the server.
+        // getInitialProps runs on the server for initial render, and on the client for navigation.
+        // We only want to run the prepass step on the server.
+        if (typeof window !== 'undefined') {
+          return { ...pageProps, urqlClient };
+        }
+
+        await ssrPrepass(<AppTree {...appTreeProps} />);
+
+        // Serialize the urqlClient to null on the client-side.
+        // This ensures we don't share client and server instances of the urqlClient.
+        (urqlClient as any).toJSON = () => {
+          return null;
+        };
+
+        return {
+          ...pageProps,
+          urqlState: ssrCache ? ssrCache.extractData() : undefined,
+          urqlClient,
+        };
       };
-
-      return {
-        ...pageProps,
-        urqlState: ssrCache ? ssrCache.extractData() : undefined,
-        urqlClient,
-      };
-    };
+    }
 
     return withUrql;
   };


### PR DESCRIPTION
## Summary

Relates to: https://github.com/FormidableLabs/urql/issues/754

We need to implement a switch between `getInitialProps`, `getStaticProps` and `getServerProps` I've been browsing some examples but have not yet succeeded in finding a reasonable approach. This is a first step towards some common guidelines.

## Set of changes

- Optionally bind `getInitialProps` to `withUrql`
