### PR TITLE
(chore) - Upgrade to wonka@^4.0.14

### DIFF
--- a/.changeset/real-falcons-clap.md
+++ b/.changeset/real-falcons-clap.md
@@ -1,0 +1,15 @@
+---
+'@urql/exchange-execute': patch
+'@urql/exchange-graphcache': patch
+'@urql/exchange-multipart-fetch': patch
+'@urql/exchange-persisted-fetch': patch
+'@urql/exchange-populate': patch
+'@urql/exchange-retry': patch
+'@urql/exchange-suspense': patch
+'@urql/core': patch
+'@urql/preact': patch
+'urql': patch
+'@urql/svelte': patch
+---
+
+Upgrade to a minimum version of wonka@^4.0.14 to work around issues with React Native's minification builds, which use uglify-es and could lead to broken bundles.

--- a/exchanges/execute/package.json
+++ b/exchanges/execute/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.11.7",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/exchanges/graphcache/package.json
+++ b/exchanges/graphcache/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.11.7",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/exchanges/multipart-fetch/package.json
+++ b/exchanges/multipart-fetch/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@urql/core": ">=1.11.7",
     "extract-files": "^8.1.0",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/exchanges/persisted-fetch/package.json
+++ b/exchanges/persisted-fetch/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.11.8",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/exchanges/populate/package.json
+++ b/exchanges/populate/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.11.6",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.11.7",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "publishConfig": {
     "access": "public"

--- a/exchanges/suspense/package.json
+++ b/exchanges/suspense/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@urql/core": ">=1.11.7",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "dependencies": {
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preact-urql/package.json
+++ b/packages/preact-urql/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@urql/core": "^1.11.6",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -60,6 +60,6 @@
   },
   "dependencies": {
     "@urql/core": "^1.11.0",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   }
 }

--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@urql/core": "^1.11.6",
-    "wonka": "^4.0.10"
+    "wonka": "^4.0.14"
   },
   "devDependencies": {
     "graphql": "^15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14903,10 +14903,10 @@ winston@0.8.x:
     pkginfo "0.3.x"
     stack-trace "0.0.x"
 
-wonka@^4.0.10:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.13.tgz#8d188160bd5742870c78ede7a4eba686d089a33f"
-  integrity sha512-aWg92IVvbP/kp+q9rw+k/Uw3C/S2J0dTDNhEhivGVH3GXJZgpFk2nuyVtiS7Y1d0UG3m4jvOrR7bPXim6D/TBg==
+wonka@^4.0.14:
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.14.tgz#77d680a84e575ed15a9f975eb87d6c530488f3a4"
+  integrity sha512-v9vmsTxpZjrA8CYfztbuoTQSHEsG3ZH+NCYfasHm0V3GqBupXrjuuz0RJyUaw2cRO7ouW2js0P6i853/qxlDcA==
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Resolve #831 

This works around a bundling issue in React Native, which uses `uglify-es`, a deprecated minifier/uglifier. This caused invalid JS output, which would lead to errors.

This PR is set to bump all packages by a patch release to forcefully get users to use the new version, since it also saves on size and improves performance. Theoretically, this will prompt bundlers to upgrade `wonka` and deduplicate it either way, even if only one of these patches is installed.