### PR TITLE
(fix) - Fix timing for out-of-band client.reexecuteOperation calls

### DIFF
--- a/.changeset/strong-games-scream.md
+++ b/.changeset/strong-games-scream.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix timing for out-of-band `client.reexecuteOperation` calls. This would surface in asynchronous caching scenarios, where no result would be delivered by the cache synchronously, while it still calls `client.reexecuteOperation` for e.g. a `network-only` request, which happens for `cache-and-network`. This issue becomes especially obvious in highly synchronous frameworks like Svelte.

--- a/packages/core/src/utils/defer.ts
+++ b/packages/core/src/utils/defer.ts
@@ -1,0 +1,4 @@
+export const scheduleTask: (fn: () => void) => void =
+  typeof Promise !== 'undefined'
+    ? Promise.prototype.then.bind(Promise.resolve())
+    : fn => setTimeout(fn, 0);

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from './toSuspenseSource';
 export * from './stringifyVariables';
 export * from './maskTypename';
 export * from './withPromise';
+export * from './defer';
 
 export const noop = () => {
   /* noop */


### PR DESCRIPTION
Resolve #721

## Summary

    When an operation becomes asynchronous, by matter of an exchange
    delaying it, while it also calls client.reexecuteOpoeration, we
    were calling client.reexecuteOperation out-of-band, which causes
    the reexecuted operation to be dispatched immediately.
    We can't detect the intent of the exchange, and don't know that it
    may afterwards immediately send a result synchronously after the delay,
    but we do know that once an operation becomes asynchronous, the timing
    of client.reexecuteOperation is not sensitive anymore. So instead we
    now choose to defer it by a tick.

## Set of changes

- Add a `defer` to `@urql/core`
- Defer flushing the queue actively in `reexecuteOperation` when no other operation is in-band and actively being worked on