### PR TITLE
(core) - Omit Content-Type header when using GET

### DIFF
--- a/.changeset/pretty-pillows-serve.md
+++ b/.changeset/pretty-pillows-serve.md
@@ -1,0 +1,7 @@
+---
+'@urql/core': patch
+'@urql/exchange-multipart-fetch': patch
+'@urql/exchange-persisted-fetch': patch
+---
+
+Don't set the "content-type" on the http-headers when using GET in the fetchExchange.

--- a/.changeset/pretty-pillows-serve.md
+++ b/.changeset/pretty-pillows-serve.md
@@ -4,4 +4,4 @@
 '@urql/exchange-persisted-fetch': patch
 ---
 
-Don't set the "content-type" on the http-headers when using GET in the fetchExchange.
+Omit the `Content-Type: application/json` HTTP header when using GET in the `fetchExchange`, `persistedFetchExchange`, or `multipartFetchExchange`.

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -87,9 +87,8 @@ export const makeFetchOptions = (
     ...extraOptions,
     body: !useGETMethod && body ? JSON.stringify(body) : undefined,
     method: useGETMethod ? 'GET' : 'POST',
-    headers: {
-      'content-type': 'application/json',
-      ...extraOptions.headers,
-    },
+    headers: useGETMethod
+      ? extraOptions.headers
+      : { 'content-type': 'application/json', ...extraOptions.headers },
   };
 };


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

Fixes: https://github.com/FormidableLabs/urql/issues/956

## Summary

Remove the `content-type` from the headers when using GET.

## Set of changes

- Remove the `content-type` from the headers when using GET.
