### PR TITLE
(next-urql) - reuse the ssrExchange when there's one present

### DIFF
--- a/.changeset/wet-squids-glow.md
+++ b/.changeset/wet-squids-glow.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Reuse the ssrExchange when there is one present on the client-side

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -22,6 +22,8 @@ function getDisplayName(Component: React.ComponentType<any>) {
   return Component.displayName || Component.name || 'Component';
 }
 
+let ssr;
+
 export function withUrqlClient(
   getClientConfig: NextUrqlClientConfig,
   options?: WithUrqlClientOptions
@@ -35,7 +37,7 @@ export function withUrqlClient(
           return urqlClient;
         }
 
-        const ssr = ssrExchange({ initialState: urqlState });
+        if (!ssr) ssr = ssrExchange({ initialState: urqlState });
         const clientConfig = getClientConfig(ssr);
         if (!clientConfig.exchanges) {
           // When the user does not provide exchanges we make the default assumption.


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Restores former behavior where we reused the [`ssrExchange`](https://github.com/FormidableLabs/urql/blob/next-urql%400.3.8/packages/next-urql/src/init-urql-client.ts)

## Set of changes

- Reuse the ssr exchange
