### PR TITLE
Docfix: import populate from correct library.

### DIFF
--- a/docs/advanced/auto-populate-mutations.md
+++ b/docs/advanced/auto-populate-mutations.md
@@ -29,7 +29,7 @@ client options.
 
 ```ts
 import { createClient, dedupExchange, populateExchange, fetchExchange } from '@urql/core';
-import { populateExchange } from '@urql/exchange-graphcache';
+import { populateExchange } from '@urql/exchange-populate';
 
 const client = createClient({
   // ...


### PR DESCRIPTION
##  Summary

The import line for populate should point to `@urql/exchange-populate`, not `@urql/exchange-graphcache`

## Set of changes

One line documentation fix
