### PR TITLE
(graphcache) - add special case for fetching an introspection result in graphcache

### DIFF
--- a/.changeset/afraid-dragons-train.md
+++ b/.changeset/afraid-dragons-train.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Add special-case for fetching an introspection result in our schema-checking, this avoids an error when urql-devtools fetches the backend graphql schema.

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -22,6 +22,7 @@ export const isFieldNullable = (
   typename: string,
   fieldName: string
 ): boolean => {
+  if (fieldName === '__schema') return true;
   const field = getField(schema, typename, fieldName);
   return !!field && isNullableType(field.type);
 };
@@ -42,6 +43,7 @@ export const isFieldAvailableOnType = (
   typename: string,
   fieldName: string
 ): boolean => {
+  if (fieldName === '__schema') return true;
   return !!getField(schema, typename, fieldName);
 };
 

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -6,6 +6,7 @@ import { write, writeOptimistic } from '../operations/write';
 import * as InMemoryData from './data';
 import { Store } from './store';
 import { noop } from '../test-utils/utils';
+import { getIntrospectionQuery, parse } from 'graphql';
 
 const Appointment = gql`
   query appointment($id: String) {
@@ -385,10 +386,9 @@ describe('Store with OptimisticMutationConfig', () => {
       {
         query: connection,
       },
-      // @ts-ignore
       {
         exercisesConnection: null,
-      }
+      } as any
     );
     let { data } = query(store, { query: connection });
 
@@ -802,5 +802,14 @@ describe('Store with storage', () => {
       'Invalid optimistic mutation field: `deleteTodo` is not a mutation field in the defined schema, but the `optimistic` option is referencing it.'
     );
     expect(warnMessage).toContain('https://bit.ly/2XbVrpR#24');
+  });
+
+  it('should not warn for an introspection result root', function () {
+    // eslint-disable-next-line
+    const schema = require('../test-utils/simple_schema.json');
+    const store = new Store({ schema });
+
+    query(store, { query: parse(getIntrospectionQuery()) }, schema);
+    expect(console.warn).toBeCalledTimes(0);
   });
 });


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Fixes: https://github.com/FormidableLabs/urql/issues/889

This adds a special case to our schemaPredicates to ignore the `__schema` field

## Set of changes

- ads a special case to our schemaPredicates to ignore the `__schema` field
