### PR TITLE
(next-urql) - streamline client creation

### DIFF
--- a/.changeset/weak-pants-lick.md
+++ b/.changeset/weak-pants-lick.md
@@ -1,0 +1,26 @@
+---
+'next-urql': major
+---
+
+Transform the `withUrqlClient` function, this removes the second argument formerly called `mergeExchanges` and merges it with the first argument.
+The first argument will only accept functions from now on.
+
+To migrate you would transform from:
+
+```js
+export default withUrqlClient(
+  ctx => ({
+    url: '',
+  }),
+  ssrExchange => [exchanges]
+);
+```
+
+to
+
+```js
+export default withUrqlClient((ssrExchange, ctx) => ({
+  url: '',
+  exchanges: [exchanges],
+}));
+```

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -213,7 +213,7 @@ const Index = () => {
   // ...
 };
 
-export default withUrqlClient(ctx => ({
+export default withUrqlClient((_ssrExchange, ctx) => ({
   // ...add your Client options here
   url: 'http://localhost:3000/graphql',
 }))(Index);
@@ -225,15 +225,15 @@ object or a function that receives the Next.js' `getInitialProps` context.
 
 One added caveat is that these options may not include the `exchanges` option because `next-urql`
 injects the `ssrExchange` automatically at the right location. If you're setting up custom exchanges
-you'll need to instead provide them in a custom `mergeExchanges` function as the second argument:
+you'll need to instead provide them in the `exchanges` property of the returned client object.
 
 ```js
 import { dedupExchange, cacheExchange, fetchExchange } from '@urql/core';
 
 import { withUrqlClient } from 'next-urql';
 
-// Modify this array to include custom exchanges:
-const mergeExchanges = ssrExchange => [dedupExchange, cacheExchange, ssrExchange, fetchExchange];
-
-export default withUrqlClient({ url: 'http://localhost:3000/graphql' }, mergeExchanges)(Index);
+export default withUrqlClient(ssrExchange => ({
+  url: 'http://localhost:3000/graphql',
+  exchanges: [dedupExchange, cacheExchange, ssrExchange, fetchExchange],
+}))(Index);
 ```

--- a/packages/next-urql/examples/1-with-urql-client/pages/index.tsx
+++ b/packages/next-urql/examples/1-with-urql-client/pages/index.tsx
@@ -30,7 +30,7 @@ Home.getInitialProps = () => {
   };
 };
 
-export default withUrqlClient((ctx: NextUrqlPageContext) => {
+export default withUrqlClient((_ssr: object, ctx: NextUrqlPageContext) => {
   return {
     url: 'https://graphql-pokemon.now.sh',
     fetchOptions: {

--- a/packages/next-urql/examples/2-with-_app.js/pages/_app.tsx
+++ b/packages/next-urql/examples/2-with-_app.js/pages/_app.tsx
@@ -17,7 +17,7 @@ App.getInitialProps = async (ctx: NextUrqlAppContext) => {
   };
 };
 
-export default withUrqlClient({ url: 'https://graphql-pokemon.now.sh', fetch })(
+export default withUrqlClient(() => ({ url: 'https://graphql-pokemon.now.sh', fetch }))(
   // @ts-ignore
   App
 );

--- a/packages/next-urql/examples/3-with-custom-exchange/pages/index.tsx
+++ b/packages/next-urql/examples/3-with-custom-exchange/pages/index.tsx
@@ -18,13 +18,14 @@ const Home: React.FC = () => (
   </div>
 );
 
-export default withUrqlClient(
-  { url: 'https://graphql-pokemon.now.sh', fetch },
-  (ssrExchange: SSRExchange) => [
+export default withUrqlClient((ssrExchange) => ({
+  exchanges: [
     dedupExchange,
     urlExchange,
     cacheExchange,
     ssrExchange,
     fetchExchange,
-  ]
-)(Home);
+  ],
+  url: 'https://graphql-pokemon.now.sh',
+  fetch,
+}))(Home);

--- a/packages/next-urql/examples/4-with-navigation/pages/[pokemon].tsx
+++ b/packages/next-urql/examples/4-with-navigation/pages/[pokemon].tsx
@@ -49,7 +49,7 @@ const Pokemon = () => {
   return <h1>{result.data.pokemon.name}</h1>;
 };
 
-export default withUrqlClient({
+export default withUrqlClient(() => ({
   url: 'https://graphql-pokemon.now.sh',
   fetch,
-})(Pokemon);
+}))(Pokemon);

--- a/packages/next-urql/examples/4-with-navigation/pages/index.tsx
+++ b/packages/next-urql/examples/4-with-navigation/pages/index.tsx
@@ -15,7 +15,7 @@ const Home: NextComponentType<NextUrqlPageContext> = () => (
   </div>
 );
 
-export default withUrqlClient((ctx: NextUrqlPageContext) => {
+export default withUrqlClient((_ssr: object, ctx: NextUrqlPageContext) => {
   return {
     url: 'https://graphql-pokemon.now.sh',
     fetchOptions: {

--- a/packages/next-urql/examples/5-with-suspense-exchange/pages/index.tsx
+++ b/packages/next-urql/examples/5-with-suspense-exchange/pages/index.tsx
@@ -18,13 +18,15 @@ const Home: React.FC = () => (
   </div>
 );
 
-export default withUrqlClient(
-  { url: 'https://graphql-pokemon.now.sh', fetch, suspense: true },
-  (ssrExchange: SSRExchange) => [
+export default withUrqlClient((ssrExchange) => ({
+  url: 'https://graphql-pokemon.now.sh',
+  fetch,
+  suspense: true,
+  exchanges: [
     dedupExchange,
     suspenseExchange,
     cacheExchange,
     ssrExchange,
     fetchExchange,
   ]
-)(Home);
+}))(Home);

--- a/packages/next-urql/src/__tests__/init-urql-client.spec.ts
+++ b/packages/next-urql/src/__tests__/init-urql-client.spec.ts
@@ -9,13 +9,4 @@ describe('initUrqlClient', () => {
     expect(urqlClient).toHaveProperty('url', 'http://localhost:3000');
     expect(urqlClient).toHaveProperty('suspense', true);
   });
-
-  it('should accept an optional mergeExchanges function to allow for exchange composition', () => {
-    const urqlClient = initUrqlClient({
-      url: 'http://localhost:3000',
-    });
-
-    expect(urqlClient).toHaveProperty('url', 'http://localhost:3000');
-    expect(urqlClient).toHaveProperty('suspense', true);
-  });
 });

--- a/packages/next-urql/src/__tests__/init-urql-client.spec.ts
+++ b/packages/next-urql/src/__tests__/init-urql-client.spec.ts
@@ -1,7 +1,7 @@
 import { initUrqlClient } from '../init-urql-client';
 
 describe('initUrqlClient', () => {
-  it('should return the urqlClient instance and ssrCache', () => {
+  it('should return the urqlClient instance', () => {
     const urqlClient = initUrqlClient({
       url: 'http://localhost:3000',
     });

--- a/packages/next-urql/src/__tests__/init-urql-client.spec.ts
+++ b/packages/next-urql/src/__tests__/init-urql-client.spec.ts
@@ -1,27 +1,21 @@
-import { ssrExchange } from 'urql';
-
 import { initUrqlClient } from '../init-urql-client';
 
 describe('initUrqlClient', () => {
   it('should return the urqlClient instance and ssrCache', () => {
-    const [urqlClient, ssrCache] = initUrqlClient({
+    const urqlClient = initUrqlClient({
       url: 'http://localhost:3000',
     });
 
     expect(urqlClient).toHaveProperty('url', 'http://localhost:3000');
     expect(urqlClient).toHaveProperty('suspense', true);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(ssrCache!.toString()).toEqual(ssrExchange().toString());
   });
 
   it('should accept an optional mergeExchanges function to allow for exchange composition', () => {
-    const [urqlClient, ssrCache] = initUrqlClient({
+    const urqlClient = initUrqlClient({
       url: 'http://localhost:3000',
     });
 
     expect(urqlClient).toHaveProperty('url', 'http://localhost:3000');
     expect(urqlClient).toHaveProperty('suspense', true);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(ssrCache!.toString()).toEqual(ssrExchange().toString());
   });
 });

--- a/packages/next-urql/src/__tests__/init-urql-client.spec.ts
+++ b/packages/next-urql/src/__tests__/init-urql-client.spec.ts
@@ -1,10 +1,4 @@
-import {
-  ssrExchange,
-  debugExchange,
-  dedupExchange,
-  cacheExchange,
-  fetchExchange,
-} from 'urql';
+import { ssrExchange } from 'urql';
 
 import { initUrqlClient } from '../init-urql-client';
 
@@ -21,43 +15,13 @@ describe('initUrqlClient', () => {
   });
 
   it('should accept an optional mergeExchanges function to allow for exchange composition', () => {
-    const [urqlClient, ssrCache] = initUrqlClient(
-      {
-        url: 'http://localhost:3000',
-      },
-      ssrEx => [
-        debugExchange,
-        dedupExchange,
-        cacheExchange,
-        ssrEx,
-        fetchExchange,
-      ]
-    );
+    const [urqlClient, ssrCache] = initUrqlClient({
+      url: 'http://localhost:3000',
+    });
 
     expect(urqlClient).toHaveProperty('url', 'http://localhost:3000');
     expect(urqlClient).toHaveProperty('suspense', true);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(ssrCache!.toString()).toEqual(ssrExchange().toString());
-  });
-
-  it('should accept some initial state to populate the cache', () => {
-    const initialState = {
-      123: { data: { name: 'Kadabra', type: 'Psychic' } },
-      456: { data: { name: 'Butterfree', type: ['Psychic', 'Bug'] } },
-    };
-
-    const [urqlClient, ssrCache] = initUrqlClient(
-      {
-        url: 'http://localhost:3000',
-      },
-      undefined,
-      initialState
-    );
-
-    expect(urqlClient).toHaveProperty('url', 'http://localhost:3000');
-    expect(urqlClient).toHaveProperty('suspense', true);
-
-    const data = ssrCache && ssrCache.extractData();
-    expect(data).toEqual(initialState);
   });
 });

--- a/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
+++ b/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
@@ -85,7 +85,7 @@ describe('withUrqlClient', () => {
         fetchOptions: {
           headers: { Authorization: (ctx && ctx.req!.headers!.cookie) || '' },
         },
-        exchanges: [ssrExchange, ...defaultExchanges],
+        exchanges: [ssrExchange],
       }))(MockApp);
     });
 
@@ -95,6 +95,7 @@ describe('withUrqlClient', () => {
       expect(spyInitUrqlClient).toHaveBeenCalledWith({
         url: 'http://localhost:3000',
         fetchOptions: { headers: { Authorization: token } },
+        exchanges: [ssrExchange],
       });
     });
   });

--- a/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
+++ b/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { Client, defaultExchanges } from 'urql';
+import { Client } from 'urql';
 
 import { withUrqlClient, NextUrqlPageContext } from '..';
 import * as init from '../init-urql-client';
@@ -65,6 +65,7 @@ describe('withUrqlClient', () => {
   describe('with ctx callback to create client options', () => {
     // Simulate a token that might be passed in a request to the server-rendered application.
     const token = Math.random().toString(36).slice(-10);
+    let mockSsrExchange;
 
     const mockContext: NextUrqlPageContext = {
       AppTree: MockAppTree,
@@ -85,7 +86,7 @@ describe('withUrqlClient', () => {
         fetchOptions: {
           headers: { Authorization: (ctx && ctx.req!.headers!.cookie) || '' },
         },
-        exchanges: [ssrExchange],
+        exchanges: [(mockSsrExchange = ssrExchange)],
       }))(MockApp);
     });
 
@@ -95,7 +96,7 @@ describe('withUrqlClient', () => {
       expect(spyInitUrqlClient).toHaveBeenCalledWith({
         url: 'http://localhost:3000',
         fetchOptions: { headers: { Authorization: token } },
-        exchanges: [ssrExchange],
+        exchanges: [mockSsrExchange],
       });
     });
   });

--- a/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
+++ b/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
@@ -46,6 +46,7 @@ describe('withUrqlClient', () => {
       expect(app.props().urqlClient).toBeInstanceOf(Client);
       expect(app.props().urqlClient.url).toBe('http://localhost:3000');
       expect(spyInitUrqlClient).toHaveBeenCalledTimes(1);
+      expect(spyInitUrqlClient.mock.calls[0][0].exchanges).toHaveLength(4);
     });
 
     it('should create the urql client instance server-side inside getInitialProps', async () => {
@@ -101,7 +102,7 @@ describe('withUrqlClient', () => {
     });
   });
 
-  describe('with mergeExchanges provided', () => {
+  describe('with exchanges provided', () => {
     const exchange = jest.fn(() => op => op);
 
     beforeEach(() => {
@@ -111,15 +112,7 @@ describe('withUrqlClient', () => {
       }))(MockApp);
     });
 
-    it('calls the user-supplied mergeExchanges function', () => {
-      const tree = shallow(<Component />);
-      const app = tree.find(MockApp);
-
-      const client = app.props().urqlClient;
-      expect(client).toBeInstanceOf(Client);
-    });
-
-    it('uses exchanges returned from mergeExchanges', () => {
+    it('uses exchanges defined in the client config', () => {
       const tree = shallow(<Component />);
       const app = tree.find(MockApp);
 

--- a/packages/next-urql/src/init-urql-client.ts
+++ b/packages/next-urql/src/init-urql-client.ts
@@ -1,13 +1,9 @@
 import { createClient, Client, ClientOptions } from 'urql';
 import 'isomorphic-unfetch';
-import { SSRExchange } from './types';
 
 let urqlClient: Client | null = null;
-const ssrCache: SSRExchange | null = null;
 
-export function initUrqlClient(
-  clientOptions: ClientOptions
-): [Client | null, SSRExchange | null] {
+export function initUrqlClient(clientOptions: ClientOptions): Client | null {
   // Create a new Client for every server-side rendered request.
   // This ensures we reset the state for each rendered page.
   // If there is an exising client instance on the client-side, use it.
@@ -20,5 +16,5 @@ export function initUrqlClient(
   }
 
   // Return both the Client instance and the ssrCache.
-  return [urqlClient, ssrCache];
+  return urqlClient;
 }

--- a/packages/next-urql/src/init-urql-client.ts
+++ b/packages/next-urql/src/init-urql-client.ts
@@ -1,39 +1,21 @@
-import {
-  createClient,
-  dedupExchange,
-  cacheExchange,
-  fetchExchange,
-  ssrExchange,
-  Client,
-  Exchange,
-} from 'urql';
+import { createClient, Client, ClientOptions } from 'urql';
 import 'isomorphic-unfetch';
-import { NextUrqlClientOptions, SSRData, SSRExchange } from './types';
+import { SSRExchange } from './types';
 
 let urqlClient: Client | null = null;
-let ssrCache: SSRExchange | null = null;
+const ssrCache: SSRExchange | null = null;
 
 export function initUrqlClient(
-  clientOptions: NextUrqlClientOptions,
-  mergeExchanges: (ssrEx: SSRExchange) => Exchange[] = ssrEx => [
-    dedupExchange,
-    cacheExchange,
-    ssrEx,
-    fetchExchange,
-  ],
-  initialState?: SSRData
+  clientOptions: ClientOptions
 ): [Client | null, SSRExchange | null] {
   // Create a new Client for every server-side rendered request.
   // This ensures we reset the state for each rendered page.
   // If there is an exising client instance on the client-side, use it.
   const isServer = typeof window === 'undefined';
   if (isServer || !urqlClient) {
-    ssrCache = ssrExchange({ initialState });
-
     urqlClient = createClient({
       ...clientOptions,
       suspense: isServer || clientOptions.suspense,
-      exchanges: mergeExchanges(ssrCache),
     });
   }
 

--- a/packages/next-urql/src/types.ts
+++ b/packages/next-urql/src/types.ts
@@ -3,13 +3,10 @@ import { NextPageContext } from 'next';
 import { ClientOptions, Exchange, Client } from 'urql';
 import { AppContext } from 'next/app';
 
-export type NextUrqlClientOptions = Omit<ClientOptions, 'exchanges'>;
-
-export type NextUrqlClientConfig =
-  | NextUrqlClientOptions
-  | ((ctx?: NextPageContext) => NextUrqlClientOptions);
-
-export type MergeExchanges = (ssrExchange: SSRExchange) => Exchange[];
+export type NextUrqlClientConfig = (
+  ssrExchange: SSRExchange,
+  ctx?: NextPageContext
+) => ClientOptions;
 
 export interface NextUrqlPageContext extends NextPageContext {
   urqlClient: Client;

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -20,13 +20,10 @@ export function withUrqlClient(clientConfig: NextUrqlClientConfig) {
           return urqlClient;
         }
 
-        const clientOptions =
-          typeof clientConfig === 'function'
-            ? clientConfig(ssrExchange({ initialState: urqlState }))
-            : clientConfig;
-
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return initUrqlClient(clientOptions)[0]!;
+        return initUrqlClient(
+          clientConfig(ssrExchange({ initialState: urqlState }))
+        )!;
       }, [urqlClient, urqlState]);
 
       return (
@@ -48,11 +45,8 @@ export function withUrqlClient(clientConfig: NextUrqlClientConfig) {
         ? (appOrPageCtx as AppContext).ctx
         : (appOrPageCtx as NextPageContext);
 
-      const opts =
-        typeof clientConfig === 'function'
-          ? clientConfig(ssrExchange({ initialState: undefined }), ctx)
-          : clientConfig;
-      const [urqlClient, ssrCache] = initUrqlClient(opts);
+      const ssrCache = ssrExchange({ initialState: undefined });
+      const urqlClient = initUrqlClient(clientConfig(ssrCache, ctx));
 
       if (urqlClient) {
         (ctx as NextUrqlContext).urqlClient = urqlClient;


### PR DESCRIPTION
## Summary

This is a breaking change for `next-urql`, we were seeing a lot of confusion because of the `mergeExchanges` argument. This proposal streamlines it to the normal client.
 
However this does impose us to always specify a function for the creation of a client

Implements https://github.com/FormidableLabs/urql/issues/813

Still have to rewrite a lot of the testing.

TODO:
- [x] update examplees
- [x] update docs
