### PR TITLE
(populate) - refactor and remove the need for visit & typeinfo

### DIFF
--- a/exchanges/populate/src/helpers/node.ts
+++ b/exchanges/populate/src/helpers/node.ts
@@ -5,6 +5,7 @@ import {
   GraphQLOutputType,
   isWrappingType,
   GraphQLWrappingType,
+  Kind,
 } from 'graphql';
 
 export type SelectionSet = ReadonlyArray<SelectionNode>;
@@ -28,3 +29,10 @@ export const unwrapType = (
 
   return type || null;
 };
+
+export function createNameNode(value: string): NameNode {
+  return {
+    kind: Kind.NAME,
+    value,
+  };
+}

--- a/exchanges/populate/src/helpers/traverse.ts
+++ b/exchanges/populate/src/helpers/traverse.ts
@@ -1,0 +1,96 @@
+import {
+  SelectionNode,
+  Kind,
+  ASTNode,
+  DefinitionNode,
+  GraphQLSchema,
+  GraphQLFieldMap,
+  isAbstractType,
+  FragmentDefinitionNode,
+  FragmentSpreadNode,
+} from 'graphql';
+import { unwrapType, getName } from './node';
+
+export function traverse(
+  node: ASTNode,
+  enter?: (n: ASTNode) => ASTNode | void,
+  exit?: (n: ASTNode) => ASTNode | void
+): any {
+  if (enter) {
+    node = enter(node) || node;
+  }
+
+  switch (node.kind) {
+    case Kind.DOCUMENT: {
+      node = {
+        ...node,
+        definitions: node.definitions.map(
+          n => traverse(n, enter, exit) as DefinitionNode
+        ),
+      };
+      break;
+    }
+    case Kind.OPERATION_DEFINITION:
+    case Kind.FIELD:
+    case Kind.FRAGMENT_DEFINITION: {
+      if (node.selectionSet) {
+        node = {
+          ...node,
+          selectionSet: {
+            ...node.selectionSet,
+            selections: node.selectionSet.selections.map(
+              n => traverse(n, enter, exit) as SelectionNode
+            ),
+          },
+        };
+      }
+      break;
+    }
+  }
+
+  if (exit) {
+    node = exit(node) || node;
+  }
+
+  return node;
+}
+
+export function resolveFields(
+  schema: GraphQLSchema,
+  visits: string[]
+): GraphQLFieldMap<any, any> {
+  let currentFields = schema.getQueryType()!.getFields();
+
+  for (let i = 0; i < visits.length; i++) {
+    const t = unwrapType(currentFields[visits[i]].type);
+
+    if (isAbstractType(t)) {
+      currentFields = {};
+      schema.getPossibleTypes(t).forEach(implementedType => {
+        currentFields = {
+          ...currentFields,
+          // @ts-ignore TODO: proper casting
+          ...schema.getType(implementedType.name)!.toConfig().fields,
+        };
+      });
+    } else {
+      // @ts-ignore TODO: proper casting
+      currentFields = schema.getType(t!.name)!.toConfig().fields;
+    }
+  }
+
+  return currentFields;
+}
+
+/** Get fragment names referenced by node. */
+export function getUsedFragmentNames(node: FragmentDefinitionNode) {
+  const names: string[] = [];
+
+  traverse(node, n => {
+    if (n.kind === Kind.FRAGMENT_SPREAD) {
+      names.push(getName(n as FragmentSpreadNode));
+    }
+  });
+
+  return names;
+}

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -375,12 +375,12 @@ const resolvePosition = (
       schema.getPossibleTypes(t).forEach(implementedType => {
         currentFields = {
           ...currentFields,
-          // @ts-ignore
+          // @ts-ignore TODO: proper casting
           ...schema.getType(implementedType.name)!.toConfig().fields,
         };
       });
     } else {
-      // @ts-ignore
+      // @ts-ignore TODO: proper casting
       currentFields = schema.getType(t!.name)!.toConfig().fields;
     }
   }

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -6,7 +6,6 @@ import {
   IntrospectionQuery,
   FragmentSpreadNode,
   NameNode,
-  ASTNode,
   isCompositeType,
   isAbstractType,
   Kind,

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -352,13 +352,23 @@ const nameNode = (value: string): NameNode => ({
 const getUsedFragments = (node: ASTNode) => {
   const names: string[] = [];
 
-  visit(node, {
-    FragmentSpread: f => {
-      names.push(getName(f));
-    },
+  traverse(node, n => {
+    if (n.kind === Kind.FRAGMENT_SPREAD) {
+      names.push(getName(n as FragmentSpreadNode));
+    }
   });
 
   return names;
+};
+
+const traverse = (node, enter, exit) => {
+  if (node.selectionSet) {
+    node.selectionSet.selections.forEach(n => {
+      if (enter) enter(n);
+      traverse(n, enter, exit);
+      if (exit) exit(n);
+    });
+  }
 };
 
 const resolvePosition = (

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -349,7 +349,7 @@ const nameNode = (value: string): NameNode => ({
 });
 
 /** Get fragment names referenced by node. */
-const getUsedFragments = (node: ASTNode) => {
+const getUsedFragments = (node: FragmentDefinitionNode) => {
   const names: string[] = [];
 
   traverse(node, n => {
@@ -361,7 +361,11 @@ const getUsedFragments = (node: ASTNode) => {
   return names;
 };
 
-const traverse = (node, enter, exit) => {
+const traverse = (
+  node: any,
+  enter?: (n: SelectionNode) => void,
+  exit?: (n: SelectionNode) => void
+) => {
   if (node.selectionSet) {
     node.selectionSet.selections.forEach(n => {
       if (enter) enter(n);

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -111,7 +111,6 @@ export const populateExchange = ({
       ops$,
       tap(handleIncomingQuery),
       tap(handleIncomingTeardown),
-      // @ts-ignore
       map(handleIncomingMutation),
       forward
     );
@@ -228,7 +227,7 @@ export const addFragmentsToQuery = (
   query: DocumentNode,
   activeTypeFragments: TypeFragmentMap,
   userFragments: UserFragmentMap
-) => {
+): DocumentNode => {
   const requiredUserFragments: Record<
     string,
     FragmentDefinitionNode
@@ -367,7 +366,7 @@ const traverse = (
   node: ASTNode,
   enter?: (n: ASTNode) => ASTNode | void,
   exit?: (n: ASTNode) => ASTNode | void
-): ASTNode => {
+): any => {
   if (enter) {
     node = enter(node) || node;
   }

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -151,7 +151,6 @@ export const extractSelectionsFromQuery = (
   ) => {
     const selections: SelectionNode[] = [];
     const validTypes = (schema.getType(type) as GraphQLObjectType).getFields();
-
     const validTypeProperties = Object.keys(validTypes);
 
     selectionSet.selections.forEach(selection => {
@@ -173,6 +172,7 @@ export const extractSelectionsFromQuery = (
         selections.push(selection);
       }
     });
+
     return { ...selectionSet, selections };
   };
 
@@ -273,7 +273,9 @@ export const addFragmentsToQuery = (
         let possibleTypes: readonly GraphQLObjectType<any, any>[] = [];
         if (!isCompositeType(type)) {
           warn(
-            'Invalid type: The type ` + type + ` is used with @populate but does not exist.',
+            'Invalid type: The type `' +
+              type +
+              '` is used with @populate but does not exist.',
             17
           );
         } else {
@@ -341,8 +343,12 @@ export const addFragmentsToQuery = (
           ...node,
           definitions: [
             ...node.definitions,
-            ...Object.values(additionalFragments),
-            ...Object.values(requiredUserFragments),
+            ...Object.keys(additionalFragments).map(
+              key => additionalFragments[key]
+            ),
+            ...Object.keys(requiredUserFragments).map(
+              key => requiredUserFragments[key]
+            ),
           ],
         };
       }


### PR DESCRIPTION
Removes the need for `graphql Typeinfo` & `visitWithTypeInfo` in the populate exchange