### PR TITLE
(core) - Shorten queries for hashing

### DIFF
--- a/.changeset/hip-adults-look.md
+++ b/.changeset/hip-adults-look.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Remove whitespace and comments from string-queries

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -73,3 +73,17 @@ it('should return a valid query object with variables', () => {
     variables: { test: 5 },
   });
 });
+
+it('should remove comments', () => {
+  const doc = `
+    {
+      # broken
+      test
+    }
+  `;
+  const val = createRequest(doc);
+  expect(print(val.query)).toBe(`{
+  test
+}
+`);
+});

--- a/packages/core/src/utils/request.test.ts
+++ b/packages/core/src/utils/request.test.ts
@@ -76,7 +76,7 @@ it('should return a valid query object with variables', () => {
 
 it('should remove comments', () => {
   const doc = `
-    {
+    { #query
       # broken
       test
     }

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -7,7 +7,8 @@ interface Documents {
   [key: number]: DocumentNode;
 }
 
-const hashQuery = (q: string): number => hash(q.replace(/[\s,]+/g, ' ').trim());
+const hashQuery = (q: string): number =>
+  hash(q.replace(/([\s,]|#[^\n\r]+)+/g, ' ').trim());
 
 const docs: Documents = Object.create(null);
 

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -20,7 +20,8 @@ export const createRequest = (
   let query: DocumentNode;
   if (typeof q === 'string') {
     key = hashQuery(q);
-    query = docs[key] !== undefined ? docs[key] : parse(q);
+    query =
+      docs[key] !== undefined ? docs[key] : parse(q, { noLocation: true });
   } else if ((q as any).__key !== undefined) {
     key = (q as any).__key;
     query = q;


### PR DESCRIPTION
## Summary

This shortens the querystring by removing whitespaces and comments when a request is created with an unparsed query.

