### PR TITLE
Remove duplicate of populateExchange import

### DIFF
--- a/docs/advanced/auto-populate-mutations.md
+++ b/docs/advanced/auto-populate-mutations.md
@@ -28,7 +28,7 @@ Afterwards we can set the `populateExchange` up by adding it to our list of `exc
 client options.
 
 ```ts
-import { createClient, dedupExchange, populateExchange, fetchExchange } from '@urql/core';
+import { createClient, dedupExchange, fetchExchange } from '@urql/core';
 import { populateExchange } from '@urql/exchange-populate';
 
 const client = createClient({


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary
Removes duplicate (and also non existent) import of `populateExchange` from `@urql/core`
<!-- What's the motivation of this change? What does it solve? -->

## Set of changes
Changed file  `docs/advanced/auto-populate-mutations.md`
<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
