### PR TITLE
(graphcache) Validation for Graphcache's opts.updates, opts.resolvers, opts.optimistic

### DIFF
--- a/.changeset/thick-avocados-enjoy.md
+++ b/.changeset/thick-avocados-enjoy.md
@@ -2,5 +2,6 @@
 '@urql/exchange-graphcache': minor
 ---
 
-Issue warnings when an unknown type has been included in Graphcache's opts.key configuration to help spot typos.
-See: [#820](https://github.com/FormidableLabs/urql/pull/820)
+Issue warnings when an unknown type or field has been included in Graphcache's `opts` configuration to help spot typos.
+Checks `opts.keys`, `opts.updates`, `opts.resolvers` and `opts.optimistic`.
+See: [#820](https://github.com/FormidableLabs/urql/pull/820) and [#826](https://github.com/FormidableLabs/urql/pull/826)

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -289,3 +289,24 @@ This error occurs when an unknown type is found in `opts.keys`.
 
 Check whether your schema is up-to-date, or whether you're using an invalid
 typename in `opts.keys`, maybe due to a typo.
+
+## (21) Invalid mutation
+
+> Invalid mutation field `???` is not in the defined schema but the `updates` option is referencing it.
+
+When you're passing an introspected schema to the cache exchange, it is
+able to check whether your `opts.updates.Mutation` is valid.
+This error occurs when an unknown mutation field is found in `opts.updates.Mutation`.
+
+Check whether your schema is up-to-date, or whether you've got a typo in `opts.updates.Mutation`.
+
+## (22) Invalid subscription
+
+> Invalid subscription field: `???` is not in the defined schema but the `updates` option is referencing it.
+
+When you're passing an introspected schema to the cache exchange, it is
+able to check whether your `opts.updates.Subscription` is valid.
+This error occurs when an unknown subscription field is found in `opts.updates.Subscription`.
+
+Check whether your schema is up-to-date, or whether you're using an invalid
+subscription name in `opts.updates.Subscription`, maybe due to a typo.

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -310,3 +310,14 @@ This error occurs when an unknown subscription field is found in `opts.updates.S
 
 Check whether your schema is up-to-date, or whether you're using an invalid
 subscription name in `opts.updates.Subscription`, maybe due to a typo.
+
+## (23) Invalid resolver
+
+> Invalid resolver: `???` is not in the defined schema, but the `resolvers`
+> option is referencing it.
+
+When you're passing an introspected schema to the cache exchange, it is
+able to check whether your `opts.resolvers` is valid.
+This error occurs when an unknown query, type or field is found in `opts.resolvers`.
+
+Check whether your schema is up-to-date, or whether you've got a typo in `opts.resolvers`.

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -321,3 +321,14 @@ able to check whether your `opts.resolvers` is valid.
 This error occurs when an unknown query, type or field is found in `opts.resolvers`.
 
 Check whether your schema is up-to-date, or whether you've got a typo in `opts.resolvers`.
+
+## (24) Invalid optimistic mutation
+
+> Invalid optimistic mutation field: `???` is not a mutation field in the defined schema,
+> but the `optimistic` option is referencing it.
+
+When you're passing an introspected schema to the cache exchange, it is
+able to check whether your `opts.optimistic` is valid.
+This error occurs when a field in `opts.optimistic` is not in the schema's `Mutation` fields.
+
+Check whether your schema is up-to-date, or whether you've got a typo in `Mutation` or `opts.optimistic`.

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -10,7 +10,12 @@ import {
 } from 'graphql';
 
 import { warn, invariant } from '../helpers/help';
-import { KeyingConfig, UpdatesConfig, ResolverConfig } from '../types';
+import {
+  KeyingConfig,
+  UpdatesConfig,
+  ResolverConfig,
+  OptimisticMutationConfig,
+} from '../types';
 
 export const isFieldNullable = (
   schema: GraphQLSchema,
@@ -222,6 +227,30 @@ export function expectValidResolversConfig(
           }
         }
       }
+    }
+  }
+}
+
+export function expectValidOptimisticMutationsConfig(
+  schema: GraphQLSchema,
+  optimisticMutations: OptimisticMutationConfig
+): void {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  const validMutations = schema.getMutationType()
+    ? Object.keys(
+        (schema.getMutationType() as GraphQLObjectType).toConfig().fields
+      )
+    : [];
+
+  for (const mutation in optimisticMutations) {
+    if (validMutations.indexOf(mutation) === -1) {
+      warn(
+        `Invalid optimistic mutation field: \`${mutation}\` is not a mutation field in the defined schema, but the \`optimistic\` option is referencing it.`,
+        24
+      );
     }
   }
 }

