### PR TITLE
(next) - prevent client-serialization even without getInitialProps

### DIFF
--- a/.changeset/curly-bags-tap.md
+++ b/.changeset/curly-bags-tap.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Prevent serialization even if we don't have getInitialProps

--- a/.changeset/curly-bags-tap.md
+++ b/.changeset/curly-bags-tap.md
@@ -2,4 +2,4 @@
 'next-urql': patch
 ---
 
-Prevent serialization even if we don't have getInitialProps
+Prevent serialization of the `Client` for `withUrqlClient` even if the target component doesn't have a `getInitialProps` method. Before this caused the client to not be initialised correctly on the client-side.

--- a/packages/next-urql/src/init-urql-client.ts
+++ b/packages/next-urql/src/init-urql-client.ts
@@ -13,6 +13,9 @@ export function initUrqlClient(clientOptions: ClientOptions): Client | null {
       ...clientOptions,
       suspense: isServer || clientOptions.suspense,
     });
+    // Serialize the urqlClient to null on the client-side.
+    // This ensures we don't share client and server instances of the urqlClient.
+    (urqlClient as any).toJSON = () => null;
   }
 
   // Return both the Client instance and the ssrCache.

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -111,12 +111,6 @@ export function withUrqlClient(
         // Run the prepass step on AppTree. This will run all urql queries on the server.
         await ssrPrepass(<AppTree {...appTreeProps} />);
 
-        // Serialize the urqlClient to null on the client-side.
-        // This ensures we don't share client and server instances of the urqlClient.
-        (urqlClient as any).toJSON = () => {
-          return null;
-        };
-
         return {
           ...pageProps,
           urqlState: ssrCache ? ssrCache.extractData() : undefined,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

We shouldn't serialize the urql-client down to the client, we used to rely on this happening within `getInitialProps`, now that this isn't always present it'd be better to rely on `initUrqlClient` to handle this for us.

## Set of changes

- add `client.toJSON = () => null` to `initUrqlClient` to prevent serialization between server and client.
