### PR TITLE
(graphcache) - Add root operation type traversal warning

### DIFF
--- a/.changeset/rich-eels-shop.md
+++ b/.changeset/rich-eels-shop.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Add warning for queries that traverse an Operation Root Type (Mutation / Subscription types occuring in a query result)

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -332,3 +332,36 @@ able to check whether your `opts.optimistic` is valid.
 This error occurs when a field in `opts.optimistic` is not in the schema's `Mutation` fields.
 
 Check whether your schema is up-to-date, or whether you've got a typo in `Mutation` or `opts.optimistic`.
+
+## (25) Invalid root traversal
+
+> Invalid root traversel: A selection was being read on `???` which is an uncached root type.
+> The `Mutation` and `Subscription` types are special Operation Root Types and cannot be read back
+> from the cache.
+
+In GraphQL every schema has three [Operation Root
+Types](https://spec.graphql.org/June2018/#sec-Root-Operation-Types). The `Query` type is the only
+one that is cached in Graphcache's normalized cache, since it's the root of all normalized cache
+data, i.e. all data is linked and connects back to the `Query` type.
+
+The `Subscription` and `Mutation` types are special and uncached; they may link to entities that
+will be updated in the normalized cache data, but are themselves not cached, since they're never
+directly queried.
+
+When your schema treats `Mutation` or `Subscription` like regular entity types you may get this
+warning. This may happen because you've used the default reserved names `Mutation` or `Subscription`
+for entities rather than as special Operation Root Types, and haven't specified this in the schema.
+Hence this issue can often be fixed by either enabling
+[Schema Awareness](https://formidable.com/open-source/urql/docs/graphcache/schema-awareness/) or by
+adding a `schema` definition to your GraphQL Schema like so:
+
+```graphql
+schema {
+  query: Query
+  mutation: YourMutation
+  subscription: YourSubscription
+}
+```
+
+Where `YourMutation` and `YourSubscription` are your custom Operation Root Types, instead of relying
+on the default names `"Mutation"` and `"Subscription"`.

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -335,7 +335,7 @@ Check whether your schema is up-to-date, or whether you've got a typo in `Mutati
 
 ## (25) Invalid root traversal
 
-> Invalid root traversel: A selection was being read on `???` which is an uncached root type.
+> Invalid root traversal: A selection was being read on `???` which is an uncached root type.
 > The `Mutation` and `Subscription` types are special Operation Root Types and cannot be read back
 > from the cache.
 

--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -28,7 +28,8 @@ export type ErrorCode =
   | 21
   | 22
   | 23
-  | 24;
+  | 24
+  | 25;
 
 type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
 

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -237,6 +237,21 @@ const readSelection = (
   const isQuery = key === store.rootFields['query'];
 
   const entityKey = (result && store.keyOfEntity(result)) || key;
+  if (!isQuery && !!ctx.store.rootNames[entityKey]) {
+    warn(
+      'Invalid root traversel: A selection was being read on `' +
+        entityKey +
+        '` which is an uncached root type.\n' +
+        'The `' +
+        ctx.store.rootFields.mutation +
+        '` and `' +
+        ctx.store.rootFields.subscription +
+        '` types are special ' +
+        'Operation Root Types and cannot be read back from the cache.',
+      25
+    );
+  }
+
   const typename = !isQuery
     ? InMemoryData.readRecord(entityKey, '__typename') ||
       (result && result.__typename)

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -239,7 +239,7 @@ const readSelection = (
   const entityKey = (result && store.keyOfEntity(result)) || key;
   if (!isQuery && !!ctx.store.rootNames[entityKey]) {
     warn(
-      'Invalid root traversel: A selection was being read on `' +
+      'Invalid root traversal: A selection was being read on `' +
         entityKey +
         '` which is an uncached root type.\n' +
         'The `' +


### PR DESCRIPTION
Resolve #858

## Summary

Add warning for queries that traverse an Operation Root Type (Mutation / Subscription types occuring in a query result)

It's possible for someone to _explicitly_ use `Mutation` or `Subscription` inside `Query`, which by convention is discouraged and shouldn't be done. The worst that we do in such a case is now issue a warning, but I believe it's more important to prevent this mistake than to ignore it silentily, especially since it's extremely uncommon.

## Set of changes

- Add check to `readSelection` for non-Query root types and issue warning
- Add explanation of the warning to `errors.md`
- Ensure that the warning logs out the relevant typenames
