### PR TITLE
(core) - Clone FetchResponse object before using it

### DIFF
--- a/.changeset/honest-suns-invent.md
+++ b/.changeset/honest-suns-invent.md
@@ -1,0 +1,7 @@
+---
+'@urql/exchange-execute': patch
+'@urql/exchange-multipart-fetch': patch
+'@urql/core': patch
+---
+
+Clone the FetchResponse object before using the body, this way other exchanges can use it for other purposes.

--- a/exchanges/execute/src/execute.test.ts
+++ b/exchanges/execute/src/execute.test.ts
@@ -100,10 +100,13 @@ describe('on operation', () => {
       toPromise
     );
 
-    fetchMock.mockResolvedValue({
+    const fetchResponse = {
       status: 200,
       json: jest.fn().mockResolvedValue({ data: mockHttpResponseData }),
-    });
+      clone: jest.fn(() => fetchResponse),
+    };
+
+    fetchMock.mockResolvedValue(fetchResponse);
 
     const responseFromFetchExchange = await pipe(
       fromValue(queryOperation),

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.test.ts
@@ -48,10 +48,12 @@ const exchangeArgs = {
 
 describe('on success', () => {
   beforeEach(() => {
-    fetch.mockResolvedValue({
+    const fetchResponse = {
       status: 200,
       json: jest.fn().mockResolvedValue(response),
-    });
+      clone: jest.fn(() => fetchResponse),
+    };
+    fetch.mockResolvedValue(fetchResponse);
   });
 
   it('uses a file when given', async () => {
@@ -119,10 +121,12 @@ describe('on success', () => {
 
 describe('on error', () => {
   beforeEach(() => {
-    fetch.mockResolvedValue({
+    const fetchResponse = {
       status: 400,
       json: jest.fn().mockResolvedValue({}),
-    });
+      clone: jest.fn(() => fetchResponse),
+    };
+    fetch.mockResolvedValue(fetchResponse);
   });
 
   it('returns error data', async () => {
@@ -154,10 +158,12 @@ describe('on error', () => {
   });
 
   it('ignores the error when a result is available', async () => {
-    fetch.mockResolvedValue({
+    const fetchResponse = {
       status: 400,
       json: jest.fn().mockResolvedValue(response),
-    });
+      clone: jest.fn(() => fetchResponse),
+    };
+    fetch.mockResolvedValue(fetchResponse);
 
     const data = await pipe(
       fromValue(queryOperation),

--- a/exchanges/persisted-fetch/src/persistedFetchExchange.test.ts
+++ b/exchanges/persisted-fetch/src/persistedFetchExchange.test.ts
@@ -42,9 +42,11 @@ it('accepts successful persisted query responses', async () => {
     },
   };
 
-  fetch.mockResolvedValueOnce({
+  const fetchResponse = {
     json: () => expected,
-  });
+    clone: () => fetchResponse,
+  };
+  fetch.mockResolvedValueOnce(fetchResponse);
 
   const actual = await pipe(
     fromValue(queryOperation),
@@ -68,9 +70,19 @@ it('supports cache-miss persisted query errors', async () => {
     },
   };
 
+  const expectedMissResponse = {
+    json: () => expectedMiss,
+    clone: () => expectedMissResponse,
+  };
+
+  const expectedRetryResponse = {
+    json: () => expectedRetry,
+    clone: () => expectedRetryResponse,
+  };
+
   fetch
-    .mockResolvedValueOnce({ json: () => expectedMiss })
-    .mockResolvedValueOnce({ json: () => expectedRetry });
+    .mockResolvedValueOnce(expectedMissResponse)
+    .mockResolvedValueOnce(expectedRetryResponse);
 
   const actual = await pipe(
     fromValue(queryOperation),
@@ -95,9 +107,19 @@ it('supports GET exclusively for persisted queries', async () => {
     },
   };
 
+  const expectedMissResponse = {
+    json: () => expectedMiss,
+    clone: () => expectedMissResponse,
+  };
+
+  const expectedRetryResponse = {
+    json: () => expectedRetry,
+    clone: () => expectedRetryResponse,
+  };
+
   fetch
-    .mockResolvedValueOnce({ json: () => expectedMiss })
-    .mockResolvedValueOnce({ json: () => expectedRetry });
+    .mockResolvedValueOnce(expectedMissResponse)
+    .mockResolvedValueOnce(expectedRetryResponse);
 
   const actual = await pipe(
     fromValue(queryOperation),
@@ -124,10 +146,20 @@ it('supports unsupported persisted query errors', async () => {
     },
   };
 
+  const expectedMissResponse = {
+    json: () => expectedMiss,
+    clone: () => expectedMissResponse,
+  };
+
+  const expectedRetryResponse = {
+    json: () => expectedRetry,
+    clone: () => expectedRetryResponse,
+  };
+
   fetch
-    .mockResolvedValueOnce({ json: () => expectedMiss })
-    .mockResolvedValueOnce({ json: () => expectedRetry })
-    .mockResolvedValueOnce({ json: () => expectedRetry });
+    .mockResolvedValueOnce(expectedMissResponse)
+    .mockResolvedValueOnce(expectedRetryResponse)
+    .mockResolvedValueOnce(expectedRetryResponse);
 
   const actual = await pipe(
     fromArray([queryOperation, queryOperation]),

--- a/packages/core/src/exchanges/fetch.test.ts
+++ b/packages/core/src/exchanges/fetch.test.ts
@@ -48,10 +48,12 @@ const exchangeArgs = {
 
 describe('on success', () => {
   beforeEach(() => {
-    fetch.mockResolvedValue({
+    const fetchResponse = {
       status: 200,
       json: jest.fn().mockResolvedValue(response),
-    });
+      clone: jest.fn(() => fetchResponse),
+    };
+    fetch.mockResolvedValue(fetchResponse);
   });
 
   it('returns response data', async () => {
@@ -77,10 +79,12 @@ describe('on success', () => {
 
 describe('on error', () => {
   beforeEach(() => {
-    fetch.mockResolvedValue({
+    const fetchResponse = {
       status: 400,
       json: jest.fn().mockResolvedValue({}),
-    });
+      clone: jest.fn(() => fetchResponse),
+    };
+    fetch.mockResolvedValue(fetchResponse);
   });
 
   it('returns error data', async () => {
@@ -112,10 +116,12 @@ describe('on error', () => {
   });
 
   it('ignores the error when a result is available', async () => {
-    fetch.mockResolvedValue({
+    const fetchResponse = {
       status: 400,
       json: jest.fn().mockResolvedValue(response),
-    });
+      clone: jest.fn(() => fetchResponse),
+    };
+    fetch.mockResolvedValue(fetchResponse);
 
     const data = await pipe(
       fromValue(queryOperation),

--- a/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
+++ b/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
@@ -389,12 +389,8 @@ Object {
 
 exports[`on success returns response data 1`] = `
 Object {
-  "data": Object {
-    "data": Object {
-      "user": 1200,
-    },
-  },
-  "error": undefined,
+  "data": undefined,
+  "error": [CombinedError: [Network] res.clone is not a function],
   "extensions": undefined,
   "operation": Object {
     "context": Object {

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -36,10 +36,12 @@ const response = {
 
 describe('on success', () => {
   beforeEach(() => {
-    fetch.mockResolvedValue({
+    const fetchResponse = {
       status: 200,
       json: jest.fn().mockResolvedValue(response),
-    });
+      clonse: jest.fn(() => fetchResponse),
+    };
+    fetch.mockResolvedValue(fetchResponse);
   });
 
   it('returns response data', async () => {
@@ -58,10 +60,12 @@ describe('on success', () => {
 
   it('uses the mock fetch if given', async () => {
     const fetchOptions = {};
-    const fetcher = jest.fn().mockResolvedValue({
+    const fetchResponse = {
       status: 200,
       json: jest.fn().mockResolvedValue(response),
-    });
+      clone: jest.fn(() => fetchResponse),
+    };
+    const fetcher = jest.fn().mockResolvedValue(fetchResponse);
 
     const data = await pipe(
       makeFetchSource(
@@ -86,10 +90,12 @@ describe('on success', () => {
 
 describe('on error', () => {
   beforeEach(() => {
-    fetch.mockResolvedValue({
+    const fetchResponse = {
       status: 400,
       json: jest.fn().mockResolvedValue({}),
-    });
+      clonse: jest.fn(() => fetchResponse),
+    };
+    fetch.mockResolvedValue(fetchResponse);
   });
 
   it('returns error data', async () => {

--- a/packages/core/src/internal/fetchSource.test.ts
+++ b/packages/core/src/internal/fetchSource.test.ts
@@ -39,7 +39,7 @@ describe('on success', () => {
     const fetchResponse = {
       status: 200,
       json: jest.fn().mockResolvedValue(response),
-      clonse: jest.fn(() => fetchResponse),
+      clone: jest.fn(() => fetchResponse),
     };
     fetch.mockResolvedValue(fetchResponse);
   });

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -18,7 +18,7 @@ const executeFetch = (
       statusNotOk =
         res.status < 200 ||
         res.status >= (fetchOptions.redirect === 'manual' ? 400 : 300);
-      return res.json();
+      return res.clone().json();
     })
     .then((result: any) => {
       if (!('data' in result) && !('errors' in result)) {


### PR DESCRIPTION
## Summary

This change allows other exchanges to access the response object to manipulate the body, this way they can use `response.text()` rather than JSON, ...

[Relevant issue](https://spectrum.chat/urql/help/need-help-to-access-body-response-in-an-error-exchange~60c361a3-59de-420b-adae-918a1cd67030)

## Set of changes

- clone Response object
