### PR TITLE
(core) - Fix formatDocument mutating original document

### DIFF
--- a/.changeset/six-hornets-smile.md
+++ b/.changeset/six-hornets-smile.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix `formatDocument` mutating parts of the `DocumentNode` which may be shared by other documents and queries. Also ensure that a formatted document will always generate the same key in `createRequest` as the original document.

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -1,10 +1,12 @@
-import gql from 'graphql-tag';
 import {
   createClient,
   ExchangeIO,
   Operation,
   OperationResult,
+  formatDocument,
 } from '@urql/core';
+
+import gql from 'graphql-tag';
 import { pipe, map, makeSubject, tap, publish } from 'wonka';
 import { offlineExchange } from './offlineExchange';
 
@@ -263,7 +265,7 @@ describe('offline', () => {
     expect(dispatchOperationSpy).toHaveBeenCalledTimes(1);
     expect((dispatchOperationSpy.mock.calls[0][0] as any).key).toEqual(1);
     expect((dispatchOperationSpy.mock.calls[0][0] as any).query).toEqual(
-      mutationOp.query
+      formatDocument(mutationOp.query)
     );
   });
 });

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -10,7 +10,6 @@ interface Documents {
 const hashQuery = (q: string): number => hash(q.replace(/[\s,]+/g, ' ').trim());
 
 const docs: Documents = Object.create(null);
-const keyProp = '__key';
 
 export const createRequest = (
   q: string | DocumentNode,
@@ -21,8 +20,8 @@ export const createRequest = (
   if (typeof q === 'string') {
     key = hashQuery(q);
     query = docs[key] !== undefined ? docs[key] : parse(q);
-  } else if ((q as any)[keyProp] !== undefined) {
-    key = (q as any)[keyProp];
+  } else if ((q as any).__key !== undefined) {
+    key = (q as any).__key;
     query = q;
   } else {
     key = hashQuery(print(q));
@@ -30,7 +29,7 @@ export const createRequest = (
   }
 
   docs[key] = query;
-  (query as any)[keyProp] = key;
+  (query as any).__key = key;
 
   return {
     key: vars ? phash(key, stringifyVariables(vars)) >>> 0 : key,


### PR DESCRIPTION
Resolve #879 

- Fix the formatDocument mutating parts of the original document
- Fix a formatted document from creating a different hash in createRequest

The latter works because `formatDocument` can be assumed to be called
by caches, like the cacheExchange, so they shouldn't ever alter the
resulting hash.

This does affect the minzipped size: `3.44kB => 3.46kB`