### PR TITLE
Add operationName to GET queries

### DIFF
--- a/.changeset/weak-rats-perform.md
+++ b/.changeset/weak-rats-perform.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Add operationName to GET queries

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -44,6 +44,10 @@ export const makeFetchURL = (
   if (!useGETMethod || !body) return url;
 
   const search: string[] = [];
+  if (body.operationName) {
+    search.push('operationName=' + encodeURIComponent(body.operationName));
+  }
+
   if (body.query) {
     search.push('query=' + encodeURIComponent(body.query));
   }


### PR DESCRIPTION
## Summary
When GET queries are used, and especially with persisted queries it is hard to debug them as only hash is displayed in network debugger. Urql already sends operationName when POST is used and this only adds the same value to url when GET is used.

## Set of changes
- add operationName to GET queries query