### PR TITLE
(exchanges) implement auth exchange

### DIFF
--- a/exchanges/auth/CHANGELOG.md
+++ b/exchanges/auth/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.0.1
+
+**Initial Release**

--- a/exchanges/auth/CHANGELOG.md
+++ b/exchanges/auth/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## v0.0.1
+## v0.1.0
 
 **Initial Release**

--- a/exchanges/auth/README.md
+++ b/exchanges/auth/README.md
@@ -14,81 +14,148 @@ yarn add @urql/exchange-auth
 npm install --save @urql/exchange-auth
 ```
 
-You'll then need to add the `authExchange`, that this package exposes, (and `errorExchange`) to your `urql` Client
+You'll then need to add the `authExchange`, that this package exposes to your `urql` Client
 
 ```js
-import { createClient, dedupExchange, cacheExchange, errorExchange } from 'urql';
+import { createClient, dedupExchange, cacheExchange, Operation } from 'urql';
 import { executeExchange } from '@urql/exchange-execute';
+
+/**
+ * your auth state can be anything
+ * this is a generic example with a token and refreshToken, but it can
+ * include token expiry for example if you want to check that in willAuthError
+ * without having to decode the token every time
+ **/
+
+type AuthState = {
+  token: String;
+  refreshToken: String;
+} | null;
 
 const client = createClient({
   url: 'http://localhost:1234/graphql',
   exchanges: [
     dedupExchange,
     cacheExchange,
-    errorExchange({
-      onError: ({ error }) => {
-        // We only get an auth error here when the auth excahnge had attempted to refresh auth and getting an auth error again for the second time
-        const isAuthError = error.graphQLErrors.some(
-          e => e.extensions?.code === "FORBIDDEN",
-        );
-
-        if (isAuthError) {
-          // log the user out
-        }
-      }
-    }),
     authExchange({
-      addAuthToOperation: ({ authState, operation }) => {
-        const token = authState?.token;
-        const authHeader = {
-          Authorization: token || "",
-        };
+        addAuthToOperation: ({
+          authState,
+          operation,
+        }: {
+          authState: AuthState;
+          operation: Operation;
+        }): Operation => {
+          // the token isn't in the auth state, return the operation without changes
+          if (!authState || !authState.token) {
+            return operation;
+          }
 
-        const fetchOptions =
-          typeof operation.context.fetchOptions === "function"
-            ? operation.context.fetchOptions()
-            : operation.context.fetchOptions || {};
+          const { token } = authState;
 
-        return {
-          ...operation,
-          context: {
-            ...operation.context,
-            fetchOptions: {
-              ...fetchOptions,
-              headers: {
-                ...fetchOptions.headers,
-                ...authHeader,
+          const authHeader = {
+            Authorization: token,
+          };
+
+          const fetchOptions =
+            typeof operation.context.fetchOptions === 'function'
+              ? operation.context.fetchOptions()
+              : operation.context.fetchOptions || {};
+
+          return {
+            ...operation,
+            context: {
+              ...operation.context,
+              fetchOptions: {
+                ...fetchOptions,
+                headers: {
+                  ...fetchOptions.headers,
+                  ...authHeader,
+                },
               },
             },
-          },
-        };
-      },
-      willAuthError: ({ operation, authState }) => {
-        if (!authState) return true;
-        // e.g. check for expiration, existence of auth etc
-        return false;
-      },
-      didAuthError: ({ error, authState }) => {
-        // check if the error was an auth error (this can be implemented in various ways, e.g. 401 or a speciall error code)
-        return error.graphQLErrors.some(
-          e => e.extensions?.code === "FORBIDDEN",
-        );
-      },
-      getAuth: async ({ authState }) => {
-        // for initial launch, fetch the auth state from storage (local storage, async storage etx)
-        if (!authState) {
-          const token = await SInfo.getItem(TOKEN_KEY, {});
-          const refreshToken = await SInfo.getItem(REFRESH_TOKEN_KEY, {});
-          return { token, refreshToken };
-        }
+          };
+        },
+        willAuthError: ({ authState }) => {
+          if (!authState) return true;
+          // e.g. check for expiration, existence of auth etc
+          return false;
+        },
+        didAuthError: ({ error }) => {
+          // check if the error was an auth error (this can be implemented in various ways, e.g. 401 or a special error code)
+          return error.graphQLErrors.some(
+            e => e.extensions?.code === 'FORBIDDEN',
+          );
+        },
+        getAuth: async ({ authState, mutate }) => {
+          // for initial launch, fetch the auth state from storage (local storage, async storage etc)
+          if (!authState) {
+            const token = localStorage.getItem('token');
+            const refreshToken = localStorage.getItem('refreshToken');
+            if (token && refreshToken) {
+              return { token, refreshToken };
+            }
+            return null;
+          }
 
-        // otherwise fetch the new auth state async, e.g. from an api using a refresh token
-        return { token: "new-token", refreshToken: "new-refresh" };
-      },
-    }),
+          /**
+           * the following code gets exetuted when an auth error has occurred
+           * we should refresh the token if possible and return a new auth state
+           * If refrsh fails, we should log out
+           **/
+
+          // if your refresh logic is in graphQL, you must use this mutate function to call it
+          // if your refresh logic is a separate RESTful endpoint, use fetch or similar
+          const result = await mutate(refreshMutation, {
+            token: authState!.refreshToken,
+          });
+
+          if (result.data?.refreshLogin) {
+            // save the new tokens in storage for next restart
+            localStorage.setItem('token', result.data.refreshLogin.token);
+            localStorage.setItem('refreshToken', result.data.refreshLogin.refreshToken);
+
+            // return the new tokens
+            return {
+              token: result.data.refreshLogin.token,
+              refreshToken: result.data.refreshLogin.refreshToken,
+            };
+          }
+
+          // otherwise, if refresh fails, log clear storage and log out
+          localStorage.clear();
+
+          // your app logout logic should trigger here
+          logout();
+
+          return null;
+        },
+      }),
     fetchExchange
   ],
 });
