### PR TITLE
(core) - Expose client.subscription shortcut method

### DIFF
--- a/.changeset/hot-dryers-drive.md
+++ b/.changeset/hot-dryers-drive.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Expose `client.subscription` to be correctly recognized by exchange

--- a/.changeset/hot-dryers-drive.md
+++ b/.changeset/hot-dryers-drive.md
@@ -2,4 +2,4 @@
 '@urql/core': minor
 ---
 
-Expose `client.subscription` to be correctly recognized by exchange
+Expose a `client.subscription`shortcut method, similar to `client.query` and `client.mutation`

--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -48,10 +48,7 @@ package](https://github.com/apollographql/subscriptions-transport-ws).
 import { Client, defaultExchanges, subscriptionExchange } from 'urql';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 
-const subscriptionClient = new SubscriptionClient(
-  'wss://localhost/graphql',
-  { reconnect: true }
-);
+const subscriptionClient = new SubscriptionClient('wss://localhost/graphql', { reconnect: true });
 
 const client = new Client({
   url: '/graphql',
@@ -132,3 +129,9 @@ As we can see, the `result.data` is being updated and transformed by
 the `handleSubscription` function. This works over time, so as
 new messages come in, we will append them to the list of previous
 messages.
+
+## Directly with @urql/core
+
+To consume subscriptions without any level of abstraction you should
+use `client.subscription` method for the subscription exchange to
+correctly pick it up. Or you can use `client.executeSubscription(createRequest(query, variables))`.

--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -130,8 +130,28 @@ the `handleSubscription` function. This works over time, so as
 new messages come in, we will append them to the list of previous
 messages.
 
-## Directly with @urql/core
+## One-off Subscriptions
 
-To consume subscriptions without any level of abstraction you should
-use `client.subscription` method for the subscription exchange to
-correctly pick it up. Or you can use `client.executeSubscription(createRequest(query, variables))`.
+Whe you're using subscriptions directly without `urql`'s framework bindings, you can use the `Client`'s `subscription` method for one-off subscriptions. This method is similar to the ones for mutations and subscriptions [that we've seen before on the "Core Package" page.](../concepts/core-package.md#one-off-queries-and-mutations)
+
+This method will always [returns a Wonka stream](../concepts/stream-patterns.md#the-wonka-library) and doesn't have a `.toPromise()` shortcut method, since promises won't return the multiple values that a subscription may deliver. Let's convert the above example to one without framework code, as we may use subscriptions in a Node.js environment.
+
+```js
+import { pipe, subscribe } from 'wonka';
+
+const newMessages = `
+  subscription MessageSub {
+    newMessages {
+      id
+      from
+      text
+    }
+  }
+`;
+
+const { unsubscribe } = pipe(
+  client.subscription(MessageSub),
+  subscribe(result => {
+    console.log(result); // { data: ... }
+  })
+);

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -105,9 +105,9 @@ page.](../concepts/core-package.md#one-off-queries-and-mutations)
 
 ### client.subscription
 
-This is similar to [`client.query`](#clientquery), but provides raw stream without `toPromise` method.
+This is similar to [`client.query`](#clientquery), but does not provide a `toPromise()` helper method on the streams it returns.
 
-[Read more about how to use setup subscriptions](../advanced/subscriptions.md)
+[Read more about how to use this API on the "Subscriptions" page.](../advanced/subscriptions.md)
 
 #### client.reexecuteOperation
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -53,7 +53,7 @@ repeatedly in the interval you pass.
 ### client.executeSubscription
 
 This is functionally the same as `client.executeQuery`, but creates operations for subscriptions
-instead, with `operationName` set to `'mutation'`.
+instead, with `operationName` set to `'subscription'`.
 
 ### client.executeMutation
 
@@ -102,6 +102,12 @@ This is similar to [`client.query`](#clientquery), but dispatches mutations inst
 
 [Read more about how to use this API on the "Core Package"
 page.](../concepts/core-package.md#one-off-queries-and-mutations)
+
+### client.subscription
+
+This is similar to [`client.query`](#clientquery), but provides raw stream without `toPromise` method.
+
+[Read more about how to use setup subscriptions](../advanced/subscriptions.md)
 
 #### client.reexecuteOperation
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -314,10 +314,6 @@ export class Client {
     variables?: Variables,
     context?: Partial<OperationContext>
   ): Source<OperationResult<Data>> {
-    if (!context || typeof context.suspense !== 'boolean') {
-      context = { ...context, suspense: false };
-    }
-
     return this.executeSubscription(createRequest(query, variables), context);
   }
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -309,6 +309,18 @@ export class Client {
     return response$;
   };
 
+  subscription<Data = any, Variables extends object = {}>(
+    query: DocumentNode | string,
+    variables?: Variables,
+    context?: Partial<OperationContext>
+  ): Source<OperationResult<Data>> {
+    if (!context || typeof context.suspense !== 'boolean') {
+      context = { ...context, suspense: false };
+    }
+
+    return this.executeSubscription(createRequest(query, variables), context);
+  }
+
   executeSubscription = (
     query: GraphQLRequest,
     opts?: Partial<OperationContext>


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

Resolves #837 

## Summary

Expose `client.subscription` to be correctly recognized by the exchange.

## Set of changes

An only small addition to `@urql/core` API.