### PR TITLE
(next-urql) - only include prepass in server-build

### DIFF
--- a/.changeset/quiet-weeks-notice.md
+++ b/.changeset/quiet-weeks-notice.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Use `process.browser` to remove `react-ssr-prepass` from the client-build

--- a/.changeset/quiet-weeks-notice.md
+++ b/.changeset/quiet-weeks-notice.md
@@ -2,4 +2,4 @@
 'next-urql': patch
 ---
 
-Use `process.browser` to remove `react-ssr-prepass` from the client-build
+Use `typeof window !== 'undefiend'` to remove `react-ssr-prepass` from the client-build

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -77,26 +77,29 @@ export function withUrqlClient(
       // getInitialProps runs on the server for initial render, and on the client for navigation.
       // We only want to run the prepass step on the server.
       if (typeof window !== 'undefined') {
-        return { ...pageProps, urqlClient };
       }
 
-      const props = { ...pageProps, urqlClient };
-      const appTreeProps = isApp ? props : { pageProps: props };
+      if (process.browser) {
+        const props = { ...pageProps, urqlClient };
+        const appTreeProps = isApp ? props : { pageProps: props };
 
-      // Run the prepass step on AppTree. This will run all urql queries on the server.
-      await ssrPrepass(<AppTree {...appTreeProps} />);
+        // Run the prepass step on AppTree. This will run all urql queries on the server.
+        await ssrPrepass(<AppTree {...appTreeProps} />);
 
-      // Serialize the urqlClient to null on the client-side.
-      // This ensures we don't share client and server instances of the urqlClient.
-      (urqlClient as any).toJSON = () => {
-        return null;
-      };
+        // Serialize the urqlClient to null on the client-side.
+        // This ensures we don't share client and server instances of the urqlClient.
+        (urqlClient as any).toJSON = () => {
+          return null;
+        };
 
-      return {
-        ...pageProps,
-        urqlState: ssrCache ? ssrCache.extractData() : undefined,
-        urqlClient,
-      };
+        return {
+          ...pageProps,
+          urqlState: ssrCache ? ssrCache.extractData() : undefined,
+          urqlClient,
+        };
+      }
+
+      return { ...pageProps, urqlClient };
     };
 
     return withUrql;

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -73,10 +73,12 @@ export function withUrqlClient(
         pageProps = await AppOrPage.getInitialProps(appOrPageCtx as any);
       }
 
-      // Check the window object to determine whether or not we are on the server.
+      // Check the process.browser property to determine whether or not we are on the server.
       // getInitialProps runs on the server for initial render, and on the client for navigation.
       // We only want to run the prepass step on the server.
-      if ((process as any).browser === 'false') {
+      if ((process as any).browser) {
+        return { ...pageProps, urqlClient };
+      } else {
         const props = { ...pageProps, urqlClient };
         const appTreeProps = isApp ? props : { pageProps: props };
 
@@ -85,9 +87,7 @@ export function withUrqlClient(
 
         // Serialize the urqlClient to null on the client-side.
         // This ensures we don't share client and server instances of the urqlClient.
-        (urqlClient as any).toJSON = () => {
-          return null;
-        };
+        (urqlClient as any).toJSON = () => null;
 
         return {
           ...pageProps,
@@ -95,8 +95,6 @@ export function withUrqlClient(
           urqlClient,
         };
       }
-
-      return { ...pageProps, urqlClient };
     };
 
     return withUrql;

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -73,10 +73,10 @@ export function withUrqlClient(
         pageProps = await AppOrPage.getInitialProps(appOrPageCtx as any);
       }
 
-      // Check the process.browser property to determine whether or not we are on the server.
+      // Check the window object to determine whether or not we are on the server.
       // getInitialProps runs on the server for initial render, and on the client for navigation.
       // We only want to run the prepass step on the server.
-      if ((process as any).browser) {
+      if (typeof window !== 'undefined') {
         return { ...pageProps, urqlClient };
       } else {
         const props = { ...pageProps, urqlClient };

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -76,10 +76,7 @@ export function withUrqlClient(
       // Check the window object to determine whether or not we are on the server.
       // getInitialProps runs on the server for initial render, and on the client for navigation.
       // We only want to run the prepass step on the server.
-      if (typeof window !== 'undefined') {
-      }
-
-      if (process.browser) {
+      if ((process as any).browser === 'false') {
         const props = { ...pageProps, urqlClient };
         const appTreeProps = isApp ? props : { pageProps: props };
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/FormidableLabs/urql/issues/801
Blocked by: https://github.com/FormidableLabs/react-ssr-prepass/pull/54

When [Next.js makes the client-side bundle](https://github.com/zeit/next.js/blob/canary/packages/next/build/webpack-config.ts#L810) it exposes a `process` variable to determine we are on the server or not.

The good thing about this is that we can use this to remove code for certain bundles, now this will transform to `ìf (false)` for the client-side bundle, when that happens `terser` can perform `dead code removal` and effectively remove this whole dep from the client-side bundle.

## Set of changes

- utilize `process.browser` to remove the `react-ssr-prepass` dependency on the client-side bundle

## Size impact

Before

```
Page                                                           Size     First Load
─ λ /                                                          37.3 kB      106 kB
```

After

```
Page                                                           Size     First Load
─ λ /                                                          29 kB       97.5 kB
```