### PR TITLE
(graphcache) - Implement opportunities to reduce bundlesize on Graphcache

### DIFF
--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -39,7 +39,7 @@ import { warn, pushDebugNode, popDebugNode } from '../helpers/help';
 
 import {
   Context,
-  SelectionIterator,
+  makeSelectionIterator,
   ensureData,
   makeContext,
   updateContext,
@@ -116,7 +116,7 @@ const readRoot = (
     return originalData;
   }
 
-  const iter = new SelectionIterator(entityKey, entityKey, select, ctx);
+  const iter = makeSelectionIterator(entityKey, entityKey, select, ctx);
   const data = {} as Data;
   data.__typename = originalData.__typename;
 
@@ -258,7 +258,7 @@ const readSelection = (
   // The following closely mirrors readSelection, but differs only slightly for the
   // sake of resolving from an existing resolver result
   data.__typename = typename;
-  const iter = new SelectionIterator(typename, entityKey, select, ctx);
+  const iter = makeSelectionIterator(typename, entityKey, select, ctx);
 
   let node: FieldNode | void;
   let hasFields = false;

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -37,7 +37,7 @@ import {
 import * as InMemoryData from '../store/data';
 import {
   Context,
-  SelectionIterator,
+  makeSelectionIterator,
   ensureData,
   makeContext,
   updateContext,
@@ -199,7 +199,7 @@ const writeSelection = (
     InMemoryData.writeRecord(entityKey, '__typename', typename);
   }
 
-  const iter = new SelectionIterator(
+  const iter = makeSelectionIterator(
     typename,
     entityKey || typename,
     select,

--- a/scripts/babel/transform-invariant-warning.js
+++ b/scripts/babel/transform-invariant-warning.js
@@ -18,7 +18,32 @@ const plugin = ({ template, types: t }) => {
         const { name } = path.node.callee;
         if ((name === 'warn') && !path.node[visited]) {
           path.node[visited] = true;
-          path.replaceWith(wrapWithDevCheck({ NODE: path.node }));
+
+          // The production-check may be hoisted if the parent
+          // is already an if-statement only containing the
+          // warn call
+          let p = path;
+          while (t.isExpressionStatement(p.parentPath.node)) {
+            if (
+              t.isBlockStatement(p.parentPath.parentPath.node) &&
+              p.parentPath.parentPath.node.body.length === 1 &&
+              p.parentPath.parentPath.node.body[0] === path.parentPath.node &&
+              t.isIfStatement(p.parentPath.parentPath.parentPath.node) &&
+              p.parentPath.parentPath.parentPath.node.consequent ===
+                p.parentPath.parentPath.node
+            ) {
+              p = p.parentPath.parentPath.parentPath;
+            } else if (
+              t.isIfStatement(p.parentPath.parentPath.node) &&
+              p.parentPath.parentPath.node.consequent === p.parentPath.node
+            ) {
+              p = path.parentPath.parentPath;
+            } else {
+              break;
+            }
+          }
+
+          p.replaceWith(wrapWithDevCheck({ NODE: p.node }));
         } else if (name === 'invariant' && !path.node[visited]) {
           path.node[visited] = true;
           const formerNode = path.node.arguments[1];

--- a/scripts/babel/transform-invariant-warning.js
+++ b/scripts/babel/transform-invariant-warning.js
@@ -30,12 +30,14 @@ const plugin = ({ template, types: t }) => {
               p.parentPath.parentPath.node.body[0] === path.parentPath.node &&
               t.isIfStatement(p.parentPath.parentPath.parentPath.node) &&
               p.parentPath.parentPath.parentPath.node.consequent ===
-                p.parentPath.parentPath.node
+                p.parentPath.parentPath.node &&
+              !p.parentPath.parentPath.node.alternate
             ) {
               p = p.parentPath.parentPath.parentPath;
             } else if (
               t.isIfStatement(p.parentPath.parentPath.node) &&
-              p.parentPath.parentPath.node.consequent === p.parentPath.node
+              p.parentPath.parentPath.node.consequent === p.parentPath.node &&
+              !p.parentPath.parentPath.node.alternate
             ) {
               p = path.parentPath.parentPath;
             } else {


### PR DESCRIPTION
This should likely be batched with #840 (and #793)

It reduces the bundlesize of Graphcache using two small changes:

- Replace `SelectionIterator` with a `makeSelectionIterator` function. Curiously this doesn't reduce performance, so is 100% safe. This gets rid of a lot of unique variable names (due to instance properties) that aren't used anywhere else.
- Add some hoist-logic to the `transform-invariant-warning` Babel transform. I discovered that some statements were still sticking around, since we add the production-check below some if-statements for `warn` calls. Instead the plugin will now check whether one or more parents of the `warn()` call are if-statements only containing this call, and appropriately hoist the wrapped production check.

Bundlesize went from `6.3kB` to `6.17kB` minzipped (delta `-0.13kB`)