### PR TITLE
(exchanges) - implement requestPolicyExchange

### DIFF
--- a/docs/concepts/exchanges.md
+++ b/docs/concepts/exchanges.md
@@ -25,7 +25,8 @@ Other available exchanges:
 - `retryExchange`: Allows operations to be retried
 - `devtoolsExchange`: Provides the ability to use the [urql-devtools](https://github.com/FormidableLabs/urql-devtools)
 - `multipartFetchExchange`: Provides multipart file upload capability
-- `suspenseExchange` (experimental): Allows the use of React Suspense on the client-side with `urql`'s built-in suspense mode
+- `suspenseExchange` (experimental): Allows the use of React Suspense on the client-side with `urql`'s built-in suspense modeµ
+- `requestPolicyExchange`: Automatically upgrades `cache-only` and `cache-first` operations to `cache-and-network` after a given amount of time.
 
 It is also possible to apply custom exchanges to override the default logic.
 

--- a/exchanges/request-policy/CHANGELOG.md
+++ b/exchanges/request-policy/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+**Initial Release**

--- a/exchanges/request-policy/README.md
+++ b/exchanges/request-policy/README.md
@@ -1,6 +1,7 @@
 # @urql/exchange-request-policy (Exchange factory)
 
-`@urql/exchange-request-policy` is an exchange for the [`urql`](../../README.md) GraphQL client that allows operations (queries, mutations, subscriptions) to be retried based on an `options` parameter.
+`@urql/exchange-request-policy` is an exchange for the [`urql`](../../README.md) GraphQL client that will automatically upgrade operation request-policies
+on a time-to-live basis.
 
 ## Quick Start Guide
 
@@ -11,3 +12,26 @@ yarn add @urql/exchange-request-policy
 # or
 npm install --save @urql/exchange-request-policy
 ```
+
+Then add it to your client.
+
+```js
+import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql';
+import { requestPolicyExchange } from '@urql/exchange-request-policy';
+
+const client = createClient({
+  url: 'http://localhost:1234/graphql',
+  exchanges: [
+    dedupExchange,
+    requestPolicyExchange({
+      // The amount of time in ms that has to go by before upgrading, default is 5 minutes
+      ttl: 60 * 1000, // 1 minute.
+    }),
+    cacheExchange,
+    fetchExchange,
+  ],
+});
+```
+
+Now when the exchange sees a `cache-first` operation that hasn't been seen in ttl amount of time it will upgrade
+the `requestPolicy` to `cache-and-network`.

--- a/exchanges/request-policy/README.md
+++ b/exchanges/request-policy/README.md
@@ -1,0 +1,13 @@
+# @urql/exchange-request-policy (Exchange factory)
+
+`@urql/exchange-request-policy` is an exchange for the [`urql`](../../README.md) GraphQL client that allows operations (queries, mutations, subscriptions) to be retried based on an `options` parameter.
+
+## Quick Start Guide
+
+First install `@urql/exchange-request-policy` alongside `urql`:
+
+```sh
+yarn add @urql/exchange-request-policy
+# or
+npm install --save @urql/exchange-request-policy
+```

--- a/exchanges/request-policy/README.md
+++ b/exchanges/request-policy/README.md
@@ -24,8 +24,10 @@ const client = createClient({
   exchanges: [
     dedupExchange,
     requestPolicyExchange({
-      // The amount of time in ms that has to go by before upgrading, default is 5 minutes
+      // The amount of time in ms that has to go by before upgrading, default is 5 minutes.
       ttl: 60 * 1000, // 1 minute.
+      // An optional function that allows you to specify whether an operation should be upgraded.
+      shouldUpgrade: operation => operation.context.requestPolicy !== 'cache-only',
     }),
     cacheExchange,
     fetchExchange,

--- a/exchanges/request-policy/package.json
+++ b/exchanges/request-policy/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@urql/exchange-request-policy",
+  "version": "0.1.0",
+  "description": "An exchange for operation request-policy upgrading in urql",
+  "sideEffects": false,
+  "homepage": "https://formidable.com/open-source/urql/docs/",
+  "bugs": "https://github.com/FormidableLabs/urql/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/urql.git",
+    "directory": "exchanges/request-policy"
+  },
+  "keywords": [
+    "urql",
+    "graphql client",
+    "formidablelabs",
+    "exchanges",
+    "react",
+    "request-policy"
+  ],
+  "main": "dist/urql-exchange-request-policy",
+  "module": "dist/urql-exchange-request-policy.mjs",
+  "types": "dist/types/index.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql-exchange-request-policy.mjs",
+      "require": "./dist/urql-exchange-request-policy.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "README.md",
+    "dist/"
+  ],
+  "scripts": {
+    "test": "jest",
+    "clean": "rimraf dist",
+    "check": "tsc --noEmit",
+    "lint": "eslint --ext=js,jsx,ts,tsx .",
+    "build": "rollup -c ../../scripts/rollup/config.js",
+    "prepare": "node ../../scripts/prepare/index.js",
+    "prepublishOnly": "run-s clean build"
+  },
+  "jest": {
+    "preset": "../../scripts/jest/preset"
+  },
+  "devDependencies": {
+    "graphql": "^15.1.0"
+  },
+  "peerDependencies": {
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+  },
+  "dependencies": {
+    "@urql/core": ">=1.12.0",
+    "wonka": "^4.0.14"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/exchanges/request-policy/src/index.ts
+++ b/exchanges/request-policy/src/index.ts
@@ -1,0 +1,1 @@
+export { requestPolicyExchange } from './requestPolicyExchange';

--- a/exchanges/request-policy/src/requestPolicyExchange.test.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.test.ts
@@ -89,7 +89,7 @@ it(`upgrades to cache-and-network`, done => {
   }, 10);
 });
 
-it(`upgrades to cache-and-network`, done => {
+it(`doesn't upgrade when shouldUpgrade returns false`, done => {
   const response = jest.fn(
     (forwardOp: Operation): OperationResult => {
       return {

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -1,0 +1,44 @@
+import { Operation, Exchange } from '@urql/core';
+import { pipe, map } from 'wonka';
+
+const defaultTTL = 5 * 60 * 1000;
+
+export interface Options {
+  ttl: number;
+}
+
+export const requestPolicyExchange = (options): Exchange => ({ forward }) => {
+  const operations = new Map();
+
+  const TTL = (options || {}).ttl || defaultTTL;
+
+  const processIncomingOperation = (operation: Operation): Operation => {
+    if (
+      operation.context.requestPolicy !== 'cache-first' &&
+      operation.context.requestPolicy !== 'cache-only'
+    )
+      return operation;
+    if (!operations.has(operation.key)) {
+      operations.set(operation.key, new Date());
+      return operation;
+    } else {
+      const lastOccurrence = operations.get(operation.key);
+      const currentTime = new Date().getTime();
+      if (currentTime - lastOccurrence.getTime() > TTL) {
+        operations.set(operation.key, new Date());
+        return {
+          ...operation,
+          context: {
+            ...operation.context,
+            requestPolicy: 'cache-and-network',
+          },
+        };
+      }
+      return operation;
+    }
+  };
+
+  return ops$ => {
+    return forward(pipe(ops$, map(processIncomingOperation)));
+  };
+};

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -4,7 +4,8 @@ import { pipe, map } from 'wonka';
 const defaultTTL = 5 * 60 * 1000;
 
 export interface Options {
-  ttl: number;
+  shouldUpgrade?: (op: Operation) => boolean;
+  ttl?: number;
 }
 
 export const requestPolicyExchange = (options: Options): Exchange => ({
@@ -24,9 +25,13 @@ export const requestPolicyExchange = (options: Options): Exchange => ({
       operations.set(operation.key, new Date());
       return operation;
     }
+
     const lastOccurrence = operations.get(operation.key);
     const currentTime = new Date().getTime();
-    if (currentTime - lastOccurrence.getTime() > TTL) {
+    if (
+      currentTime - lastOccurrence.getTime() > TTL &&
+      (options.shouldUpgrade ? options.shouldUpgrade(operation) : true)
+    ) {
       operations.set(operation.key, new Date());
       return {
         ...operation,

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -7,7 +7,9 @@ export interface Options {
   ttl: number;
 }
 
-export const requestPolicyExchange = (options): Exchange => ({ forward }) => {
+export const requestPolicyExchange = (options: Options): Exchange => ({
+  forward,
+}) => {
   const operations = new Map();
 
   const TTL = (options || {}).ttl || defaultTTL;

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -21,21 +21,21 @@ export const requestPolicyExchange = (options): Exchange => ({ forward }) => {
     if (!operations.has(operation.key)) {
       operations.set(operation.key, new Date());
       return operation;
-    } else {
-      const lastOccurrence = operations.get(operation.key);
-      const currentTime = new Date().getTime();
-      if (currentTime - lastOccurrence.getTime() > TTL) {
-        operations.set(operation.key, new Date());
-        return {
-          ...operation,
-          context: {
-            ...operation.context,
-            requestPolicy: 'cache-and-network',
-          },
-        };
-      }
-      return operation;
     }
+    const lastOccurrence = operations.get(operation.key);
+    const currentTime = new Date().getTime();
+    if (currentTime - lastOccurrence.getTime() > TTL) {
+      operations.set(operation.key, new Date());
+      return {
+        ...operation,
+        context: {
+          ...operation.context,
+          requestPolicy: 'cache-and-network',
+        },
+      };
+    }
+
+    return operation;
   };
 
   return ops$ => {

--- a/exchanges/request-policy/src/retryExchange.test.ts
+++ b/exchanges/request-policy/src/retryExchange.test.ts
@@ -1,0 +1,90 @@
+import gql from 'graphql-tag';
+
+import { pipe, map, makeSubject, publish, tap } from 'wonka';
+
+import {
+  createClient,
+  Operation,
+  OperationResult,
+  ExchangeIO,
+} from '@urql/core';
+import { requestPolicyExchange } from './requestPolicyExchange';
+
+const dispatchDebug = jest.fn();
+
+const mockOptions = {
+  ttl: 5,
+};
+
+const queryOne = gql`
+  {
+    author {
+      id
+      name
+    }
+  }
+`;
+
+const queryOneData = {
+  __typename: 'Query',
+  author: {
+    __typename: 'Author',
+    id: '123',
+    name: 'Author',
+  },
+};
+
+let client, op, ops$, next;
+beforeEach(() => {
+  client = createClient({ url: 'http://0.0.0.0' });
+  op = client.createRequestOperation('query', {
+    key: 1,
+    query: queryOne,
+  });
+
+  ({ source: ops$, next } = makeSubject<Operation>());
+});
+
+it(`upgrades to cache-and-network`, done => {
+  const response = jest.fn(
+    (forwardOp: Operation): OperationResult => {
+      return {
+        operation: forwardOp,
+        data: queryOneData,
+      };
+    }
+  );
+
+  const result = jest.fn();
+  const forward: ExchangeIO = ops$ => {
+    return pipe(ops$, map(response));
+  };
+
+  pipe(
+    requestPolicyExchange(mockOptions)({
+      forward,
+      client,
+      dispatchDebug,
+    })(ops$),
+    tap(result),
+    publish
+  );
+
+  next(op);
+
+  expect(response).toHaveBeenCalledTimes(1);
+  expect(response.mock.calls[0][0].context.requestPolicy).toEqual(
+    'cache-first'
+  );
+  expect(result).toHaveBeenCalledTimes(1);
+
+  setTimeout(() => {
+    next(op);
+    expect(response).toHaveBeenCalledTimes(2);
+    expect(response.mock.calls[1][0].context.requestPolicy).toEqual(
+      'cache-and-network'
+    );
+    expect(result).toHaveBeenCalledTimes(2);
+    done();
+  }, 10);
+});

--- a/exchanges/request-policy/tsconfig.json
+++ b/exchanges/request-policy/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/core/*": ["../../node_modules/@urql/core/src/*"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements an exchange that monitors all incoming operations and checks them vs an internal map, if this operation is `cache-first` or `cache-only` and has exceeded the TTL it will upgrade this operation to a `cache-and-network` policy. This helps us refresh stale data.

The user can specify a custom TTL in ms

## Set of changes

- add new exchange
