### PR TITLE
(svelte) - Expand Readables with factory and PromiseLike methods

### DIFF
--- a/.changeset/strange-donuts-listen.md
+++ b/.changeset/strange-donuts-listen.md
@@ -1,0 +1,39 @@
+---
+'@urql/svelte': minor
+---
+
+Refactor all operations to allow for more use-cases which preserve state and allow all modes of Svelte to be applied to urql.
+
+```
+// Standard Usage:
+mutate({ query, variables })()
+
+// Subscribable Usage:
+$: result = mutate({ query, variables });
+
+// Curried Usage
+const executeMutation = mutate({ query, variables });
+const onClick = () => executeMutation();
+
+// Curried Usage with overrides
+const executeMutation = mutate({ query });
+const onClick = () => await executeMutation({ variables });
+
+// Subscribable Usage (as before):
+$: result = query({ query: TestQuery, variables });
+
+// Subscribable Usage which preserves state over time:
+const testQuery = query({ query: TestQuery });
+// - this preserves the state even when the variables change!
+$: result = testQuery({ variables });
+
+// Promise-based callback usage:
+const testQuery = query({ query: TestQuery });
+const doQuery = async () => await testQuery;
+
+// Promise-based usage updates the subscribables!
+const testQuery = query({ query: TestQuery });
+const doQuery = async () => await testQuery;
+// - doQuery will also update this result
+$: result = query({ query: TestQuery, variables });
+```

--- a/packages/svelte-urql/example/src/App.svelte
+++ b/packages/svelte-urql/example/src/App.svelte
@@ -5,7 +5,7 @@
 
   let i = 0;
 
