### PR TITLE
(react-hooks) prefer exported function instead of block-scoped variable

### DIFF
--- a/.changeset/six-shoes-kneel.md
+++ b/.changeset/six-shoes-kneel.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+prefer exported function instead of block-scoped variable

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -28,9 +28,9 @@ export type UseMutationResponse<T, V> = [
   ) => Promise<OperationResult<T>>
 ];
 
-export const useMutation = <T = any, V = object>(
+export function useMutation<T = any, V = object>(
   query: DocumentNode | string
-): UseMutationResponse<T, V> => {
+): UseMutationResponse<T, V> {
   const isMounted = useRef(true);
   const client = useClient();
 
@@ -69,4 +69,4 @@ export const useMutation = <T = any, V = object>(
   }, []);
 
   return [state, executeMutation];
-};
+}

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -30,9 +30,9 @@ export type UseQueryResponse<T> = [
   (opts?: Partial<OperationContext>) => void
 ];
 
-export const useQuery = <T = any, V = object>(
+export function useQuery<T = any, V = object>(
   args: UseQueryArgs<V>
-): UseQueryResponse<T> => {
+): UseQueryResponse<T> {
   const client = useClient();
 
   // This creates a request which will keep a stable reference
@@ -100,4 +100,4 @@ export const useQuery = <T = any, V = object>(
   );
 
   return [state, executeQuery];
-};
+}

--- a/packages/react-urql/src/hooks/useRequest.ts
+++ b/packages/react-urql/src/hooks/useRequest.ts
@@ -3,10 +3,10 @@ import { useRef, useMemo } from 'react';
 import { GraphQLRequest, createRequest } from '@urql/core';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
-export const useRequest = (
+export function useRequest(
   query: string | DocumentNode,
   variables?: any
-): GraphQLRequest => {
+): GraphQLRequest {
   const prev = useRef<undefined | GraphQLRequest>(undefined);
 
   return useMemo(() => {
@@ -19,4 +19,4 @@ export const useRequest = (
       return request;
     }
   }, [query, variables]);
-};
+}

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -18,7 +18,7 @@ import { useClient } from '../context';
 
 let currentInit = false;
 
-export const useSource = <T>(source: Source<T>, init: T): T => {
+export function useSource<T>(source: Source<T>, init: T): T {
   const isMounted = useRef(true);
 
   const [state, setState] = useState(() => {
@@ -55,9 +55,9 @@ export const useSource = <T>(source: Source<T>, init: T): T => {
   }, [source]);
 
   return state;
-};
+}
 
-export const useBehaviourSubject = <T>(value: T) => {
+export function useBehaviourSubject<T>(value: T) {
   const client = useClient();
 
   const state = useMemo((): [Source<T>, (value: T) => void] => {
@@ -93,4 +93,4 @@ export const useBehaviourSubject = <T>(value: T) => {
   if (client.suspense) state[1](value);
 
   return state;
-};
+}

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -30,10 +30,10 @@ export type UseSubscriptionResponse<T> = [
   (opts?: Partial<OperationContext>) => void
 ];
 
-export const useSubscription = <T = any, R = T, V = object>(
+export function useSubscription<T = any, R = T, V = object>(
   args: UseSubscriptionArgs<V>,
   handler?: SubscriptionHandler<T, R>
-): UseSubscriptionResponse<R> => {
+): UseSubscriptionResponse<R> {
   const client = useClient();
 
   // Update handler on constant ref, since handler changes shouldn't
@@ -108,4 +108,4 @@ export const useSubscription = <T = any, R = T, V = object>(
   );
 
   return [state, executeSubscription];
-};
+}


### PR DESCRIPTION
## Summary

This PR changes the definition of React Hooks to use `export function` instead of `export const`. It's a simple change that allow developers later to interact better with the signature of the hooks.

In TS, these `const` are defined as block-scoped variables, and cannot be overwritten/redefined/overloaded by external TS libraries or consumers. 

You can see a [real-time example for that here](https://www.typescriptlang.org/play/?ssl=1&ssc=1&pln=12&pc=2#code/CYUwxgNghgTiAEBbA9sArhBByALiAzjlvAN4CwAUPNfAPS3wgAeADsjDvAGZoB2YOAJbJe8AO7sA1vko1Grdpx78hIpAE8AYnzAAKFrCiIAXPEIxBvAOYBKU+ctWA3JVk168th3hgRheMDIBLy44lJu1MxenL68-ojqAGqwpvqGJmY4FtY28AC8AHyZ2c6UAL6uFKCQsAgo6JjwuAREpBGeitw6qqIJ2vxpMEamvGiIAEYgMHbwoxNTLlQ0UZ2x8Ukp8IPDs2OT0-lFc-uLZUA)  , and it's [also reported as issue](https://github.com/microsoft/TypeScript/issues/39622) 

I'm working on a new plugin for https://github.com/dotansimha/graphql-code-generator , and I would like to extend `urql` behaviour with module augmentation - but at the moment it's not possible because of the way the hooks are defined.

## Set of changes

Changed `export const` to be `export function` in all React Hooks.
