### PR TITLE
(next-urql) - disable suspense when we aren't binding getInitialProps

### DIFF
--- a/.changeset/kind-goats-carry.md
+++ b/.changeset/kind-goats-carry.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Disable suspense on the urql-client when we aren't using react-ssr-prepass.

--- a/.changeset/kind-goats-carry.md
+++ b/.changeset/kind-goats-carry.md
@@ -2,4 +2,4 @@
 'next-urql': patch
 ---
 
-Disable suspense on the urql-client when we aren't using react-ssr-prepass.
+Disable suspense on the `Client` when we aren't using `react-ssr-prepass`.

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,7 @@
 {
   "packages": [
     "packages/core",
+    "packages/next-urql",
     "packages/react-urql",
     "packages/preact-urql",
     "packages/svelte-urql",

--- a/packages/next-urql/src/__tests__/init-urql-client.spec.ts
+++ b/packages/next-urql/src/__tests__/init-urql-client.spec.ts
@@ -1,12 +1,27 @@
 import { initUrqlClient } from '../init-urql-client';
 
 describe('initUrqlClient', () => {
-  it('should return the urqlClient instance', () => {
-    const urqlClient = initUrqlClient({
-      url: 'http://localhost:3000',
-    });
+  it('should return the urqlClient instance (suspense)', () => {
+    const urqlClient = initUrqlClient(
+      {
+        url: 'http://localhost:3000',
+      },
+      true
+    );
 
     expect(urqlClient).toHaveProperty('url', 'http://localhost:3000');
     expect(urqlClient).toHaveProperty('suspense', true);
+  });
+
+  it('should return the urqlClient instance (no-suspense)', () => {
+    const urqlClient = initUrqlClient(
+      {
+        url: 'http://localhost:3000',
+      },
+      false
+    );
+
+    expect(urqlClient).toHaveProperty('url', 'http://localhost:3000');
+    expect(urqlClient).toHaveProperty('suspense', false);
   });
 });

--- a/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
+++ b/packages/next-urql/src/__tests__/with-urql-client.spec.tsx
@@ -97,11 +97,14 @@ describe('withUrqlClient', () => {
     it('should allow a user to access the ctx object from Next on the server', async () => {
       Component.getInitialProps &&
         (await Component.getInitialProps(mockContext));
-      expect(spyInitUrqlClient).toHaveBeenCalledWith({
-        url: 'http://localhost:3000',
-        fetchOptions: { headers: { Authorization: token } },
-        exchanges: [mockSsrExchange],
-      });
+      expect(spyInitUrqlClient).toHaveBeenCalledWith(
+        {
+          url: 'http://localhost:3000',
+          fetchOptions: { headers: { Authorization: token } },
+          exchanges: [mockSsrExchange],
+        },
+        true
+      );
     });
   });
 

--- a/packages/next-urql/src/init-urql-client.ts
+++ b/packages/next-urql/src/init-urql-client.ts
@@ -3,7 +3,10 @@ import 'isomorphic-unfetch';
 
 let urqlClient: Client | null = null;
 
-export function initUrqlClient(clientOptions: ClientOptions): Client | null {
+export function initUrqlClient(
+  clientOptions: ClientOptions,
+  canEnableSuspense: boolean
+): Client | null {
   // Create a new Client for every server-side rendered request.
   // This ensures we reset the state for each rendered page.
   // If there is an exising client instance on the client-side, use it.
@@ -11,7 +14,7 @@ export function initUrqlClient(clientOptions: ClientOptions): Client | null {
   if (isServer || !urqlClient) {
     urqlClient = createClient({
       ...clientOptions,
-      suspense: isServer || clientOptions.suspense,
+      suspense: canEnableSuspense && (isServer || clientOptions.suspense),
     });
     // Serialize the urqlClient to null on the client-side.
     // This ensures we don't share client and server instances of the urqlClient.

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -30,6 +30,10 @@ export function withUrqlClient(
 ) {
   if (!options) options = {};
   return (AppOrPage: NextPage<any> | typeof NextApp) => {
+    const shouldBindGetInitialprops = Boolean(
+      AppOrPage.getInitialProps || options!.ssr
+    );
+
     const withUrql = ({ urqlClient, urqlState, ...rest }: WithUrqlProps) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const client = React.useMemo(() => {
@@ -52,7 +56,7 @@ export function withUrqlClient(
         }
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return initUrqlClient(clientConfig)!;
+        return initUrqlClient(clientConfig, shouldBindGetInitialprops)!;
       }, [urqlClient, urqlState]);
 
       return (
@@ -65,7 +69,7 @@ export function withUrqlClient(
     // Set the displayName to indicate use of withUrqlClient.
     withUrql.displayName = `withUrqlClient(${getDisplayName(AppOrPage)})`;
 
-    if (AppOrPage.getInitialProps || options!.ssr) {
+    if (shouldBindGetInitialprops) {
       withUrql.getInitialProps = async (appOrPageCtx: NextUrqlContext) => {
         const { AppTree } = appOrPageCtx;
 
@@ -86,7 +90,7 @@ export function withUrqlClient(
             fetchExchange,
           ];
         }
-        const urqlClient = initUrqlClient(clientConfig);
+        const urqlClient = initUrqlClient(clientConfig, true);
 
         if (urqlClient) {
           (ctx as NextUrqlContext).urqlClient = urqlClient;


### PR DESCRIPTION

Fixes: https://github.com/FormidableLabs/urql/issues/883

[New sandbox](https://codesandbox.io/s/next-urql-pokedex-ko54t)
[Generated bundle](https://pkg.csb.dev/FormidableLabs/urql/commit/52ae6e87/next-urql)

## Summary

disable suspense when we aren't binding getInitialProps, enabling thi…s without getInitialProps means we aren't using prepass which results in react-dom/server throwing an error about suspense not being supported server-side

## Set of changes

- disable suspense when we aren't binding getInitialProps