+```
+
+## Handling rrrors via the errorExchange
+
+Handling the logout logic in `getAuth` is the easiest way to get started, but it means the errors will always get swallowed by the `authExchange`.
+If you want to handle errors globally, this can be done using the `errorExchange`:
+
+```js
+import { errorExchange } from 'urql';
+
+// this needs to be placed ABOVE the authExchange in the exchanges array, otherwise the auth error will show up hear before the auth exchange has had the chance to handle it
+errorExchange({
+  onError: ({ error }) => {
+    // we only get an auth error here when the auth excahnge had attempted to refresh auth and getting an auth error again for the second time
+    const isAuthError = error.graphQLErrors.some(
+      e => e.extensions?.code === 'FORBIDDEN',
+    );
+
+    if (isAuthError) {
+      // clear storage, log the user out etc
+    }
+  }
+}),
 ```
 
 ## Maintenance Status

--- a/exchanges/auth/README.md
+++ b/exchanges/auth/README.md
@@ -18,19 +18,7 @@ You'll then need to add the `authExchange`, that this package exposes to your `u
 
 ```js
 import { createClient, dedupExchange, cacheExchange, Operation } from 'urql';
-import { executeExchange } from '@urql/exchange-execute';
-
-/**
- * your auth state can be anything
- * this is a generic example with a token and refreshToken, but it can
- * include token expiry for example if you want to check that in willAuthError
- * without having to decode the token every time
- **/
-
-type AuthState = {
-  token: String;
-  refreshToken: String;
-} | null;
+import { authExchange } from '@urql/exchange-auth';
 
 const client = createClient({
   url: 'http://localhost:1234/graphql',
@@ -38,104 +26,96 @@ const client = createClient({
     dedupExchange,
     cacheExchange,
     authExchange({
-        addAuthToOperation: ({
-          authState,
-          operation,
-        }: {
-          authState: AuthState;
-          operation: Operation;
-        }): Operation => {
-          // the token isn't in the auth state, return the operation without changes
-          if (!authState || !authState.token) {
-            return operation;
-          }
+      addAuthToOperation: ({
+        authState,
+        operation,
+      }) => {
+        // the token isn't in the auth state, return the operation without changes
+        if (!authState || !authState.token) {
+          return operation;
+        }
 
-          const { token } = authState;
+        // fetchOptions can be a function (See Client API) but you can simplify this based on usage
+        const fetchOptions =
+          typeof operation.context.fetchOptions === 'function'
+            ? operation.context.fetchOptions()
+            : operation.context.fetchOptions || {};
 
-          const authHeader = {
-            Authorization: token,
-          };
-
-          const fetchOptions =
-            typeof operation.context.fetchOptions === 'function'
-              ? operation.context.fetchOptions()
-              : operation.context.fetchOptions || {};
-
-          return {
-            ...operation,
-            context: {
-              ...operation.context,
-              fetchOptions: {
-                ...fetchOptions,
-                headers: {
-                  ...fetchOptions.headers,
-                  ...authHeader,
-                },
+        return {
+          ...operation,
+          context: {
+            ...operation.context,
+            fetchOptions: {
+              ...fetchOptions,
+              headers: {
+                ...fetchOptions.headers,
+                "Authorization": authState.token,
               },
             },
-          };
-        },
-        willAuthError: ({ authState }) => {
-          if (!authState) return true;
-          // e.g. check for expiration, existence of auth etc
-          return false;
-        },
-        didAuthError: ({ error }) => {
-          // check if the error was an auth error (this can be implemented in various ways, e.g. 401 or a special error code)
-          return error.graphQLErrors.some(
-            e => e.extensions?.code === 'FORBIDDEN',
-          );
-        },
-        getAuth: async ({ authState, mutate }) => {
-          // for initial launch, fetch the auth state from storage (local storage, async storage etc)
-          if (!authState) {
-            const token = localStorage.getItem('token');
-            const refreshToken = localStorage.getItem('refreshToken');
-            if (token && refreshToken) {
-              return { token, refreshToken };
-            }
-            return null;
+          },
+        };
+      },
+      willAuthError: ({ authState }) => {
+        if (!authState) return true;
+        // e.g. check for expiration, existence of auth etc
+        return false;
+      },
+      didAuthError: ({ error }) => {
+        // check if the error was an auth error (this can be implemented in various ways, e.g. 401 or a special error code)
+        return error.graphQLErrors.some(
+          e => e.extensions?.code === 'FORBIDDEN',
+        );
+      },
+      getAuth: async ({ authState, mutate }) => {
+        // for initial launch, fetch the auth state from storage (local storage, async storage etc)
+        if (!authState) {
+          const token = localStorage.getItem('token');
+          const refreshToken = localStorage.getItem('refreshToken');
+          if (token && refreshToken) {
+            return { token, refreshToken };
           }
-
-          /**
-           * the following code gets exetuted when an auth error has occurred
-           * we should refresh the token if possible and return a new auth state
-           * If refrsh fails, we should log out
-           **/
-
-          // if your refresh logic is in graphQL, you must use this mutate function to call it
-          // if your refresh logic is a separate RESTful endpoint, use fetch or similar
-          const result = await mutate(refreshMutation, {
-            token: authState!.refreshToken,
-          });
-
-          if (result.data?.refreshLogin) {
-            // save the new tokens in storage for next restart
-            localStorage.setItem('token', result.data.refreshLogin.token);
-            localStorage.setItem('refreshToken', result.data.refreshLogin.refreshToken);
-
-            // return the new tokens
-            return {
-              token: result.data.refreshLogin.token,
-              refreshToken: result.data.refreshLogin.refreshToken,
-            };
-          }
-
-          // otherwise, if refresh fails, log clear storage and log out
-          localStorage.clear();
-
-          // your app logout logic should trigger here
-          logout();
-
           return null;
-        },
-      }),
+        }
+
+        /**
+         * the following code gets exetuted when an auth error has occurred
+         * we should refresh the token if possible and return a new auth state
+         * If refrsh fails, we should log out
+         **/
+
+        // if your refresh logic is in graphQL, you must use this mutate function to call it
+        // if your refresh logic is a separate RESTful endpoint, use fetch or similar
+        const result = await mutate(refreshMutation, {
+          token: authState!.refreshToken,
+        });
+
+        if (result.data?.refreshLogin) {
+          // save the new tokens in storage for next restart
+          localStorage.setItem('token', result.data.refreshLogin.token);
+          localStorage.setItem('refreshToken', result.data.refreshLogin.refreshToken);
+
+          // return the new tokens
+          return {
+            token: result.data.refreshLogin.token,
+            refreshToken: result.data.refreshLogin.refreshToken,
+          };
+        }
+
+        // otherwise, if refresh fails, log clear storage and log out
+        localStorage.clear();
+
+        // your app logout logic should trigger here
+        logout();
+
+        return null;
+      },
+    }),
     fetchExchange
   ],
 });
 ```
 
