### PR TITLE
810: Graphcache warnings for `opts.keys`

### DIFF
--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -272,3 +272,15 @@ You probably have called `cache.invalidate` with data that the cache can't gener
 
 This may either happen because you're missing the `__typename` and `id` or `_id` field or if the last two
 aren't applicable to this entity a custom `keys` entry.
+
+## (20) Invalid Object type <a id="20"></a>
+
+> Invalid Object type: The type `???` is not an object in the defined schema,
+> but the `keys` option is referencing it.
+
+When you're passing an introspected schema to the cache exchange, it is
+able to check whether your `opts.keys` is valid.
+This error occurs when an unknown type is found in `opts.keys`.
+
+Check whether your schema is up-to-date, or whether you're using an invalid
+typename in `opts.keys`, maybe due to a typo.

--- a/exchanges/graphcache/src/ast/schemaPredicates.test.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.test.ts
@@ -1,9 +1,6 @@
 import { buildClientSchema } from 'graphql';
+import { mocked } from 'ts-jest/utils';
 import * as SchemaPredicates from './schemaPredicates';
-
-let warnSpy: jest.SpyInstance;
-beforeEach(() => (warnSpy = jest.spyOn(console, 'warn')));
-afterEach(() => warnSpy.mockRestore());
 
 describe('SchemaPredicates', () => {
   // eslint-disable-next-line
@@ -71,8 +68,8 @@ describe('SchemaPredicates', () => {
       SchemaPredicates.isFieldNullable(schema, 'Todo', 'goof')
     ).toBeFalsy();
 
-    expect(warnSpy).toBeCalledTimes(1);
-    const warnMessage = warnSpy.mock.calls[0][0];
+    expect(console.warn).toBeCalledTimes(1);
+    const warnMessage = mocked(console.warn).mock.calls[0][0];
     expect(warnMessage).toContain('The field `goof` does not exist on `Todo`');
     expect(warnMessage).toContain('https://bit.ly/2XbVrpR#4');
   });

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -10,6 +10,7 @@ import {
 } from 'graphql';
 
 import { warn, invariant } from '../helpers/help';
+import { KeyingConfig } from '../types';
 
 export const isFieldNullable = (
   schema: GraphQLSchema,
@@ -110,4 +111,21 @@ function expectAbstractType(
       'but a fragment in the GraphQL document is using it as a type condition.',
     5
   );
+}
+
+export function expectValidKeyingConfig(
+  schema: GraphQLSchema,
+  keys: KeyingConfig
+): void {
+  const types = Object.keys(schema.getTypeMap());
+  Object.keys(keys).forEach(key => {
+    if (types.indexOf(key) === -1) {
+      warn(
+        'Invalid Object type: The type `' +
+          key +
+          '` is not an object in the defined schema, but the `keys` option is referencing it.',
+        20
+      );
+    }
+  });
 }

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -117,15 +117,17 @@ export function expectValidKeyingConfig(
   schema: GraphQLSchema,
   keys: KeyingConfig
 ): void {
-  const types = Object.keys(schema.getTypeMap());
-  Object.keys(keys).forEach(key => {
-    if (types.indexOf(key) === -1) {
-      warn(
-        'Invalid Object type: The type `' +
-          key +
-          '` is not an object in the defined schema, but the `keys` option is referencing it.',
-        20
-      );
-    }
-  });
+  if (process.env.NODE_ENV !== 'production') {
+    const types = Object.keys(schema.getTypeMap());
+    Object.keys(keys).forEach(key => {
+      if (types.indexOf(key) === -1) {
+        warn(
+          'Invalid Object type: The type `' +
+            key +
+            '` is not an object in the defined schema, but the `keys` option is referencing it.',
+          20
+        );
+      }
+    });
+  }
 }

--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -23,7 +23,8 @@ export type ErrorCode =
   | 16
   | 17
   | 18
-  | 19;
+  | 19
+  | 20;
 
 type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
 

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag';
-
+import { mocked } from 'ts-jest/utils';
 import { Data, StorageAdapter } from '../types';
 import { query } from '../operations/query';
 import { write, writeOptimistic } from '../operations/write';
@@ -74,10 +74,6 @@ const todosData = {
   ],
 } as any;
 
-let warnSpy: jest.SpyInstance;
-beforeEach(() => (warnSpy = jest.spyOn(console, 'warn')));
-afterEach(() => warnSpy.mockRestore());
-
 describe('Store', () => {
   it('supports unformatted query documents', () => {
     const store = new Store();
@@ -121,7 +117,7 @@ describe('Store with KeyingConfig', () => {
       },
     });
 
-    expect(warnSpy).not.toBeCalled();
+    expect(console.warn).not.toBeCalled();
   });
 
   it("should warn if a key doesn't exist in the schema", function () {
@@ -133,8 +129,8 @@ describe('Store with KeyingConfig', () => {
       },
     });
 
-    expect(warnSpy).toBeCalledTimes(1);
-    const warnMessage = warnSpy.mock.calls[0][0];
+    expect(console.warn).toBeCalledTimes(1);
+    const warnMessage = mocked(console.warn).mock.calls[0][0];
     expect(warnMessage).toContain(
       'The type `NotInSchema` is not an object in the defined schema, but the `keys` option is referencing it'
     );

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -27,6 +27,7 @@ import { writeFragment, startWrite } from '../operations/write';
 import { invalidate, invalidateEntity } from '../operations/invalidate';
 import { keyOfField } from './keys';
 import * as InMemoryData from './data';
+import * as SchemaPredicates from '../ast/schemaPredicates';
 
 type RootField = 'query' | 'mutation' | 'subscription';
 
@@ -73,6 +74,10 @@ export class Store implements Cache {
       if (queryType) queryName = queryType.name;
       if (mutationType) mutationName = mutationType.name;
       if (subscriptionType) subscriptionName = subscriptionType.name;
+
+      if (this.keys) {
+        SchemaPredicates.expectValidKeyingConfig(this.schema, this.keys);
+      }
     }
 
     this.rootFields = {

--- a/scripts/jest/setup.js
+++ b/scripts/jest/setup.js
@@ -10,8 +10,8 @@ jest.restoreAllMocks();
 const originalConsole = console;
 global.console = {
   ...originalConsole,
-  warn() { /* noop */ },
-  error(message) { throw new Error(message); }
+  warn: jest.SpyInstance = () => { /* noop */ },
+  error: jest.SpyInstance = (message) => { throw new Error(message); }
 };
 
 jest.spyOn(console, 'log');


### PR DESCRIPTION
## Summary

As described in #810, when a schema is known, we want to validate `opts.keys`, `opts.updates`, `opts.resolvers`, and `opts.optimistic`.

When any of the validation fails, we want to warn the user (either via console or throwing an error).

## Set of changes

*This PR only deals with `opts.keys`*, not the others (updates/resolvers/optimistic), to get feedback.

The issue I'd like feedback on is: If the new validation calls `console.warn`, we preserve backwards compatibility because no error is thrown that would change the real functionality. If the new validation throws an error, that is backwards incompatible and we would need to do a major version bump.

IMO, throwing an error is probably better, but until we are ready to do a major version bump, I think we should use `console.warn`.

Thoughts?

I will finish the rest of #810 (opts.updates, opts.resolvers, and opts.optimistic) in another PR -- just want to get feedback on this b/compat issue first.