### PR TITLE
(babel) - esm-support

### DIFF
--- a/scripts/babel/transform-esm-compatability.js
+++ b/scripts/babel/transform-esm-compatability.js
@@ -1,0 +1,36 @@
+const checkForTypeCheck = (node) => {
+  if (node.type === "LogicalExpression") {
+    return checkForTypeCheck(node.left) || checkForTypeCheck(node.right);
+  } else if (node.left && node.left.operator === "typeof" && node.left.argument.name === "process") {
+    return true;
+  }
+  return false;
+};
+
+const plugin = ({ template, types: t }) => {
+  const typeCheckNode = template.expression.ast`typeof process !== 'undefined'`;
+
+  return {
+    visitor: {
+      BinaryExpression(path) {
+        const { node } = path;
+        const { left } = node;
+        if (left && left.property && left.property.name === "NODE_ENV") {
+          const logicalExpression = path.findParent((path) => path.isLogicalExpression());
+          if (!logicalExpression) {
+            // This is a normal singular if-statement
+            path.replaceWith(t.logicalExpression("&&", typeCheckNode, node));
+          } else {
+            // This is a logical expression, we need to find out whether or not we're already using the check.
+            const { left, right } = logicalExpression.node;
+            console.log(left, right);
+            if (checkForTypeCheck(left) || checkForTypeCheck(right)) return;
+            logicalExpression.replaceWith(t.logicalExpression("&&", typeCheckNode, logicalExpression.node));
+          }
+        }
+      }
+    }
+  };
+};
+
+export default plugin;

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -15,6 +15,7 @@ import cleanup from './cleanup-plugin.js'
 import babelPluginTransformPipe from '../babel/transform-pipe';
 import babelPluginTransformInvariant from '../babel/transform-invariant-warning';
 import babelPluginTransformDebugTarget from '../babel/transform-debug-target';
+import babelPluginTransformEsmCompatability from '../babel/transform-esm-compatability';
 
 import * as settings from './settings';
 
@@ -71,9 +72,10 @@ export const makePlugins = ({ isProduction } = {}) => [
     exclude: 'node_modules/**',
     presets: [],
     plugins: [
-      babelPluginTransformDebugTarget,
       babelPluginTransformPipe,
+      babelPluginTransformDebugTarget,
       babelPluginTransformInvariant,
+      babelPluginTransformEsmCompatability,
       'babel-plugin-modular-graphql',
       'babel-plugin-closure-elimination',
       '@babel/plugin-transform-object-assign',


### PR DESCRIPTION
Add a transform that gets rid of all the `process.env.NODE_ENV !== 'production'` checks and transforms them into `typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'`.

This is an issue we initially faced in `devtools` where we tried to introduce conditionals `process?.env?.NODE_ENV` which will result in the same esm-incompatability where the global isn't correctly referenced.

I've tested and this check is also correctly DCE'd by `terser` and `closure`.

[Try it out](https://try.terser.org/)

```
const x = () => {
  if (typeof process !== 'undefined' && 'production' !== 'production') {
    console.log('y')    
  }
}

x();
```