### PR TITLE
(core) - Strip whitespace from query for GET requests

### DIFF
--- a/.changeset/pretty-squids-learn.md
+++ b/.changeset/pretty-squids-learn.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Remove redundant whitespaces when using GET for graphql queries.

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -49,7 +49,9 @@ export const makeFetchURL = (
   }
 
   if (body.query) {
-    search.push('query=' + encodeURIComponent(body.query));
+    search.push(
+      'query=' + encodeURIComponent(body.query.replace(/[\s,]+/g, ' ').trim())
+    );
   }
 
   if (body.variables) {

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -50,7 +50,10 @@ export const makeFetchURL = (
 
   if (body.query) {
     search.push(
-      'query=' + encodeURIComponent(body.query.replace(/[\s,]+/g, ' ').trim())
+      'query=' +
+        encodeURIComponent(
+          body.query.replace(/([\s,]|#[^\n\r]+)+/g, ' ').trim()
+        )
     );
   }
 


### PR DESCRIPTION
## Summary

Strips redundant whitespaces when using `GET`

This solves the case where the user provides their own queries, ....

Fixes: https://github.com/FormidableLabs/urql/issues/907

## Set of changes

- Strips redundant whitespaces when using `GET`
