### PR TITLE
(docs) - elaborate on graphcache documentation

### DIFF
--- a/docs/graphcache/custom-updates.md
+++ b/docs/graphcache/custom-updates.md
@@ -5,10 +5,10 @@ order: 3
 
 # Custom Updates
 
-Every time a `subscription` triggeres or a `mutation` receives a response GraphCache will look at the response and see
+Every time Graphcache sees a result from the API for a `subscription` or a `mutation` it will look at the response and traverse it.
 if it can get a key from the response. This key is by default derived from the `__typename` and `id`/`_id`, unless
 customized in your `keys` configuration, this entity will then be added to the cache this means that
-an existing entity with the found key will be updated.. While it will update all normalized entities that it finds in
+This means that existing entities with a found key will be updated and new ones will be written. While it will update all normalized entities that it finds in
 those results, it can't for instance tell whether a new item should be appended or removed from a
 list.
 
@@ -271,7 +271,7 @@ The _Optimistic Updates_ configuration allows us to set up "temporary" results f
 will be applied immediately. This is a great solution to reduce the waiting time for the user.
 
 > Note that an optimistic response is meant to be a temporary update to an entity until the server responds to your mutation.
-> This means that what you return here should reflect the shape of what the server would return.
+> This means that what you return here should reflect the shape of what the server will return.
 
 This technique is often used with one-off mutations that are assumed to succeed, like starring a
 repository, or liking a tweet. In such cases it's often desirable to make the interaction feel

--- a/docs/graphcache/custom-updates.md
+++ b/docs/graphcache/custom-updates.md
@@ -5,8 +5,10 @@ order: 3
 
 # Custom Updates
 
-_Graphcache_ will attempt to automatically react to your mutations' and subscriptions' results
-but sometimes this isn't possible. While it will update all normalized entities that it finds in
+Every time a `subscription` triggeres or a `mutation` receives a response GraphCache will look at the response and see
+if it can get a key from the response. This key is by default derived from the `__typename` and `id`/`_id`, unless
+customized in your `keys` configuration, this entity will then be added to the cache this means that
+an existing entity with the found key will be updated.. While it will update all normalized entities that it finds in
 those results, it can't for instance tell whether a new item should be appended or removed from a
 list.
 
@@ -257,7 +259,7 @@ Now we'd need to traverse all the `todos` to find which we need, but there's ano
 Rather than use `cache.inspectFields('Query')`, which would give us all queried `todo` fields with their arguments, we can instead provide an object as the argument to `inspectFields` asking for all `Todo` types for a given id.
 
 ```js
-cache.inspectFields({ __typename: 'Todo', id: args.id })
+cache.inspectFields({ __typename: 'Todo', id: args.id });
 ```
 
 Now we'll get all fields for the given `todo` and can freely update the `authors`.
@@ -267,6 +269,9 @@ Now we'll get all fields for the given `todo` and can freely update the `authors
 If we know what result a mutation may return, why wait for the GraphQL API to fulfill our mutations?
 The _Optimistic Updates_ configuration allows us to set up "temporary" results for mutations, which
 will be applied immediately. This is a great solution to reduce the waiting time for the user.
+
+> Note that an optimistic response is meant to be a temporary update to an entity until the server responds to your mutation.
+> This means that what you return here should reflect the shape of what the server would return.
 
 This technique is often used with one-off mutations that are assumed to succeed, like starring a
 repository, or liking a tweet. In such cases it's often desirable to make the interaction feel

--- a/docs/graphcache/custom-updates.md
+++ b/docs/graphcache/custom-updates.md
@@ -6,13 +6,11 @@ order: 3
 # Custom Updates
 
 Every time Graphcache sees a result from the API for a `subscription` or a `mutation` it will look at the response and traverse it.
-if it can get a key from the response. This key is by default derived from the `__typename` and `id`/`_id`, unless
-customized in your `keys` configuration, this entity will then be added to the cache this means that
-This means that existing entities with a found key will be updated and new ones will be written. While it will update all normalized entities that it finds in
-those results, it can't for instance tell whether a new item should be appended or removed from a
-list.
+This process is the same as for queries but instead of starting at the Query root type,
+it will start searching for keyable entities, where an object's `__typename` and `id` or `_id` fields (or a custom keys config)
+are provided, so it can write normalized entities to the cache.
 
