### PR TITLE
(next-urql) - bump react-ssr-prepass

### DIFF
--- a/.changeset/light-birds-kneel.md
+++ b/.changeset/light-birds-kneel.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Bump `react-ssr-prepass` so it can get eliminated in the client-side bundle, this because the 1.2.1 version added "sideEffects:false"

--- a/packages/next-urql/package.json
+++ b/packages/next-urql/package.json
@@ -50,7 +50,7 @@
     "react-is": "^16.12.0"
   },
   "dependencies": {
-    "react-ssr-prepass": "^1.2.0",
+    "react-ssr-prepass": "^1.2.1",
     "urql": ">=1.9.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11255,14 +11255,7 @@ react-side-effect@^1.1.0:
   dependencies:
     shallowequal "^1.0.1"
 
-react-ssr-prepass@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.2.0.tgz#e16efd472237ffd0c8086146e02ed6c3d46c1383"
-  integrity sha512-KwZ+nuQWLQyfJpNIEzuipGyJDffDiQEk0z1/RpoN/PySH/YbQ7J+Yf1h5sUM66nlJ5SQCBn9AjUJaOUnnIuSLQ==
-  dependencies:
-    object-is "^1.1.2"
-
-react-ssr-prepass@^1.2.1:
+react-ssr-prepass@^1.1.2, react-ssr-prepass@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.2.1.tgz#ba867bbe60714f42977dbe1ef9b8ff469b950602"
   integrity sha512-8hMhx9zXyEZ+t4oI0chPInxm/HpjrmvNuZxI5TmIXbORYmIV2CnK4WVPTdm/7Iq+3/6RAiNxTNZSQyUu5irX4Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11255,10 +11255,17 @@ react-side-effect@^1.1.0:
   dependencies:
     shallowequal "^1.0.1"
 
-react-ssr-prepass@^1.1.2, react-ssr-prepass@^1.2.0:
+react-ssr-prepass@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.2.0.tgz#e16efd472237ffd0c8086146e02ed6c3d46c1383"
   integrity sha512-KwZ+nuQWLQyfJpNIEzuipGyJDffDiQEk0z1/RpoN/PySH/YbQ7J+Yf1h5sUM66nlJ5SQCBn9AjUJaOUnnIuSLQ==
+  dependencies:
+    object-is "^1.1.2"
+
+react-ssr-prepass@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.2.1.tgz#ba867bbe60714f42977dbe1ef9b8ff469b950602"
+  integrity sha512-8hMhx9zXyEZ+t4oI0chPInxm/HpjrmvNuZxI5TmIXbORYmIV2CnK4WVPTdm/7Iq+3/6RAiNxTNZSQyUu5irX4Q==
   dependencies:
     object-is "^1.1.2"
 


### PR DESCRIPTION
## Summary

Bump `react-ssr-prepass` to 1.2.1, this will allow terser to safely remove this import due to `sideEffects: false` being added.

Relates to: #801 

## Set of changes

- Bump `react-ssr-prepass` to 1.2.1