--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -24,7 +24,9 @@ export type ErrorCode =
   | 17
   | 18
   | 19
-  | 20;
+  | 20
+  | 21
+  | 22;
 
 type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
 

--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -27,7 +27,8 @@ export type ErrorCode =
   | 20
   | 21
   | 22
-  | 23;
+  | 23
+  | 24;
 
 type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
 

--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -26,7 +26,8 @@ export type ErrorCode =
   | 19
   | 20
   | 21
-  | 22;
+  | 22
+  | 23;
 
 type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
 

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -153,6 +153,9 @@ describe('Query', () => {
       __typename: 'Query',
       todos: [{ __typename: 'Todo', id: '0', text: 'Solve bug' }],
     });
+
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it('should respect altered root types', () => {
@@ -184,6 +187,9 @@ describe('Query', () => {
       __typename: 'query_root',
       todos: [{ __typename: 'Todo', id: '0', text: 'Solve bug' }],
     });
+
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it('should allow subsequent read when first result was null', () => {
@@ -245,5 +251,8 @@ describe('Query', () => {
       __typename: 'query_root',
       todos: [null],
     });
+
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 });

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -41,8 +41,6 @@ describe('Query', () => {
         ],
       }
     );
-
-    jest.resetAllMocks();
   });
 
   it('test partial results', () => {

--- a/exchanges/graphcache/src/operations/write.test.ts
+++ b/exchanges/graphcache/src/operations/write.test.ts
@@ -44,6 +44,33 @@ describe('Query', () => {
     jest.clearAllMocks();
   });
 
+  it('should not crash for valid writes', async () => {
+    const VALID_TODO_QUERY = gql`
+      mutation {
+        toggleTodo {
+          id
+          text
+          complete
+        }
+      }
+    `;
+    write(
+      store,
+      { query: VALID_TODO_QUERY },
+      {
+        __typename: 'Mutation',
+        toggleTodo: {
+          __typename: 'Todo',
+          id: '0',
+          text: 'Teach',
+          complete: true,
+        },
+      }
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
   it('should warn once for invalid fields on an entity', () => {
     const INVALID_TODO_QUERY = gql`
       mutation {
@@ -82,7 +109,9 @@ describe('Query', () => {
       }
     );
     expect(console.warn).toHaveBeenCalledTimes(1);
-    expect((console.warn as any).mock.calls[0][0]).toMatch(/incomplete/);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(
+      /The field `incomplete` does not exist on `Todo`/
+    );
   });
 
   it('should warn once for invalid fields on an entity', () => {
@@ -131,7 +160,9 @@ describe('Query', () => {
     );
 
     expect(console.warn).toHaveBeenCalledTimes(1);
-    expect((console.warn as any).mock.calls[0][0]).toMatch(/writer/);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(
+      /The field `writer` does not exist on `Todo`/
+    );
   });
 
   it('should skip undefined values that are expected', () => {
@@ -146,7 +177,9 @@ describe('Query', () => {
     write(store, { query }, { field: undefined } as any);
     // Because of us writing an undefined field
     expect(console.warn).toHaveBeenCalledTimes(2);
-    expect((console.warn as any).mock.calls[0][0]).toMatch(/undefined/);
+    expect((console.warn as any).mock.calls[0][0]).toMatch(
+      /The field `field` does not exist on `Query`/
+    );
 
     InMemoryData.initDataState(store.data, null);
     // The field must still be `'test'`

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -338,7 +338,7 @@ describe('Store with OptimisticMutationConfig', () => {
     InMemoryData.initDataState(store.data, null);
   });
 
-  it('Should resolve a property', () => {
+  it('should resolve a property', () => {
     const todoResult = store.resolve({ __typename: 'Todo', id: '0' }, 'text');
     expect(todoResult).toEqual('Go to the shops');
     const authorResult = store.resolve(
@@ -362,7 +362,7 @@ describe('Store with OptimisticMutationConfig', () => {
     InMemoryData.clearDataState();
   });
 
-  it('Should resolve a link property', () => {
+  it('should resolve a link property', () => {
     const parent = {
       id: '0',
       text: 'test',
@@ -840,5 +840,28 @@ describe('Store with storage', () => {
     InMemoryData.initDataState(store.data, null);
     expect(InMemoryData.readRecord('Query', 'base')).toBe(true);
     InMemoryData.clearDataState();
+  });
+
+  it("should warn if an optimistic field doesn't exist in the schema's mutations", function () {
+    new Store({
+      schema: require('../test-utils/simple_schema.json'),
+      updates: {
+        Mutation: {
+          toggleTodo: noop,
+        },
+      },
+      optimistic: {
+        toggleTodo: () => null,
+        // This field should be warned about.
+        deleteTodo: () => null,
+      },
+    });
+
+    expect(console.warn).toBeCalledTimes(1);
+    const warnMessage = mocked(console.warn).mock.calls[0][0];
+    expect(warnMessage).toContain(
+      'Invalid optimistic mutation field: `deleteTodo` is not a mutation field in the defined schema, but the `optimistic` option is referencing it.'
+    );
+    expect(warnMessage).toContain('https://bit.ly/2XbVrpR#24');
   });
 });

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -86,6 +86,13 @@ export class Store implements Cache {
         if (hasUpdates) {
           SchemaPredicates.expectValidUpdatesConfig(this.schema, this.updates);
         }
+
+        if (this.resolvers) {
+          SchemaPredicates.expectValidResolversConfig(
+            this.schema,
+            this.resolvers
+          );
+        }
       }
     }
 

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -75,8 +75,10 @@ export class Store implements Cache {
       if (mutationType) mutationName = mutationType.name;
       if (subscriptionType) subscriptionName = subscriptionType.name;
 
-      if (this.keys) {
-        SchemaPredicates.expectValidKeyingConfig(this.schema, this.keys);
+      if (process.env.NODE_ENV !== 'production') {
+        if (this.keys) {
+          SchemaPredicates.expectValidKeyingConfig(this.schema, this.keys);
+        }
       }
     }
 

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -93,6 +93,13 @@ export class Store implements Cache {
             this.resolvers
           );
         }
+
+        if (this.optimisticMutations) {
+          SchemaPredicates.expectValidOptimisticMutationsConfig(
+            this.schema,
+            this.optimisticMutations
+          );
+        }
       }
     }
 

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -79,6 +79,13 @@ export class Store implements Cache {
         if (this.keys) {
           SchemaPredicates.expectValidKeyingConfig(this.schema, this.keys);
         }
+
+        const hasUpdates =
+          Object.keys(this.updates.Mutation).length > 0 ||
+          Object.keys(this.updates.Subscription).length > 0;
+        if (hasUpdates) {
+          SchemaPredicates.expectValidUpdatesConfig(this.schema, this.updates);
+        }
       }
     }
 

--- a/exchanges/graphcache/src/test-utils/simple_schema.json
+++ b/exchanges/graphcache/src/test-utils/simple_schema.json
@@ -6,7 +6,9 @@
     "mutationType": {
       "name": "Mutation"
     },
-    "subscriptionType": null,
+    "subscriptionType": {
+      "name": "Subscription"
+    },
     "types": [
       {
         "kind": "OBJECT",
@@ -234,6 +236,27 @@
               "name": "Todo",
               "ofType": null
             }
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Subscription",
+        "fields": [
+          {
+            "name": "newTodo",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Todo",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/exchanges/graphcache/src/test-utils/utils.ts
+++ b/exchanges/graphcache/src/test-utils/utils.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export const noop = () => {};

--- a/scripts/jest/preset.js
+++ b/scripts/jest/preset.js
@@ -3,6 +3,7 @@ module.exports = {
   setupFiles: [
     require.resolve('./setup.js')
   ],
+  clearMocks: true,
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/scripts/jest/setup.js
+++ b/scripts/jest/setup.js
@@ -1,11 +1,11 @@
+// This script is run before each `.test.ts` file.
+
 global.AbortController = undefined;
 global.fetch = jest.fn();
 
 process.on('unhandledRejection', error => {
   throw error;
 });
-
-jest.restoreAllMocks();
 
 const originalConsole = console;
 global.console = {


### PR DESCRIPTION
## Summary

As described in #810, when a schema is known, we want to validate `opts.keys`, `opts.updates`, `opts.resolvers`, and `opts.optimistic`.

When any of the validation fails, we want to warn the user via `console.warn`.

Validation for `opts.keys` has already been added in PR https://github.com/FormidableLabs/urql/pull/820

## Set of changes

* `opts.updates.Mutation` and `opts.updates.Subscription` are now validated against the schema.
* `opts.resolvers` is now validated against the schema.
* `opts.optimistic` is now validated against the schema.

Resolves #810.