### PR TITLE
(exchanges) - implement the focusExchange

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -21,3 +21,4 @@ more about the core package on the "Core Package" page.](../concepts/core-packag
 - [`@urql/exchange-persisted-fetch` API docs](./persisted-fetch-exchange.md)
 - [`@urql/exchange-request-policy` API docs](./request-policy-exchange.md)
 - [`@urql/exchange-auth` API docs](./auth-exchange.md)
+- [`@urql/exchange-refocus` API docs](./refocus-exchange.md)

--- a/docs/api/refocus-exchange.md
+++ b/docs/api/refocus-exchange.md
@@ -5,7 +5,7 @@ order: 10
 
 # Refocus exchange
 
-`@urql/exchange-refocus` is an exchange for the [`urql`](../../README.md) GraphQL client that tracks currently active operations and redispatches them when the
+`@urql/exchange-refocus` is an exchange for the `urql` that tracks currently active operations and redispatches them when the
 window regains focus
 
 ## Quick Start Guide

--- a/docs/api/refocus-exchange.md
+++ b/docs/api/refocus-exchange.md
@@ -1,4 +1,9 @@
-# @urql/exchange-refocus
+---
+title: '@urql/exchange-refocus'
+order: 10
+---
+
+# Refocus exchange
 
 `@urql/exchange-refocus` is an exchange for the [`urql`](../../README.md) GraphQL client that tracks currently active operations and redispatches them when the
 window regains focus

--- a/docs/concepts/exchanges.md
+++ b/docs/concepts/exchanges.md
@@ -32,6 +32,8 @@ Other available exchanges:
 - [`authExchange`](../api/auth-exchange.md): Allows complex authentication flows to be implemented
   easily.
 - [`requestPolicyExchange`](../api/request-policy-exchange.md): Automatically upgrades `cache-only` and `cache-first` operations to `cache-and-network` after a given amount of time.
+- [`refocusExchange`](../api/refocus-exchange.md): Tracks open queries and refetches them
+  when the window regains focus.
 - `devtoolsExchange`: Provides the ability to use the [urql-devtools](https://github.com/FormidableLabs/urql-devtools)
 
 It is also possible to apply custom exchanges to override the default logic.

--- a/exchanges/refocus/CHANGELOG.md
+++ b/exchanges/refocus/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+**Initial Release**

--- a/exchanges/refocus/README.md
+++ b/exchanges/refocus/README.md
@@ -1,0 +1,14 @@
+# @urql/exchange-refocus
+
+`@urql/exchange-retry` is an exchange for the [`urql`](../../README.md) GraphQL client that tracks currently active operations and redispatches them when the
+window regains focus
+
+## Quick Start Guide
+
+First install `@urql/exchange-refocus` alongside `urql`:
+
+```sh
+yarn add @urql/exchange-refocus
+# or
+npm install --save @urql/exchange-refocus
+```

--- a/exchanges/refocus/package.json
+++ b/exchanges/refocus/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@urql/exchange-refocus",
+  "version": "0.1.8",
+  "description": "An exchange for operation retry support in urql",
+  "sideEffects": false,
+  "homepage": "https://formidable.com/open-source/urql/docs/",
+  "bugs": "https://github.com/FormidableLabs/urql/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/urql.git",
+    "directory": "exchanges/retry"
+  },
+  "keywords": [
+    "urql",
+    "graphql client",
+    "formidablelabs",
+    "exchanges",
+    "react",
+    "retry"
+  ],
+  "main": "dist/urql-exchange-retry",
+  "module": "dist/urql-exchange-retry.mjs",
+  "types": "dist/types/index.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql-exchange-retry.mjs",
+      "require": "./dist/urql-exchange-retry.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "README.md",
+    "dist/"
+  ],
+  "scripts": {
+    "test": "jest",
+    "clean": "rimraf dist",
+    "check": "tsc --noEmit",
+    "lint": "eslint --ext=js,jsx,ts,tsx .",
+    "build": "rollup -c ../../scripts/rollup/config.js",
+    "prepare": "node ../../scripts/prepare/index.js",
+    "prepublishOnly": "run-s clean build"
+  },
+  "jest": {
+    "preset": "../../scripts/jest/preset"
+  },
+  "devDependencies": {
+    "@types/react": "^16.9.19",
+    "graphql": "^15.1.0",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0"
+  },
+  "peerDependencies": {
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+  },
+  "dependencies": {
+    "@urql/core": ">=1.12.0",
+    "wonka": "^4.0.14"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/exchanges/refocus/package.json
+++ b/exchanges/refocus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@urql/exchange-refocus",
-  "version": "0.1.8",
-  "description": "An exchange for operation retry support in urql",
+  "version": "0.1.0",
+  "description": "An exchange that dispatches active operations when the window regains focus",
   "sideEffects": false,
   "homepage": "https://formidable.com/open-source/urql/docs/",
   "bugs": "https://github.com/FormidableLabs/urql/issues",
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/FormidableLabs/urql.git",
-    "directory": "exchanges/retry"
+    "directory": "exchanges/refocus"
   },
   "keywords": [
     "urql",
@@ -17,16 +17,16 @@
     "formidablelabs",
     "exchanges",
     "react",
-    "retry"
+    "focus"
   ],
