### PR TITLE
(graphcache) - Reimplement default-storage serializer/deserializer

### DIFF
--- a/.changeset/thick-bees-decide.md
+++ b/.changeset/thick-bees-decide.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix storage implementation not preserving deleted values correctly or erroneously checking optimistically written entries for changes. This is fixed by adding a new default serializer to the `@urql/exchange-graphcache/default-storage` implementation, which will be incompatible with the old one.

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -1,4 +1,3 @@
-import { stringifyVariables } from '@urql/core';
 import { SerializedEntries, SerializedRequest, StorageAdapter } from '../types';
 
 const getRequestPromise = <T>(request: IDBRequest<T>): Promise<T> => {
@@ -51,24 +50,48 @@ export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
     req.result.createObjectStore(METADATA_STORE_NAME);
   };
 
+  const serializeEntry = (entry: string): string => entry.replace(/:/g, '%3a');
+
+  const deserializeEntry = (entry: string): string =>
+    entry.replace(/%3a/g, ':');
+
   const serializeBatch = (): string => {
     let data = '';
     for (const key in batch) {
       const value = batch[key];
-      data += `${stringifyVariables(key)}:${
-        value !== undefined ? stringifyVariables(value) : 'null'
-      },`;
+      data += serializeEntry(key);
+      data += ':';
+      if (value) data += serializeEntry(value);
+      data += ':';
     }
 
     return data;
   };
 
   const deserializeBatch = (input: string) => {
-    try {
-      return JSON.parse(`{${input.slice(0, -1)}}`);
-    } catch (_error) {
-      return {};
+    const data = {};
+    let char = '',
+      key = '',
+      entry = '',
+      mode = 0,
+      index = 0;
+
+    while (index < input.length) {
+      while ((char = input[index++]) !== ':') {
+        if (mode) entry += char;
+        else key += char;
+      }
+
+      if (mode) {
+        key = deserializeEntry(key);
+        entry = deserializeEntry(entry);
+        data[key] = entry || undefined;
+      } else {
+        mode = 1;
+      }
     }
+
+    return data;
   };
 
   return {

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -77,16 +77,13 @@ export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
       index = 0;
 
     while (index < input.length) {
-      while ((char = input[index++]) !== ':') {
-        if (mode) entry += char;
-        else key += char;
-      }
+      while ((char = input[index++]) !== ':') entry += char;
 
       if (mode) {
-        key = deserializeEntry(key);
-        entry = deserializeEntry(entry);
-        data[key] = entry || undefined;
+        data[key] = deserializeEntry(entry) || undefined;
       } else {
+        key = deserializeEntry(entry);
+        entry = '';
         mode = 1;
       }
     }

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -77,13 +77,16 @@ export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
       index = 0;
 
     while (index < input.length) {
-      while ((char = input[index++]) !== ':') entry += char;
+      entry = '';
+      while ((char = input[index++]) !== ':' && char) {
+        entry += char;
+      }
 
       if (mode) {
         data[key] = deserializeEntry(entry) || undefined;
+        mode = 0;
       } else {
         key = deserializeEntry(entry);
-        entry = '';
         mode = 1;
       }
     }

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -34,7 +34,7 @@ export interface DefaultStorage extends StorageAdapter {
 export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
   if (!opts) opts = {};
 
-  const DB_NAME = opts.idbName || 'graphcache-v3';
+  const DB_NAME = opts.idbName || 'graphcache-v4';
   const ENTRIES_STORE_NAME = 'entries';
   const METADATA_STORE_NAME = 'metadata';
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -557,8 +557,8 @@ export const inspectFields = (entityKey: string): FieldInfo[] => {
 
 export const persistData = () => {
   if (currentData!.storage) {
-    const entries: SerializedEntries = makeDict();
     currentIgnoreOptimistic = true;
+    const entries: SerializedEntries = makeDict();
     currentData!.persist.forEach(key => {
       const { entityKey, fieldKey } = deserializeKeyInfo(key);
       let x: void | Link | EntityField;

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -75,7 +75,7 @@ export const initDataState = (
   currentOperation = operationType;
   currentData = data;
   currentDependencies = makeDict();
-  currentIgnoreOptimistic = false;
+  currentIgnoreOptimistic = !!isOptimistic;
   if (process.env.NODE_ENV !== 'production') {
     currentDebugStack.length = 0;
   }
@@ -116,6 +116,7 @@ export const clearDataState = () => {
 
   const data = currentData!;
   const layerKey = currentOptimisticKey;
+  currentIgnoreOptimistic = false;
   currentOptimisticKey = null;
 
   // Determine whether the current operation has been a commutative layer
@@ -132,6 +133,13 @@ export const clearDataState = () => {
     }
   }
 
+  currentOperation = null;
+  currentData = null;
+  currentDependencies = null;
+  if (process.env.NODE_ENV !== 'production') {
+    currentDebugStack.length = 0;
+  }
+
   // Schedule deferred tasks if we haven't already
   if (process.env.NODE_ENV !== 'test' && !data.defer) {
     data.defer = true;
@@ -142,13 +150,6 @@ export const clearDataState = () => {
       clearDataState();
       data.defer = false;
     });
-  }
-
-  currentOperation = null;
-  currentData = null;
-  currentDependencies = null;
-  if (process.env.NODE_ENV !== 'production') {
-    currentDebugStack.length = 0;
   }
 };
 
@@ -382,8 +383,9 @@ const updateDependencies = (entityKey: string, fieldKey?: string) => {
 };
 
 const updatePersist = (entityKey: string, fieldKey: string) => {
-  if (currentData!.storage)
+  if (!currentIgnoreOptimistic && currentData!.storage) {
     currentData!.persist.add(serializeKeys(entityKey, fieldKey));
+  }
 };
 
 /** Reads an entity's field (a "record") from data */


### PR DESCRIPTION
Resolve #864 

## Summary

This fixes an issue where deleted values wouldn't be persisted correctly, since the `default-storage` serializer coerced both `null` and `undefined` to `"null"` JSON values. The `@urql/exchange/default-storage` implementation now comes with a new serializer which is incompatible with the old one but should be faster and more correct. It's incompatible with the old one, so the default `idbName` has been bumped to `graphcache-v4`.

## Set of changes

- Prevent optimistic layers from queueing up unnecessary keys onto the `data.persist` set
- Implement a new serializer and deserializer on `default-storage`
