### PR TITLE
(graphcache) - Mute warnings when using built-in fields

### DIFF
--- a/.changeset/chatty-poems-rescue.md
+++ b/.changeset/chatty-poems-rescue.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Mute warning when using built-in GraphQL fields, like `__type`

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -17,12 +17,14 @@ import {
   OptimisticMutationConfig,
 } from '../types';
 
+const BUILTIN_FIELD_RE = /^__/;
+
 export const isFieldNullable = (
   schema: GraphQLSchema,
   typename: string,
   fieldName: string
 ): boolean => {
-  if (fieldName === '__schema') return true;
+  if (BUILTIN_FIELD_RE.test(fieldName)) return true;
   const field = getField(schema, typename, fieldName);
   return !!field && isNullableType(field.type);
 };
@@ -43,7 +45,7 @@ export const isFieldAvailableOnType = (
   typename: string,
   fieldName: string
 ): boolean => {
-  if (fieldName === '__schema') return true;
+  if (BUILTIN_FIELD_RE.test(fieldName)) return true;
   return !!getField(schema, typename, fieldName);
 };
 


### PR DESCRIPTION
See: https://spectrum.chat/urql/help/is-there-a-way-to-access-cache-directly~40669292-345e-4c02-b5ca-64c95f776762?m=MTU5NTIzMDA5MDQ0Ng==