-  $: todos = query({
+  const todosQuery = query({
     query: `
       query {
         todos {
@@ -15,16 +15,19 @@
         }
       }
     `,
-    variables: { i },
   });
 
-  const increment = () => i = i + 1;
+  $: todos = todosQuery({ pause: true });
+
+  const execute = () => todosQuery().then();
 </script>
 
 {#if $todos.fetching}
   Loading...
 {:else if $todos.error}
   Oh no! {$todos.error.message}
+{:else if !$todos.data}
+  No data
 {:else}
   <ul>
     {#each $todos.data.todos as todo}
@@ -33,4 +36,4 @@
   </ul>
 {/if}
 
-<button on:click={increment}>Increment {i}</button>
+<button on:click={execute}>Execute</button>

--- a/packages/svelte-urql/src/operations/mutate.ts
+++ b/packages/svelte-urql/src/operations/mutate.ts
@@ -12,7 +12,8 @@ export interface MutationArguments<V> {
 }
 
 export interface MutationStore<T = any, V = object>
-  extends Readable<OperationResult<T>> {
+  extends Readable<OperationResult<T>>,
+    PromiseLike<OperationResult<T>> {
   (additionalArgs?: Partial<MutationArguments<V>>): Promise<OperationResult<T>>;
 }
 
@@ -37,6 +38,12 @@ export const mutate = <T = any, V = object>(
       client.mutation(args.query, args.variables as any, args.context),
       subscribe(onValue)
     ).unsubscribe;
+  };
+
+  mutate$.then = (
+    onValue: (result: OperationResult<T>) => any
+  ): Promise<any> => {
+    return mutate$().then(onValue);
   };
 
   return mutate$ as any;

--- a/packages/svelte-urql/src/operations/mutate.ts
+++ b/packages/svelte-urql/src/operations/mutate.ts
@@ -1,4 +1,6 @@
+import { pipe, subscribe } from 'wonka';
 import { OperationResult, OperationContext } from '@urql/core';
+import { Readable } from 'svelte/store';
 import { DocumentNode } from 'graphql';
 
 import { getClient } from '../context';
@@ -9,10 +11,33 @@ export interface MutationArguments<V> {
   context?: Partial<OperationContext>;
 }
 
+export interface MutationStore<T = any, V = object>
+  extends Readable<OperationResult<T>> {
+  (additionalArgs?: Partial<MutationArguments<V>>): Promise<OperationResult<T>>;
+}
+
 export const mutate = <T = any, V = object>(
   args: MutationArguments<V>
-): Promise<OperationResult<T>> => {
-  return getClient()
-    .mutation(args.query, args.variables as any, args.context)
-    .toPromise();
+): MutationStore<T, V> => {
+  const client = getClient();
+
+  function mutate$(additionalArgs?: Partial<MutationArguments<V>>) {
+    const mergedArgs = { ...args, ...additionalArgs };
+    return client
+      .mutation(
+        mergedArgs.query,
+        mergedArgs.variables as any,
+        mergedArgs.context
+      )
+      .toPromise();
+  }
+
+  mutate$.subscribe = (onValue: (result: OperationResult<T>) => void) => {
+    return pipe(
+      client.mutation(args.query, args.variables as any, args.context),
+      subscribe(onValue)
+    ).unsubscribe;
+  };
+
+  return mutate$ as any;
 };

--- a/packages/svelte-urql/src/operations/query.ts
+++ b/packages/svelte-urql/src/operations/query.ts
@@ -104,7 +104,6 @@ export const query = <T = any, V = object>(
       return queryStore({
         ...baseArgs,
         ...args,
-        pause: baseArgs.pause && args && args.pause !== true,
       });
     }
 

--- a/packages/svelte-urql/src/operations/query.ts
+++ b/packages/svelte-urql/src/operations/query.ts
@@ -10,6 +10,7 @@ import {
   take,
   share,
   subscribe,
+  publish,
   toPromise,
 } from 'wonka';
 
@@ -88,6 +89,8 @@ export const query = <T = any, V = object>(
     ),
     share
   );
+
+  publish(queryResult$);
 
   const queryStore = (baseArgs: QueryArguments<V>): QueryStore<T, V> => {
     const result$ = pipe(

--- a/packages/svelte-urql/src/operations/query.ts
+++ b/packages/svelte-urql/src/operations/query.ts
@@ -87,7 +87,11 @@ export const query = <T = any, V = object>(
 
   const queryStore = (baseArgs: QueryArguments<V>): QueryStore<T, V> => {
     function query$(args: Partial<QueryArguments<V>>) {
-      return queryStore({ ...baseArgs, ...args });
+      return queryStore({
+        ...baseArgs,
+        ...args,
+        pause: baseArgs.pause && args.pause !== true,
+      });
     }
 
     query$.subscribe = (onValue: (result: QueryResult<T>) => void) => {

--- a/packages/svelte-urql/src/operations/query.ts
+++ b/packages/svelte-urql/src/operations/query.ts
@@ -42,7 +42,7 @@ export interface QueryResult<T> {
 export interface QueryStore<T = any, V = object>
   extends Readable<QueryResult<T>>,
     PromiseLike<QueryResult<T>> {
-  (args: Partial<QueryArguments<V>>): QueryStore<T>;
+  (args?: Partial<QueryArguments<V>>): QueryStore<T>;
 }
 
 export const query = <T = any, V = object>(
@@ -100,11 +100,11 @@ export const query = <T = any, V = object>(
       })
     );
 
-    function query$(args: Partial<QueryArguments<V>>) {
+    function query$(args?: Partial<QueryArguments<V>>) {
       return queryStore({
         ...baseArgs,
         ...args,
-        pause: baseArgs.pause && args.pause !== true,
+        pause: baseArgs.pause && args && args.pause !== true,
       });
     }
 

--- a/packages/svelte-urql/src/operations/subscription.ts
+++ b/packages/svelte-urql/src/operations/subscription.ts
@@ -9,6 +9,7 @@ import {
   map,
   share,
   subscribe,
+  publish,
 } from 'wonka';
 
 import { OperationContext, CombinedError } from '@urql/core';
@@ -85,6 +86,8 @@ export const subscription = <T = any, R = T, V = object>(
     }, initialState),
     share
   );
+
+  publish(subscriptionResult$);
 
   const subscriptionStore = (
     baseArgs: SubscriptionArguments<V>

--- a/packages/svelte-urql/src/operations/subscription.ts
+++ b/packages/svelte-urql/src/operations/subscription.ts
@@ -90,7 +90,11 @@ export const subscription = <T = any, R = T, V = object>(
     baseArgs: SubscriptionArguments<V>
   ): SubscriptionStore<T, R, V> => {
     function subscription$(args: Partial<SubscriptionArguments<V>>) {
-      return subscriptionStore({ ...baseArgs, ...args });
+      return subscriptionStore({
+        ...baseArgs,
+        ...args,
+        pause: baseArgs.pause && args.pause !== true,
+      });
     }
 
     subscription$.subscribe = (

--- a/packages/svelte-urql/src/operations/subscription.ts
+++ b/packages/svelte-urql/src/operations/subscription.ts
@@ -96,7 +96,6 @@ export const subscription = <T = any, R = T, V = object>(
       return subscriptionStore({
         ...baseArgs,
         ...args,
-        pause: baseArgs.pause && args && args.pause !== true,
       });
     }
 

--- a/packages/svelte-urql/src/operations/subscription.ts
+++ b/packages/svelte-urql/src/operations/subscription.ts
@@ -38,7 +38,7 @@ export interface SubscriptionResult<T> {
 
 export interface SubscriptionStore<T = any, R = T, V = object>
   extends Readable<SubscriptionResult<T>> {
-  (args: Partial<SubscriptionArguments<V>>): SubscriptionStore<T, R, V>;
+  (args?: Partial<SubscriptionArguments<V>>): SubscriptionStore<T, R, V>;
 }
 
 export const subscription = <T = any, R = T, V = object>(
@@ -92,11 +92,11 @@ export const subscription = <T = any, R = T, V = object>(
   const subscriptionStore = (
     baseArgs: SubscriptionArguments<V>
   ): SubscriptionStore<T, R, V> => {
-    function subscription$(args: Partial<SubscriptionArguments<V>>) {
+    function subscription$(args?: Partial<SubscriptionArguments<V>>) {
       return subscriptionStore({
         ...baseArgs,
         ...args,
-        pause: baseArgs.pause && args.pause !== true,
+        pause: baseArgs.pause && args && args.pause !== true,
       });
     }
 

--- a/packages/svelte-urql/src/operations/subscription.ts
+++ b/packages/svelte-urql/src/operations/subscription.ts
@@ -1,5 +1,17 @@
-import { OperationContext, CombinedError, createRequest } from '@urql/core';
-import { pipe, fromValue, concat, scan, map, subscribe } from 'wonka';
+import {
+  pipe,
+  makeSubject,
+  fromValue,
+  switchMap,
+  onStart,
+  concat,
+  scan,
+  map,
+  share,
+  subscribe,
+} from 'wonka';
+
+import { OperationContext, CombinedError } from '@urql/core';
 import { Readable } from 'svelte/store';
 import { DocumentNode } from 'graphql';
 
@@ -9,6 +21,7 @@ import { initialState } from './constants';
 export interface SubscriptionArguments<V> {
   query: string | DocumentNode;
   variables?: V;
+  pause?: boolean;
   context?: Partial<OperationContext>;
 }
 
@@ -22,28 +35,45 @@ export interface SubscriptionResult<T> {
   extensions?: Record<string, any>;
 }
 
+export interface SubscriptionStore<T = any, R = T, V = object>
+  extends Readable<SubscriptionResult<T>> {
+  (args: Partial<SubscriptionArguments<V>>): SubscriptionStore<T, R, V>;
+}
+
 export const subscription = <T = any, R = T, V = object>(
   args: SubscriptionArguments<V>,
   handler?: SubscriptionHandler<T, R>
-): Readable<SubscriptionResult<T>> => {
+): SubscriptionStore<T, R, V> => {
   const client = getClient();
-  const request = createRequest(args.query, args.variables as any);
+  const { source: args$, next: nextArgs } = makeSubject<
+    SubscriptionArguments<V>
+  >();
 
-  const queryResult$ = pipe(
-    concat([
-      fromValue({ fetching: true, stale: false }),
-      pipe(
-        client.executeSubscription(request, args.context),
-        map(({ stale, data, error, extensions }) => ({
-          fetching: false,
-          stale: !!stale,
-          data,
-          error,
-          extensions,
-        }))
-      ),
-      fromValue({ fetching: false, stale: false }),
-    ]),
+  const subscriptionResult$ = pipe(
+    args$,
+    switchMap(args => {
+      if (args.pause) {
+        return fromValue({ fetching: false, stale: false });
+      }
+
+      return concat([
+        // Initially set fetching to true
+        fromValue({ fetching: true, stale: false }),
+        pipe(
+          client.subscription<T>(args.query, args.variables, args.context),
+          map(({ stale, data, error, extensions }) => ({
+            fetching: false,
+            stale: !!stale,
+            data,
+            error,
+            extensions,
+          }))
+        ),
+        // When the source proactively closes, fetching is set to false
+        fromValue({ fetching: false, stale: false }),
+      ]);
+    }),
+    // The individual partial results are merged into each previous result
     scan((result, partial: any) => {
       const data =
         partial.data !== undefined
@@ -52,13 +82,31 @@ export const subscription = <T = any, R = T, V = object>(
             : partial.data
           : result.data;
       return { ...result, ...partial, data };
-    }, initialState)
+    }, initialState),
+    share
   );
 
-  return {
-    subscribe(onValue) {
-      const { unsubscribe } = pipe(queryResult$, subscribe(onValue));
-      return unsubscribe as () => void;
-    },
+  const subscriptionStore = (
+    baseArgs: SubscriptionArguments<V>
+  ): SubscriptionStore<T, R, V> => {
+    function subscription$(args: Partial<SubscriptionArguments<V>>) {
+      return subscriptionStore({ ...baseArgs, ...args });
+    }
+
+    subscription$.subscribe = (
+      onValue: (result: SubscriptionResult<T>) => void
+    ) => {
+      return pipe(
+        subscriptionResult$,
+        onStart(() => {
+          nextArgs({ ...baseArgs, ...args });
+        }),
+        subscribe(onValue)
+      ).unsubscribe;
+    };
+
+    return subscription$ as any;
   };
+
+  return subscriptionStore(args);
 };


### PR DESCRIPTION
Resolve #706 
Resolve #854
Resolve #806
Resolve #795

## Summary

The previous store implementations for `query`, `mutate`, and `subscription` were not as capable as we'd hoped. Two problems surfaced mainly:

- The state of `query` and `subscription` could not be preserved. Passing new arguments meant that the old state was lost
- The APIs were confusing. Svelte has many different ways to consume data and we only provided one that worked and was limited

To solve this there are now several more ways of using these bindings. To start with a simple one `mutate` now returns a `MutationStore`, which can be subscribed to, can be called itself to start a mutation, and can be used as a `PromiseLike`

```js
// Standard Usage:
mutate({ query, variables })()

// Subscribable Usage:
$: result = mutate({ query, variables });

// Curried Usage
const executeMutation = mutate({ query, variables });
const onClick = () => executeMutation();

// Curried Usage with overrides
const executeMutation = mutate({ query });
const onClick = () => await executeMutation({ variables });
```

Similarly the `query` and `subscription` helpers support new use-cases. But they're also recursively callable to create new sub-stores!

```js
// Subscribable Usage (as before):
$: result = query({ query: TestQuery, variables });

// Subscribable Usage which preserves state over time:
const testQuery = query({ query: TestQuery });
// - this preserves the state even when the variables change!
$: result = testQuery({ variables });

// Promise-based callback usage:
const testQuery = query({ query: TestQuery });
const doQuery = async () => await testQuery;

// Promise-based usage updates the subscribables!
const testQuery = query({ query: TestQuery });
const doQuery = async () => await testQuery;
// - doQuery will also update this result
$: result = query({ query: TestQuery, variables });
```