-## Handling rrrors via the errorExchange
+## Handling Errors via the errorExchange
 
 Handling the logout logic in `getAuth` is the easiest way to get started, but it means the errors will always get swallowed by the `authExchange`.
 If you want to handle errors globally, this can be done using the `errorExchange`:
@@ -157,7 +137,3 @@ errorExchange({
   }
 }),
 ```
-
-## Maintenance Status
-
-**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.

--- a/exchanges/auth/README.md
+++ b/exchanges/auth/README.md
@@ -1,0 +1,48 @@
+<h2 align="center">@urql/exchange-auth</h2>
+
+<p align="center"><strong>An exchange for managing authentication in <code>urql</code></strong></p>
+
+`@urql/exchange-auth` is an exchange for the [`urql`](https://github.com/FormidableLabs/urql) GraphQL client which helps handle auth headers and token refresh
+
+## Quick Start Guide
+
+First install `@urql/exchange-auth` alongside `urql`:
+
+```sh
+yarn add @urql/exchange-auth
+# or
+npm install --save @urql/exchange-auth
+```
+
+You'll then need to add the `authExchange`, that this package exposes, to your `urql` Client
+
+```js
+import { createClient, dedupExchange, cacheExchange } from 'urql';
+import { executeExchange } from '@urql/exchange-execute';
+
+const client = createClient({
+  url: 'http://localhost:1234/graphql',
+  exchanges: [
+    dedupExchange,
+    cacheExchange,
+    authExchange({
+      getAuthStateFromStorage: () => {
+        // fetch your auth state from storage. This can be async
+        return { token: 'token', refreshToken: 'refresh-token' };
+      },
+      getAuthHeader: ({ authState }) => {
+        // use the auth state as constructed above to create an auth header
+        const token = authState?.token;
+        return {
+          Authorization: token ? `Bearer ${token}` : '',
+        };
+      },
+    }),
+    fetchExchange
+  ],
+});
+```
+
+## Maintenance Status
+
+**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.

--- a/exchanges/auth/README.md
+++ b/exchanges/auth/README.md
@@ -14,10 +14,10 @@ yarn add @urql/exchange-auth
 npm install --save @urql/exchange-auth
 ```
 
