### PR TITLE
(persisted-fetch) - support persisted get

### DIFF
--- a/.changeset/big-worms-punch.md
+++ b/.changeset/big-worms-punch.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted-fetch': major
+---
+
+make the persistedFetchExchange accept arguments, this to allow for GET for persisted-queries

--- a/.changeset/big-worms-punch.md
+++ b/.changeset/big-worms-punch.md
@@ -2,4 +2,24 @@
 '@urql/exchange-persisted-fetch': major
 ---
 
-make the persistedFetchExchange accept arguments, this to allow for GET for persisted-queries
+Make the persistedFetchExchange accept an optional argument, this argument consists of one option `preferGetForPersistedQueries`.
+
+To migrate you will have to change from
+
+```js
+import { persistedFetchExchange } from '@urql/exchange-persisted-fetch';
+
+createClient({
+  exchanges: [persistedFetchExchange],
+});
+```
+
+to
+
+```js
+import { persistedFetchExchange } from '@urql/exchange-persisted-fetch';
+
+createClient({
+  exchanges: [persistedFetchExchange()],
+});
+```

--- a/exchanges/persisted-fetch/src/persistedFetchExchange.test.ts
+++ b/exchanges/persisted-fetch/src/persistedFetchExchange.test.ts
@@ -109,7 +109,7 @@ it('supports GET exclusively for persisted queries', async () => {
 
   expect(fetch).toHaveBeenCalledTimes(2);
   expect(fetch.mock.calls[0][1].method).toEqual('GET');
-  expect(fetch.mock.calls[1][1].method).toEqual('GET');
+  expect(fetch.mock.calls[1][1].method).toEqual('POST');
   expect(actual.data).not.toBeUndefined();
 });
 

--- a/exchanges/persisted-fetch/src/persistedFetchExchange.ts
+++ b/exchanges/persisted-fetch/src/persistedFetchExchange.ts
@@ -105,8 +105,7 @@ export const persistedFetchExchange = (
                 operation,
                 body,
                 dispatchDebug,
-                !!(options as PersistedFetchExchangeOptions)
-                  .preferGetForPersistedQueries
+                false
               );
             }
 

--- a/exchanges/persisted-fetch/src/persistedFetchExchange.ts
+++ b/exchanges/persisted-fetch/src/persistedFetchExchange.ts
@@ -30,10 +30,15 @@ import {
 
 import { hash } from './sha256';
 
-export const persistedFetchExchange: Exchange = ({
-  forward,
-  dispatchDebug,
-}) => {
+interface PersistedFetchExchangeOptions {
+  preferGetForPersistedQueries?: boolean;
+}
+
+export const persistedFetchExchange = (
+  options?: PersistedFetchExchangeOptions
+): Exchange => ({ forward, dispatchDebug }) => {
+  if (!options) options = {};
+
   let supportsPersistedQueries = true;
 
   return ops$ => {
@@ -72,6 +77,8 @@ export const persistedFetchExchange: Exchange = ({
               },
             };
 
+            operation.context.preferGetMethod = !!(options as PersistedFetchExchangeOptions)
+              .preferGetForPersistedQueries;
             return makePersistedFetchSource(operation, body, dispatchDebug);
           }),
           mergeMap(result => {


### PR DESCRIPTION
## Summary

Implements #799 

## Set of changes

- Makes the `persistedFetchExchange` accept options
