### PR TITLE
(next-urql) - Pass resetUrqlClient method to App/Page

### DIFF
--- a/.changeset/rotten-pandas-obey.md
+++ b/.changeset/rotten-pandas-obey.md
@@ -1,0 +1,5 @@
+---
+'next-urql': minor
+---
+
+Add the option to reset the client on a next-urql application.

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -246,5 +246,5 @@ server-side rendering. This can be explicitly enabled by passing the `{ ssr: tru
 In rare scenario's you possibly will have to reset the client instance (reset all cache, ...), this is an uncommon scenario
 and we consider it "unsafe" so evaluate this carefully for yourself.
 
-When this does seem like the appropriate solution any component wrapped with `withUrqlClient` will receive the `resetClient`
+When this does seem like the appropriate solution any component wrapped with `withUrqlClient` will receive the `resetUrqlClient`
 property, when invoked this will create a new top-level client and reset all prior operations.

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -240,3 +240,11 @@ export default withUrqlClient(ssrExchange => ({
 
 Unless the component that is being wrapped already has a `getInitialProps` method, `next-urql` won't add its own SSR logic, which automatically fetches queries during
 server-side rendering. This can be explicitly enabled by passing the `{ ssr: true }` option as a second argument to `withUrqlClient`.
+
+### Resetting the client instance
+
+In rare scenario's you possibly will have to reset the client instance (reset all cache, ...), this is an uncommon scenario
+and we consider it "unsafe" so evaluate this carefully for yourself.
+
+When this does seem like the appropriate solution any component wrapped with `withUrqlClient` will receive the `resetClient`
+property, when invoked this will create a new top-level client and reset all prior operations.

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -126,7 +126,7 @@ In client-side SPAs using `urql`, you typically configure the Client yourself an
 In rare scenario's you possibly will have to reset the client instance (reset all cache, ...), this is an uncommon scenario
 and we consider it "unsafe" so evaluate this carefully for yourself.
 
-When this does seem like the appropriate solution any component wrapped with `withUrqlClient` will receive the `resetClient`
+When this does seem like the appropriate solution any component wrapped with `withUrqlClient` will receive the `resetUrqlClient`
 property, when invoked this will create a new top-level client and reset all prior operations.
 
 #### `exchanges`

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -121,6 +121,14 @@ withUrqlClient((_ssrExchange, ctx) => ({
 
 In client-side SPAs using `urql`, you typically configure the Client yourself and pass it as the `value` prop to `urql`'s context `Provider`. `withUrqlClient` handles setting all of this up for you under the hood. By default, you'll be opted into server-side `Suspense` and have the necessary `exchanges` set up for you, including the [`ssrExchange`](https://formidable.com/open-source/urql/docs/api/#ssrexchange-exchange-factory). If you need to customize your exchanges beyond the defaults `next-urql` provides, use the second argument to `withUrqlClient`, `mergeExchanges`.
 
+### Resetting the client instance
+
+In rare scenario's you possibly will have to reset the client instance (reset all cache, ...), this is an uncommon scenario
+and we consider it "unsafe" so evaluate this carefully for yourself.
+
+When this does seem like the appropriate solution any component wrapped with `withUrqlClient` will receive the `resetClient`
+property, when invoked this will create a new top-level client and reset all prior operations.
+
 #### `exchanges`
 
 When you're using `withUrqlClient` and you don't return an `exchanges` property we'll assume you wanted the default exchanges, these contain: `dedupExchange`, `cacheExchange`, `ssrExchange` (the one you received as a first argument) and the `fetchExchange`.

--- a/packages/next-urql/src/init-urql-client.ts
+++ b/packages/next-urql/src/init-urql-client.ts
@@ -3,6 +3,10 @@ import 'isomorphic-unfetch';
 
 let urqlClient: Client | null = null;
 
+export function resetClient() {
+  urqlClient = null;
+}
+
 export function initUrqlClient(
   clientOptions: ClientOptions,
   canEnableSuspense: boolean

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { NextPage, NextPageContext } from 'next';
 import NextApp, { AppContext } from 'next/app';
 import ssrPrepass from 'react-ssr-prepass';
@@ -10,7 +10,7 @@ import {
   fetchExchange,
 } from 'urql';
 
-import { initUrqlClient } from './init-urql-client';
+import { initUrqlClient, resetClient } from './init-urql-client';
 import {
   NextUrqlClientConfig,
   NextUrqlContext,
@@ -36,6 +36,9 @@ export function withUrqlClient(
 
     const withUrql = ({ urqlClient, urqlState, ...rest }: WithUrqlProps) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
+      const forceUpdate = useState(0);
+
+      // eslint-disable-next-line react-hooks/rules-of-hooks
       const client = React.useMemo(() => {
         if (urqlClient) {
           return urqlClient;
@@ -57,11 +60,21 @@ export function withUrqlClient(
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return initUrqlClient(clientConfig, shouldBindGetInitialprops)!;
-      }, [urqlClient, urqlState]);
+      }, [urqlClient, urqlState, forceUpdate[0]]);
+
+      const resetUrqlClient = () => {
+        resetClient();
+        ssr = ssrExchange({ initialState: undefined });
+        forceUpdate[1](forceUpdate[0] + 1);
+      };
 
       return (
         <Provider value={client}>
-          <AppOrPage urqlClient={client} {...rest} />
+          <AppOrPage
+            urqlClient={client}
+            resetUrqlClient={resetUrqlClient}
+            {...rest}
+          />
         </Provider>
       );
     };


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Resolves: https://github.com/FormidableLabs/urql/issues/832

We can rename this to `_dangerous_reset_store` since this resets all the exchange states, ....

## Set of changes

- Add function to invalidate current client instance