### PR TITLE
(graphcache) - should not store undefined values in storage

### DIFF
--- a/.changeset/five-zebras-marry.md
+++ b/.changeset/five-zebras-marry.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Prevent translation from undefined to null in the storage-layer

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -54,12 +54,10 @@ export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
   const serializeBatch = (): string => {
     let data = '';
     for (const key in batch) {
-      const value = batch[key];
-      data += `${stringifyVariables(key)}:${
-        value !== undefined ? stringifyVariables(value) : 'null'
-      },`;
+      if (batch[key] !== undefined) {
+        data += `${stringifyVariables(key)}:${stringifyVariables(batch[key])},`;
+      }
     }
-
     return data;
   };
 


### PR DESCRIPTION
## Summary

Should not store undefined values since these aren't valid in GraphQL

Fixes: https://github.com/FormidableLabs/urql/issues/864
Sandbox: https://codesandbox.io/s/urql-svelte-crud-with-indexeddb-cqg5i?file=/package.json

## Set of changes

- exclude translation from undefined to null in storage
