### PR TITLE
(chore) - Remove scheduleTask helpers

### DIFF
--- a/.changeset/tiny-tomatoes-bow.md
+++ b/.changeset/tiny-tomatoes-bow.md
@@ -1,0 +1,6 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/core': patch
+---
+
+Replace unnecessary `scheduleTask` polyfill with inline `Promise.resolve().then(fn)` calls.

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -261,8 +261,8 @@ describe('offline', () => {
 
     flush!();
     expect(dispatchOperationSpy).toHaveBeenCalledTimes(1);
-    expect(dispatchOperationSpy.mock.calls[0][0]!.key).toEqual(1);
-    expect(dispatchOperationSpy.mock.calls[0][0]!.query).toEqual(
+    expect((dispatchOperationSpy.mock.calls[0][0] as any).key).toEqual(1);
+    expect((dispatchOperationSpy.mock.calls[0][0] as any).query).toEqual(
       mutationOp.query
     );
   });

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -19,7 +19,6 @@ import {
 
 import { makeDict } from '../helpers/dict';
 import { invariant, currentDebugStack } from '../helpers/help';
-import { scheduleTask } from './defer';
 
 type Dict<T> = Record<string, T>;
 type KeyMap<T> = Map<string, T>;
@@ -136,7 +135,7 @@ export const clearDataState = () => {
   // Schedule deferred tasks if we haven't already
   if (process.env.NODE_ENV !== 'test' && !data.defer) {
     data.defer = true;
-    scheduleTask(() => {
+    Promise.resolve().then(() => {
       initDataState('write', data, null);
       gc();
       persistData();

--- a/exchanges/graphcache/src/store/defer.ts
+++ b/exchanges/graphcache/src/store/defer.ts
@@ -1,4 +1,0 @@
-export const scheduleTask: (fn: () => void) => void =
-  process.env.NODE_ENV === 'production' && typeof Promise !== 'undefined'
-    ? Promise.prototype.then.bind(Promise.resolve())
-    : fn => setTimeout(fn, 0);

--- a/packages/core/src/utils/defer.ts
+++ b/packages/core/src/utils/defer.ts
@@ -1,4 +1,0 @@
-export const scheduleTask: (fn: () => void) => void =
-  typeof Promise !== 'undefined'
-    ? Promise.prototype.then.bind(Promise.resolve())
-    : fn => setTimeout(fn, 0);

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -6,7 +6,6 @@ export * from './toSuspenseSource';
 export * from './stringifyVariables';
 export * from './maskTypename';
 export * from './withPromise';
-export * from './defer';
 
 export const noop = () => {
   /* noop */


### PR DESCRIPTION
Removes the `scheduleTask` ponyfill helpers in favour of inline `Promise.resolve().then(fn)` calls.

The scheduleTask helper was useful because globally we can't
tell whether `Promise` has been polyfilled for IE11 yet.
However, where this is called we _can_ already be sure of
it being polyfilled, which we do assume in other places
of the codebase.
Therefore it's safe to replace the `scheduleTask` polyfill
with a simple inline `Promise.resolve().then(fn)` call, which
is also more obvious.