### PR TITLE
fix(preact): handle case where `prev.current` is null

### DIFF
--- a/.changeset/clean-spiders-complain.md
+++ b/.changeset/clean-spiders-complain.md
@@ -1,0 +1,5 @@
+---
+'@urql/preact': patch
+---
+
+handle a bug in Preact where the current request might be `null`

--- a/packages/preact-urql/src/hooks/useRequest.ts
+++ b/packages/preact-urql/src/hooks/useRequest.ts
@@ -12,7 +12,7 @@ export const useRequest = (
   return useMemo(() => {
     const request = createRequest(query, variables);
     // We manually ensure reference equality if the key hasn't changed
-    if (prev.current !== undefined && prev.current.key === request.key) {
+    if (prev.current !== undefined && prev.current?.key === request.key) {
       return prev.current;
     } else {
       return (prev.current = request);

--- a/packages/preact-urql/src/hooks/useRequest.ts
+++ b/packages/preact-urql/src/hooks/useRequest.ts
@@ -12,7 +12,7 @@ export const useRequest = (
   return useMemo(() => {
     const request = createRequest(query, variables);
     // We manually ensure reference equality if the key hasn't changed
-    if (prev.current !== undefined && prev.current?.key === request.key) {
+    if (prev.current != null && prev.current.key === request.key) {
       return prev.current;
     } else {
       return (prev.current = request);


### PR DESCRIPTION
after upgrading to `@urql/preact@1.2.0`, I started getting an error where `prev.current` is sometimes `null`, which throws `TypeError: Cannot read property 'key' of null`

I wasn't able to test this bix with your build step, but it should transpile properly

we could probably drop the `prev.current !== undefined` with this fix, but I didn't want to change more than I had to because I don't have a ton of context on this project

<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