-You'll then need to add the `authExchange`, that this package exposes, to your `urql` Client
+You'll then need to add the `authExchange`, that this package exposes, (and `errorExchange`) to your `urql` Client
 
 ```js
-import { createClient, dedupExchange, cacheExchange } from 'urql';
+import { createClient, dedupExchange, cacheExchange, errorExchange } from 'urql';
 import { executeExchange } from '@urql/exchange-execute';
 
 const client = createClient({
@@ -25,6 +25,18 @@ const client = createClient({
   exchanges: [
     dedupExchange,
     cacheExchange,
+    errorExchange({
+      onError: ({ error }) => {
+        // We only get an auth error here when the auth excahnge had attempted to refresh auth and getting an auth error again for the second time
+        const isAuthError = error.graphQLErrors.some(
+          e => e.extensions?.code === "FORBIDDEN",
+        );
+
+        if (isAuthError) {
+          // log the user out
+        }
+      }
+    }),
     authExchange({
       addAuthToOperation: ({ authState, operation }) => {
         const token = authState?.token;

--- a/exchanges/auth/package.json
+++ b/exchanges/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urql/exchange-auth",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "An exchange for managing authentication and token refresh in urql",
   "sideEffects": false,
   "homepage": "https://formidable.com/open-source/urql/docs/",

--- a/exchanges/auth/package.json
+++ b/exchanges/auth/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@urql/exchange-auth",
+  "version": "0.0.1",
+  "description": "An exchange for managing authentication and token refresh in urql",
+  "sideEffects": false,
+  "homepage": "https://formidable.com/open-source/urql/docs/",
+  "bugs": "https://github.com/FormidableLabs/urql/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/urql.git",
+    "directory": "exchanges/auth"
+  },
+  "keywords": [
+    "urql",
+    "exchange",
+    "auth",
+    "authentication",
+    "formidablelabs",
+    "exchanges"
+  ],
+  "main": "dist/urql-exchange-auth",
+  "module": "dist/urql-exchange-auth.mjs",
+  "types": "dist/types/index.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql-exchange-auth.mjs",
+      "require": "./dist/urql-exchange-auth.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "README.md",
+    "dist/"
+  ],
+  "scripts": {
+    "test": "jest",
+    "clean": "rimraf dist extras",
+    "check": "tsc --noEmit",
+    "lint": "eslint --ext=js,jsx,ts,tsx .",
+    "build": "rollup -c ../../scripts/rollup/config.js",
+    "prepare": "node ../../scripts/prepare/index.js",
+    "prepublishOnly": "run-s clean build"
+  },
+  "jest": {
+    "preset": "../../scripts/jest/preset"
+  },
+  "dependencies": {
+    "@urql/core": ">=1.12.0",
+    "wonka": "^4.0.14"
+  },
+  "peerDependencies": {
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+  },
+  "devDependencies": {
+    "graphql": "^15.1.0",
+    "graphql-tag": "^2.10.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/exchanges/auth/src/authExchange.test.ts
+++ b/exchanges/auth/src/authExchange.test.ts
@@ -31,10 +31,18 @@ describe('on request', () => {
     const res = await pipe(
       fromValue(queryOperation),
       authExchange({
-        getAuthStateFromStorage: () => ({ token: 'my-token' }),
-        getAuthHeader: ({ authState }) => ({
-          Authorization: `Bearer ${authState.token}`,
-        }),
+        getInitialAuthState: () => ({ token: 'my-token' }),
+        addAuthToOperation: ({ authState, operation }) => {
+          return Object.assign(operation, {
+            context: {
+              fetchOptions: {
+                headers: {
+                  Authorization: `Bearer ${authState.token}`,
+                },
+              },
+            },
+          });
+        },
       })(exchangeArgs),
       take(1),
       toPromise
@@ -60,14 +68,22 @@ describe('on request', () => {
     const res = await pipe(
       fromValue(queryOperation),
       authExchange({
-        getAuthStateFromStorage: async () => {
-          return await new Promise(resolve =>
+        getInitialAuthState: async () => {
+          return await new Promise<{ token: string }>(resolve =>
             setTimeout(() => resolve({ token: 'async-token' }), 500)
           );
         },
-        getAuthHeader: ({ authState }) => ({
-          Authorization: authState.token,
-        }),
+        addAuthToOperation: ({ authState, operation }) => {
+          return Object.assign(operation, {
+            context: {
+              fetchOptions: {
+                headers: {
+                  Authorization: authState.token,
+                },
+              },
+            },
+          });
+        },
       })(exchangeArgs),
       take(1),
       toPromise
@@ -97,10 +113,18 @@ describe('on request', () => {
     await pipe(
       source,
       authExchange({
-        getAuthStateFromStorage: () => ({ token: 'my-token' }),
-        getAuthHeader: ({ authState }) => ({
-          Authorization: `Bearer ${authState.token}`,
-        }),
+        getInitialAuthState: () => ({ token: 'my-token' }),
+        addAuthToOperation: ({ authState, operation }) => {
+          return Object.assign(operation, {
+            context: {
+              fetchOptions: {
+                headers: {
+                  Authorization: `Bearer ${authState.token}`,
+                },
+              },
+            },
+          });
+        },
       })(exchangeArgs),
       tap(result),
       publish

--- a/exchanges/auth/src/authExchange.test.ts
+++ b/exchanges/auth/src/authExchange.test.ts
@@ -1,23 +1,23 @@
-import {
-  pipe,
-  fromValue,
-  toPromise,
-  take,
-  makeSubject,
-  tap,
-  publish,
-  map,
-} from 'wonka';
+import { pipe, fromValue, toPromise, take, makeSubject, tap, map } from 'wonka';
+
+import { print } from 'graphql';
 import { authExchange } from './authExchange';
+import { Client, Operation, OperationResult } from '@urql/core';
 import { queryOperation } from '@urql/core/test-utils';
 
+const operations: Operation[] = [];
 const exchangeArgs = {
   forward: op$ =>
     pipe(
       op$,
-      map(operation => ({ operation }))
+      map(
+        (operation: Operation): OperationResult => {
+          operations.push(operation);
+          return { operation };
+        }
+      )
     ),
-  client: {},
+  client: new Client({ url: '/api' }),
 } as any;
 
 const withAuthHeader = (operation, token) => {
@@ -41,22 +41,148 @@ const withAuthHeader = (operation, token) => {
   };
 };
 
-describe('on request', () => {
-  it('adds the auth header correctly', async () => {
-    const res = await pipe(
-      fromValue(queryOperation),
-      authExchange({
-        getAuth: async () => ({ token: 'my-token' }),
-        willAuthError: () => false,
-        addAuthToOperation: ({ authState, operation }) => {
-          return withAuthHeader(operation, authState!.token);
-        },
-      })(exchangeArgs),
-      take(1),
-      toPromise
-    );
+beforeEach(() => {
+  operations.length = 0;
+});
 
-    const expectedOperation = {
+it('adds the auth header correctly', async () => {
+  const res = await pipe(
+    fromValue(queryOperation),
+    authExchange({
+      getAuth: async () => ({ token: 'my-token' }),
+      willAuthError: () => false,
+      addAuthToOperation: ({ authState, operation }) => {
+        return withAuthHeader(operation, authState!.token);
+      },
+    })(exchangeArgs),
+    take(1),
+    toPromise
+  );
+
+  const expectedOperation = {
+    ...queryOperation,
+    context: {
+      ...queryOperation.context,
+      authAttempt: false,
+      fetchOptions: {
+        ...(queryOperation.context.fetchOptions || {}),
+        headers: {
+          Authorization: 'my-token',
+        },
+      },
+    },
+  };
+
+  expect(res).toEqual({ operation: expectedOperation });
+});
+
+it('adds the auth header correctly when it is fetched asynchronously', async () => {
+  const res = await pipe(
+    fromValue(queryOperation),
+    authExchange<{ token: string }>({
+      getAuth: async () => {
+        await Promise.resolve();
+        return { token: 'async-token' };
+      },
+      willAuthError: () => false,
+      addAuthToOperation: ({ authState, operation }) => {
+        return withAuthHeader(operation, authState!.token);
+      },
+    })(exchangeArgs),
+    take(1),
+    toPromise
+  );
+
+  const expectedOperation = {
+    ...queryOperation,
+    context: {
+      ...queryOperation.context,
+      authAttempt: false,
+      fetchOptions: {
+        ...(queryOperation.context.fetchOptions || {}),
+        headers: {
+          Authorization: 'async-token',
+        },
+      },
+    },
+  };
+
+  expect(res).toEqual({ operation: expectedOperation });
+});
+
+it('supports calls to the mutate() method in getAuth()', async () => {
+  const res = await pipe(
+    fromValue(queryOperation),
+    authExchange<{ token: string }>({
+      getAuth: async ({ mutate }) => {
+        const result = await mutate('mutation { auth }');
+        expect(print(result.operation.query)).toBe('mutation {\n  auth\n}\n');
+        return { token: 'async-token' };
+      },
+      willAuthError: () => false,
+      addAuthToOperation: ({ authState, operation }) => {
+        return withAuthHeader(operation, authState?.token);
+      },
+    })(exchangeArgs),
+    take(2),
+    toPromise
+  );
+
+  const expectedOperation = {
+    ...queryOperation,
+    context: {
+      ...queryOperation.context,
+      authAttempt: false,
+      fetchOptions: {
+        ...(queryOperation.context.fetchOptions || {}),
+        headers: {
+          Authorization: 'async-token',
+        },
+      },
+    },
+  };
+
+  expect(res).toEqual({ operation: expectedOperation });
+});
+
+it('adds the same token to subsequent operations', async () => {
+  const { source, next } = makeSubject<any>();
+
+  const result = jest.fn();
+  const auth$ = pipe(
+    source,
+    authExchange({
+      getAuth: async () => {
+        await Promise.resolve();
+        return { token: 'my-token' };
+      },
+      willAuthError: () => false,
+      addAuthToOperation: ({ authState, operation }) => {
+        return withAuthHeader(operation, authState!.token);
+      },
+    })(exchangeArgs),
+    tap(result),
+    take(2),
+    toPromise
+  );
+
+  next(queryOperation);
+
+  const secondQuery = {
+    ...queryOperation,
+    context: {
+      ...queryOperation.context,
+      foo: 'bar',
+    },
+  };
+
+  next(secondQuery);
+
+  await auth$;
+  expect(result).toHaveBeenCalledTimes(2);
+
+  expect(result).nthCalledWith(1, {
+    operation: {
       ...queryOperation,
       context: {
         ...queryOperation.context,
@@ -68,104 +194,22 @@ describe('on request', () => {
           },
         },
       },
-    };
-
-    expect(res).toEqual({ operation: expectedOperation });
+    },
   });
 
-  it('adds the auth header correctly when it is fetched asynchronously', async () => {
-    const res = await pipe(
-      fromValue(queryOperation),
-      authExchange({
-        getAuth: async () => {
-          return await new Promise<{ token: string }>(resolve =>
-            setTimeout(() => resolve({ token: 'async-token' }), 500)
-          );
-        },
-        willAuthError: () => false,
-        addAuthToOperation: ({ authState, operation }) => {
-          return withAuthHeader(operation, authState!.token);
-        },
-      })(exchangeArgs),
-      take(1),
-      toPromise
-    );
-
-    const expectedOperation = {
-      ...queryOperation,
+  expect(result).nthCalledWith(2, {
+    operation: {
+      ...secondQuery,
       context: {
-        ...queryOperation.context,
+        ...secondQuery.context,
         authAttempt: false,
         fetchOptions: {
-          ...(queryOperation.context.fetchOptions || {}),
+          ...(secondQuery.context.fetchOptions || {}),
           headers: {
-            Authorization: 'async-token',
+            Authorization: 'my-token',
           },
         },
       },
-    };
-
-    expect(res).toEqual({ operation: expectedOperation });
-  });
-
-  it('adds the same token to subsequent operations', async () => {
-    const { source, next } = makeSubject<any>();
-
-    const result = jest.fn();
-
-    await pipe(
-      source,
-      authExchange({
-        getAuth: async () => ({ token: 'my-token' }),
-        willAuthError: () => false,
-        addAuthToOperation: ({ authState, operation }) => {
-          return withAuthHeader(operation, authState!.token);
-        },
-      })(exchangeArgs),
-      tap(result),
-      publish
-    );
-
-    next(queryOperation);
-    const secondQuery = {
-      ...queryOperation,
-      context: {
-        ...queryOperation.context,
-        foo: 'bar',
-      },
-    };
-    next(secondQuery);
-    expect(result).toHaveBeenCalledTimes(2);
-    expect(result).nthCalledWith(1, {
-      operation: {
-        ...queryOperation,
-        context: {
-          ...queryOperation.context,
-          authAttempt: false,
-          fetchOptions: {
-            ...(queryOperation.context.fetchOptions || {}),
-            headers: {
-              Authorization: 'my-token',
-            },
-          },
-        },
-      },
-    });
-
-    expect(result).nthCalledWith(2, {
-      operation: {
-        ...secondQuery,
-        context: {
-          ...secondQuery.context,
-          authAttempt: false,
-          fetchOptions: {
-            ...(secondQuery.context.fetchOptions || {}),
-            headers: {
-              Authorization: 'my-token',
-            },
-          },
-        },
-      },
-    });
+    },
   });
 });

--- a/exchanges/auth/src/authExchange.test.ts
+++ b/exchanges/auth/src/authExchange.test.ts
@@ -1,0 +1,145 @@
+import {
+  pipe,
+  fromValue,
+  toPromise,
+  take,
+  makeSubject,
+  tap,
+  publish,
+} from 'wonka';
+import { authExchange } from './authExchange';
+import { queryOperation } from '@urql/core/test-utils';
+
+const exchangeArgs = {
+  forward: a => a,
+  client: {},
+} as any;
+
+describe('on request', () => {
+  it('does nothing when no parameters are passed in', async () => {
+    const res = await pipe(
+      fromValue(queryOperation),
+      authExchange({})(exchangeArgs),
+      take(1),
+      toPromise
+    );
+
+    expect(res).toEqual(queryOperation);
+  });
+
+  it('adds the auth header correctly', async () => {
+    const res = await pipe(
+      fromValue(queryOperation),
+      authExchange({
+        getAuthStateFromStorage: () => ({ token: 'my-token' }),
+        getAuthHeader: ({ authState }) => ({
+          Authorization: `Bearer ${authState.token}`,
+        }),
+      })(exchangeArgs),
+      take(1),
+      toPromise
+    );
+
+    const expectedOperation = {
+      ...queryOperation,
+      context: {
+        ...queryOperation.context,
+        fetchOptions: {
+          ...(queryOperation.context.fetchOptions || {}),
+          headers: {
+            Authorization: 'Bearer my-token',
+          },
+        },
+      },
+    };
+
+    expect(res).toEqual(expectedOperation);
+  });
+
+  it('adds the auth header correctly when it is fetched asynchronously', async () => {
+    const res = await pipe(
+      fromValue(queryOperation),
+      authExchange({
+        getAuthStateFromStorage: async () => {
+          return await new Promise(resolve =>
+            setTimeout(() => resolve({ token: 'async-token' }), 500)
+          );
+        },
+        getAuthHeader: ({ authState }) => ({
+          Authorization: authState.token,
+        }),
+      })(exchangeArgs),
+      take(1),
+      toPromise
+    );
+
+    const expectedOperation = {
+      ...queryOperation,
+      context: {
+        ...queryOperation.context,
+        fetchOptions: {
+          ...(queryOperation.context.fetchOptions || {}),
+          headers: {
+            Authorization: 'async-token',
+          },
+        },
+      },
+    };
+
+    expect(res).toEqual(expectedOperation);
+  });
+
+  it('adds the same token to subsequent operations', async () => {
+    const { source, next } = makeSubject<any>();
+
+    const result = jest.fn();
+
+    await pipe(
+      source,
+      authExchange({
+        getAuthStateFromStorage: () => ({ token: 'my-token' }),
+        getAuthHeader: ({ authState }) => ({
+          Authorization: `Bearer ${authState.token}`,
+        }),
+      })(exchangeArgs),
+      tap(result),
+      publish
+    );
+
+    next(queryOperation);
+    const secondQuery = {
+      ...queryOperation,
+      context: {
+        ...queryOperation.context,
+        foo: 'bar',
+      },
+    };
+    next(secondQuery);
+    expect(result).toHaveBeenCalledTimes(2);
+    expect(result).nthCalledWith(1, {
+      ...queryOperation,
+      context: {
+        ...queryOperation.context,
+        fetchOptions: {
+          ...(queryOperation.context.fetchOptions || {}),
+          headers: {
+            Authorization: 'Bearer my-token',
+          },
+        },
+      },
+    });
+
+    expect(result).nthCalledWith(2, {
+      ...secondQuery,
+      context: {
+        ...secondQuery.context,
+        fetchOptions: {
+          ...(secondQuery.context.fetchOptions || {}),
+          headers: {
+            Authorization: 'Bearer my-token',
+          },
+        },
+      },
+    });
+  });
+});

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -106,10 +106,9 @@ export function authExchange<T>({
         retryQueue.clear();
       };
 
-      let pendingPromise: Promise<any> | void = getAuth({
-        authState,
-        mutate,
-      }).then(updateAuthState);
+      let pendingPromise: Promise<any> | void = Promise.resolve()
+        .then(() => getAuth({ authState, mutate }))
+        .then(updateAuthState);
 
       const refreshAuth = (operation: Operation): Promise<any> => {
         // add to retry queue to try again later

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -1,0 +1,78 @@
+import { pipe, map, mergeMap, fromPromise, fromValue } from 'wonka';
+import { Operation } from 'urql';
+
+type AuthConfig<T> = {
+  getAuthStateFromStorage?: () => T | Promise<T>;
+  getAuthHeader?: ({ authState: T }) => { [key: string]: string };
+};
+
+const addHeadersToOperation = ({ operation, headers }) => {
+  const fetchOptions =
+    typeof operation.context.fetchOptions === 'function'
+      ? operation.context.fetchOptions()
+      : operation.context.fetchOptions || {};
+
+  return {
+    ...operation,
+    context: {
+      ...operation.context,
+      fetchOptions: {
+        ...fetchOptions,
+        headers: {
+          ...fetchOptions.headers,
+          ...(headers || {}),
+        },
+      },
+    },
+  };
+};
+
+export function authExchange<T>({
+  getAuthStateFromStorage,
+  getAuthHeader,
+}: AuthConfig<T>) {
+  let authState: T;
+  let pendingPromise: Promise<void> | void;
+
+  const initAuthState = async () => {
+    if (getAuthStateFromStorage) {
+      const state = await getAuthStateFromStorage();
+      authState = state;
+    }
+    pendingPromise = undefined;
+  };
+
+  pendingPromise = initAuthState();
+
+  return ({ forward }) => {
+    return operations$ => {
+      const pendingOps$ = pipe(
+        operations$,
+        mergeMap((operation: Operation) => {
+          if (operation.operationName !== 'teardown' && pendingPromise) {
+            return pipe(
+              fromPromise(pendingPromise),
+              map(() => {
+                if (getAuthHeader) {
+                  const headers = getAuthHeader({ authState });
+                  return addHeadersToOperation({ operation, headers });
+                } else {
+                  return operation;
+                }
+              })
+            );
+          }
+          if (getAuthHeader) {
+            const headers = getAuthHeader({ authState });
+            return fromValue(addHeadersToOperation({ operation, headers }));
+          } else {
+            return fromValue(operation);
+          }
+        })
+      );
+
+      const operationResult$ = forward(pendingOps$);
+      return operationResult$;
+    };
+  };
+}

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -5,13 +5,25 @@ import {
   fromPromise,
   fromValue,
   filter,
+  onStart,
+  take,
   makeSubject,
+  toPromise,
   merge,
   share,
   takeUntil,
 } from 'wonka';
 
-import { Operation, CombinedError, Exchange } from '@urql/core';
+import {
+  Operation,
+  OperationContext,
+  OperationResult,
+  CombinedError,
+  Exchange,
+  createRequest,
+} from '@urql/core';
+
+import { DocumentNode } from 'graphql';
 
 export interface AuthConfig<T> {
   /** addAuthToOperation() must be provided to add the custom `authState` to an Operation's context, so that it may be picked up by the `fetchExchange`. */
@@ -30,7 +42,15 @@ export interface AuthConfig<T> {
   }): boolean;
 
   /** getAuth() handles how the application refreshes or reauthenticates given a stale `authState` and should return a new `authState` or `null`. */
-  getAuth(params: { authState: T | null }): Promise<T | null>;
+  getAuth(params: {
+    authState: T | null;
+    /** The mutate() method may be used to send one-off mutations to the GraphQL API for the purpose of authentication. */
+    mutate<Data = any, Variables extends object = {}>(
+      query: DocumentNode | string,
+      variables?: Variables,
+      context?: Partial<OperationContext>
+    ): Promise<OperationResult<Data>>;
+  }): Promise<T | null>;
 }
 
 const addAuthAttemptToOperation = (
@@ -50,40 +70,62 @@ export function authExchange<T>({
   didAuthError,
   willAuthError,
 }: AuthConfig<T>): Exchange {
-  return ({ forward }) => {
+  return ({ client, forward }) => {
     const retryQueue: Map<number, Operation> = new Map();
-    let authState: T | null = null;
-
-    const updateAuthState = (newAuthState: T | null) => {
-      authState = newAuthState;
-      pendingPromise = undefined;
-      retryQueue.forEach(retryOperation);
-      retryQueue.clear();
-    };
-
-    let pendingPromise: Promise<any> | void = getAuth({ authState }).then(
-      updateAuthState
-    );
-
-    const refreshAuth = (operation: Operation): Promise<any> => {
-      // add to retry queue to try again later
-      retryQueue.set(operation.key, addAuthAttemptToOperation(operation, true));
-
-      // check that another operation isn't already doing refresh
-      if (!pendingPromise) {
-        pendingPromise = getAuth({ authState })
-          .then(updateAuthState)
-          .catch(() => updateAuthState(null));
-      }
-
-      return pendingPromise;
-    };
-
     const { source: retrySource$, next: retryOperation } = makeSubject<
       Operation
     >();
 
+    let authState: T | null = null;
+
     return operations$ => {
+      function mutate<Data = any, Variables extends object = {}>(
+        query: DocumentNode | string,
+        variables?: Variables,
+        context?: Partial<OperationContext>
+      ): Promise<OperationResult<Data>> {
+        const operation = client.createRequestOperation(
+          'mutation',
+          createRequest(query, variables),
+          context
+        );
+
+        return pipe(
+          result$,
+          onStart(() => retryOperation(operation)),
+          filter(result => result.operation.key === operation.key),
+          take(1),
+          toPromise
+        );
+      }
+
+      const updateAuthState = (newAuthState: T | null) => {
+        authState = newAuthState;
+        pendingPromise = undefined;
+        retryQueue.forEach(retryOperation);
+        retryQueue.clear();
+      };
+
+      let pendingPromise: Promise<any> | void = getAuth({
+        authState,
+        mutate,
+      }).then(updateAuthState);
+
+      const refreshAuth = (operation: Operation): Promise<any> => {
+        // add to retry queue to try again later
+        operation = addAuthAttemptToOperation(operation, true);
+        retryQueue.set(operation.key, operation);
+
+        // check that another operation isn't already doing refresh
+        if (!pendingPromise) {
+          pendingPromise = getAuth({ authState, mutate })
+            .then(updateAuthState)
+            .catch(() => updateAuthState(null));
+        }
+
+        return pendingPromise;
+      };
+
       const sharedOps$ = pipe(operations$, share);
 
       const teardownOps$ = pipe(
@@ -136,9 +178,10 @@ export function authExchange<T>({
         map(operation => addAuthToOperation({ operation, authState }))
       );
 
+      const result$ = pipe(merge([opsWithAuth$, teardownOps$]), forward, share);
+
       return pipe(
-        merge([opsWithAuth$, teardownOps$]),
-        forward,
+        result$,
         filter(({ error, operation }) => {
           if (error && didAuthError && didAuthError({ error, authState })) {
             if (!operation.context.authAttempt) {

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -10,7 +10,8 @@ import {
   share,
   takeUntil,
 } from 'wonka';
-import { Operation, CombinedError, Exchange } from 'urql';
+
+import { Operation, CombinedError, Exchange } from '@urql/core';
 
 export interface AuthConfig<T> {
   /** addAuthToOperation() must be provided to add the custom `authState` to an Operation's context, so that it may be picked up by the `fetchExchange`. */

--- a/exchanges/auth/src/index.ts
+++ b/exchanges/auth/src/index.ts
@@ -1,0 +1,1 @@
+export { authExchange } from './authExchange';

--- a/exchanges/auth/tsconfig.json
+++ b/exchanges/auth/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/core/*": ["../../node_modules/@urql/core/src/*"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}

--- a/exchanges/auth/tsconfig.json
+++ b/exchanges/auth/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "compilerOptions": {
     "baseUrl": "./",
+    "target": "es2019",
     "paths": {
       "urql": ["../../node_modules/urql/src"],
       "*-urql": ["../../node_modules/*-urql/src"],


### PR DESCRIPTION
## Summary

Currently, every user will have to build their own auth exchange for authentication, and token refresh. The motivation for this exchange is to provide a general api that enables auth and token refresh for both React and React Native.

## High level overview

The exchange will allow flexibility in:
- being used in React (web) or React Native (primarily the implication is that, the initial auth state can be fetched asynchronously or synchronously)
- what constitutes an auth error (e.g. a 401 or a specific error code)
- how to add auth to a request (format of the header(s))
- what auth state looks like (you can also store and use refresh token, token expiry or anything else)
- how to refresh token (using a REST or graphQL endpoint)
- how to react to errors (when to log the user out)

Once the exchange is created, we trigger `getAuth` for the first time. Here you should fetch your existing auth state from storage and return it. If the storage is asynchronous (in case of React Native), the exchange will pause the execution of requests until the auth is fetched and can be added to requests. Note that we don't call `getAuth` for every request, but store the `authState` in the exchange.

When the `authState` has been returned, `addAuthToOperation` will be called for each operation. You should use the auth state to add the proper auth to each request (e.g. the auth header).

Next, `willAuthError` is called. This is an opportunity to bail out early before doing a request. E.g if the JWT is expired we'll know there's no need to do the request, and it'll definitely fail.

Once the request has been done, if an error occurs, then `didAuthError` is called to check whether the error was an auth error. If this returns true, then the auth library will call `getAuth` - this is where you should use the existing auth state to create a new (hopefully valid) auth state, e.g. use the refresh token to refresh your JWT. The `authExchange` then calls `addAuthToOperation` with the new auth state and attempts to do the request again. If the second attempt also fails with an authentication error, we let the error fall through.

Finally, we use the `errorExchange` to handle critical auth failures and log out. We know that once the error reached the `errorExchange`, authentication refresh has already been attempted:

```js
import { errorExchange } from 'urql';

