### PR TITLE
(persisted-fetch) - Don't send persisted queries if the hash operation fails

### DIFF
--- a/.changeset/wet-cows-melt.md
+++ b/.changeset/wet-cows-melt.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted-fetch': patch
+---
+
+Stops sending a persisted query if the hashing function fails

--- a/exchanges/persisted-fetch/src/persistedFetchExchange.ts
+++ b/exchanges/persisted-fetch/src/persistedFetchExchange.ts
@@ -71,7 +71,7 @@ export const persistedFetchExchange = (
           // Hash the given GraphQL query
           fromPromise(hashFn(query, operation.query)),
           mergeMap(sha256Hash => {
-            // if the hashing operation was successful, add the persisted query exception
+            // if the hashing operation was successful, add the persisted query extension
             if (sha256Hash) {
               // Attach SHA256 hash and remove query from body
               body.query = undefined;

--- a/exchanges/persisted-fetch/src/persistedFetchExchange.ts
+++ b/exchanges/persisted-fetch/src/persistedFetchExchange.ts
@@ -81,22 +81,16 @@ export const persistedFetchExchange = (
                   sha256Hash,
                 },
               };
-
-              return makePersistedFetchSource(
-                operation,
-                body,
-                dispatchDebug,
-                !!(options as PersistedFetchExchangeOptions)
-                  .preferGetForPersistedQueries
-              );
-            } else {
-              return makePersistedFetchSource(
-                operation,
-                body,
-                dispatchDebug,
-                false
-              );
             }
+            return makePersistedFetchSource(
+              operation,
+              body,
+              dispatchDebug,
+              !!(
+                (options as PersistedFetchExchangeOptions)
+                  .preferGetForPersistedQueries && sha256Hash
+              )
+            );
           }),
           mergeMap(result => {
             if (result.error && isPersistedUnsupported(result.error)) {


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

In insecure browser environments, the `window.crypto.subtle` api isn't available. The default hashing function in the persisted query exchange will resolve an empty string in this case, and send that empty string as the persisted query, which leads to a `PersistedQueryNotFound` exception. This is fine, because the exchange will follow up with non-persisted query, but we can improve the default behavior by not sending a persisted query at all if the hash fails.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

Updates the persisted query exchange to only send a persisted query if there's a non-falsey hash value. Let me know if there's a better way of implementing this with Wonka!