-  "main": "dist/urql-exchange-retry",
-  "module": "dist/urql-exchange-retry.mjs",
+  "main": "dist/urql-exchange-refocus",
+  "module": "dist/urql-exchange-refocus.mjs",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/urql-exchange-retry.mjs",
-      "require": "./dist/urql-exchange-retry.js",
+      "import": "./dist/urql-exchange-refocus.mjs",
+      "require": "./dist/urql-exchange-refocus.js",
       "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     },

--- a/exchanges/refocus/src/index.ts
+++ b/exchanges/refocus/src/index.ts
@@ -1,0 +1,1 @@
+export { refocusExchange } from './refocusExchange';

--- a/exchanges/refocus/src/refocusExchange.test.ts
+++ b/exchanges/refocus/src/refocusExchange.test.ts
@@ -1,0 +1,92 @@
+import gql from 'graphql-tag';
+
+import { pipe, map, makeSubject, publish, tap } from 'wonka';
+
+import {
+  createClient,
+  Operation,
+  OperationResult,
+  ExchangeIO,
+} from '@urql/core';
+import { refocusExchange } from './refocusExchange';
+
+const dispatchDebug = jest.fn();
+
+const queryOne = gql`
+  {
+    author {
+      id
+      name
+    }
+  }
+`;
+
+const queryOneData = {
+  __typename: 'Query',
+  author: {
+    __typename: 'Author',
+    id: '123',
+    name: 'Author',
+  },
+};
+
+let client, op, ops$, next;
+beforeEach(() => {
+  client = createClient({ url: 'http://0.0.0.0' });
+  op = client.createRequestOperation('query', {
+    key: 1,
+    query: queryOne,
+  });
+
+  ({ source: ops$, next } = makeSubject<Operation>());
+});
+
+it(`attaches a listener and redispatches queries on call`, () => {
+  const response = jest.fn(
+    (forwardOp: Operation): OperationResult => {
+      return {
+        operation: forwardOp,
+        data: queryOneData,
+      };
+    }
+  );
+
+  let listener;
+  const spy = jest
+    .spyOn(window, 'addEventListener')
+    .mockImplementation((_keyword, fn) => {
+      listener = fn;
+    });
+  const reexecuteSpy = jest
+    .spyOn(client, 'reexecuteOperation')
+    .mockImplementation(() => ({}));
+
+  const result = jest.fn();
+  const forward: ExchangeIO = ops$ => {
+    return pipe(ops$, map(response));
+  };
+
+  pipe(
+    refocusExchange()({
+      forward,
+      client,
+      dispatchDebug,
+    })(ops$),
+    tap(result),
+    publish
+  );
+
+  expect(spy).toBeCalledTimes(1);
+  expect(spy).toBeCalledWith('focus', expect.anything());
+
+  next(op);
+
+  listener();
+  expect(reexecuteSpy).toBeCalledTimes(1);
+  expect(reexecuteSpy).toBeCalledWith({
+    context: expect.anything(),
+    key: 1,
+    query: queryOne,
+    operationName: 'query',
+  });
+});

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -1,0 +1,50 @@
+import { pipe, tap } from 'wonka';
+import { Exchange, Operation } from '@urql/core';
+
+export const refocusExchange = (): Exchange => {
+  return ({ client, forward }) => ops$ => {
+    const watchedOperations = new Map<number, Operation>();
+    const observedOperations = new Map<number, number>();
+    const keys: Array<number> = [];
+
+    window.addEventListener('focus', () => {
+      keys.forEach(key => {
+        const op = watchedOperations.get(key) as Operation;
+        client.reexecuteOperation(
+          client.createRequestOperation(
+            'query',
+            { key: op.key, query: op.query, variables: op.variables },
+            { requestPolicy: 'cache-and-network' }
+          )
+        );
+      });
+    });
+
+    const processIncomingOperation = (op: Operation) => {
+      if (op.operationName !== 'query' && op.operationName !== 'teardown')
+        return;
+
+      if (op.operationName === 'query' && !observedOperations.has(op.key)) {
+        observedOperations.set(op.key, 1);
+        watchedOperations.set(op.key, op);
+        keys.push(op.key);
+      } else if (op.operationName === 'query') {
+        const observedCount = observedOperations.get(op.key) as number;
+        observedOperations.set(op.key, observedCount + 1);
+      }
+
+      if (op.operationName === 'teardown' && observedOperations.has(op.key)) {
+        const observedCount = observedOperations.get(op.key) as number;
+        if (observedCount === 1) {
+          observedOperations.delete(op.key);
+          watchedOperations.delete(op.key);
+          keys.splice(keys.indexOf(op.key), 1);
+        } else {
+          observedOperations.set(op.key, observedCount - 1);
+        }
+      }
+    };
+
+    return forward(pipe(ops$, tap(processIncomingOperation)));
+  };
+};

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -9,11 +9,9 @@ export const refocusExchange = (): Exchange => {
     window.addEventListener('focus', () => {
       watchedOperations.forEach(op => {
         client.reexecuteOperation(
-          client.createRequestOperation(
-            'query',
-            { key: op.key, query: op.query, variables: op.variables },
-            { requestPolicy: 'cache-and-network' }
-          )
+          client.createRequestOperation('query', op, {
+            requestPolicy: 'cache-and-network',
+          })
         );
       });
     });

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -35,13 +35,9 @@ export const refocusExchange = (): Exchange => {
 
       if (op.operationName === 'teardown' && observedOperations.has(op.key)) {
         const observedCount = observedOperations.get(op.key) as number;
-        if (observedCount === 1) {
-          observedOperations.delete(op.key);
-          watchedOperations.delete(op.key);
-          keys.splice(keys.indexOf(op.key), 1);
-        } else {
-          observedOperations.set(op.key, observedCount - 1);
-        }
+        observedOperations.delete(op.key);
+        watchedOperations.delete(op.key);
+        keys.splice(keys.indexOf(op.key), 1);
       }
     };
 

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -5,11 +5,9 @@ export const refocusExchange = (): Exchange => {
   return ({ client, forward }) => ops$ => {
     const watchedOperations = new Map<number, Operation>();
     const observedOperations = new Map<number, number>();
-    const keys: Array<number> = [];
 
     window.addEventListener('focus', () => {
-      keys.forEach(key => {
-        const op = watchedOperations.get(key) as Operation;
+      watchedOperations.forEach(op => {
         client.reexecuteOperation(
           client.createRequestOperation(
             'query',
@@ -27,17 +25,13 @@ export const refocusExchange = (): Exchange => {
       if (op.operationName === 'query' && !observedOperations.has(op.key)) {
         observedOperations.set(op.key, 1);
         watchedOperations.set(op.key, op);
-        keys.push(op.key);
       } else if (op.operationName === 'query') {
-        const observedCount = observedOperations.get(op.key) as number;
-        observedOperations.set(op.key, observedCount + 1);
+        observedOperations.set(op.key, observedOperations.get(op.key) + 1);
       }
 
       if (op.operationName === 'teardown' && observedOperations.has(op.key)) {
-        const observedCount = observedOperations.get(op.key) as number;
         observedOperations.delete(op.key);
         watchedOperations.delete(op.key);
-        keys.splice(keys.indexOf(op.key), 1);
       }
     };
 

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -25,8 +25,6 @@ export const refocusExchange = (): Exchange => {
       if (op.operationName === 'query' && !observedOperations.has(op.key)) {
         observedOperations.set(op.key, 1);
         watchedOperations.set(op.key, op);
-      } else if (op.operationName === 'query') {
-        observedOperations.set(op.key, observedOperations.get(op.key) + 1);
       }
 
       if (op.operationName === 'teardown' && observedOperations.has(op.key)) {

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -19,9 +19,6 @@ export const refocusExchange = (): Exchange => {
     });
 
     const processIncomingOperation = (op: Operation) => {
-      if (op.operationName !== 'query' && op.operationName !== 'teardown')
-        return;
-
       if (op.operationName === 'query' && !observedOperations.has(op.key)) {
         observedOperations.set(op.key, 1);
         watchedOperations.set(op.key, op);

--- a/exchanges/refocus/tsconfig.json
+++ b/exchanges/refocus/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/core/*": ["../../node_modules/@urql/core/src/*"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}


### PR DESCRIPTION
This exchange is meant to avoid stale queries, everytime the window reenters focus the currently active queries will be refetched with a `cache-and-network` policy.

TODO:
- tests
- docs