errorExchange({
  onError: ({ error }) => {
    const isAuthError = error.graphQLErrors.some(
      e => e.extensions?.code === "FORBIDDEN",
    );

    if (isAuthError) {
      // log the user out
    }
  }
})
```

Note! The `errorExchange` must be placed _before_ the `authExchange` in the exchanges array, because exchanges get executed in reverse order.


## Configuration options

#### `getAuth: ({ authState: T | null }) => Promise<T | null>;`

Allows you to handle retrieving your auth state (usually a token and refresh token). Here is there the bulk of the auth is handled.

This function is called during initial load and whenever an auth error occurs. This way you can use is to fetch your token from storage on initial load,
or do a token refresh during auth failure.

#### `addAuthToOperation: ({ authState: T | null; operation: Operation; }) => Operation;`

Given the auth state you have defined, use that to add auth to each operation. Usuall this involves adding a JWT to the request header.

#### `didAuthError: ({ error: CombinedError; authState: T | null; }) => boolean;`

This gets called whenever a graphQL error occurs. Return `true` if the error should count as an auth error, `false` otherwise.

#### `willAuthError: ({ operation: Operation; authState: T | null; }) => boolean;`

This is checked _before_ a network request is done and gives you the opportunity to bail out early.
For example if you already you have an expiry on your jwt, this could be stored in `authState` and checked in this function.
If the token is expired, we'll know the request will fail with an auth error without having to do the request.
Defaults to `false`

## Set of changes

- [x]  fetch token from storage
- [x]  add token to operation
- [x]  define unauthorised response
- [x]  token refresh with REST
- [x] token refresh with graphQL
- [x] document input options