-Specifically, a normalized cache can't automatically assume that unrelated links have changed due to
+A normalized cache can't automatically assume that unrelated links have changed due to
 a mutation, since this is server-side specific logic. Instead, we may use the `updates`
 configuration to set up manual updates that react to mutations or subscriptions.
 

--- a/docs/graphcache/normalized-caching.md
+++ b/docs/graphcache/normalized-caching.md
@@ -64,7 +64,7 @@ the entire app, because all references to each each entity are shared.
 
 ## Terminology
 
-A few terms that will be used throughout the Graphcache documentation that are important to understand in order to get a full understanding.
+A few terms that will be used throughout the _Graphcache_ documentation that are important to understand in order to get a full understanding.
 
 - **Entity**, this is an object for which the cache can generate a key, like `Todo:1`.
 - **Record**, this is a property that relate to an entity, in the above case this would be `title`, ...

--- a/docs/graphcache/normalized-caching.md
+++ b/docs/graphcache/normalized-caching.md
@@ -66,23 +66,11 @@ the entire app, because all references to each each entity are shared.
 
 A few terms that will be used throughout the Graphcache documentation that are important to understand in order to get a full understanding.
 
-### Entity
-
-This is an object for which the cache can generate a key, like `Todo:1`.
-
-### Records
-
-These are properties that relate to an entity, in the above case this would be `title`, ...
-internally these will be represented as `Todo:1.title`
-
-### Link
-
-This is the connection between entities or the base `Query` field.
-
-a few examples would be:
-
-- `Query.todos: an array of ids`
-- `Todo:1.author: a string id`
+- **Entity**, this is an object for which the cache can generate a key, like `Todo:1`.
+- **Record**, this is a property that relate to an entity, in the above case this would be `title`, ...
+  internally these will be represented as `Todo:1.title`.
+- **Link**, This is the connection between entities or the base `Query` field, this will link an entity key (ex: `Query`/`Todo:1`) to a single or an array
+  of keys
 
 ## Key Generation
 

--- a/docs/graphcache/normalized-caching.md
+++ b/docs/graphcache/normalized-caching.md
@@ -64,8 +64,7 @@ the entire app, because all references to each each entity are shared.
 
 ## Terminology
 
-A few terms that will be used throughout the GraphCache documentation that are important to know
-to get a full understanding.
+A few terms that will be used throughout the Graphcache documentation that are important to understand in order to get a full understanding.
 
 ### Entity
 
@@ -73,7 +72,7 @@ This is an object for which the cache can generate a key, like `Todo:1`.
 
 ### Records
 
-These are properties that relate to an Entity, in the above case this would be `title`, ...
+These are properties that relate to an entity, in the above case this would be `title`, ...
 internally these will be represented as `Todo:1.title`
 
 ### Link

--- a/docs/graphcache/normalized-caching.md
+++ b/docs/graphcache/normalized-caching.md
@@ -62,6 +62,29 @@ Multiple results may refer to the same piece of data — a mutation for instance
 later on in the app. This would automatically cause _Graphcache_ to update any related queries in
 the entire app, because all references to each each entity are shared.
 
+## Terminology
+
+A few terms that will be used throughout the GraphCache documentation that are important to know
+to get a full understanding.
+
+### Entity
+
+This is an object for which the cache can generate a key, like `Todo:1`.
+
+### Records
+
+These are properties that relate to an Entity, in the above case this would be `title`, ...
+internally these will be represented as `Todo:1.title`
+
+### Link
+
+This is the connection between entities or the base `Query` field.
+
+a few examples would be:
+
+- `Query.todos: an array of ids`
+- `Todo:1.author: a string id`
+
 ## Key Generation
 
 As we saw in the previous example, by default _Graphcache_ will attempt to generate a key by


### PR DESCRIPTION
Resolves: https://github.com/FormidableLabs/urql/issues/938

## Summary

It clarifies some frequent misunderstandings within the graphCache documentation.
