### PR TITLE
(react) - Support fast-refresh

### DIFF
--- a/.changeset/old-pets-watch.md
+++ b/.changeset/old-pets-watch.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Remove ref that had impact across effects to properly support react-fast-refresh

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { useMemo, useEffect, useState, useRef } from 'react';
+import { useMemo, useEffect, useState } from 'react';
 
 import {
   Source,
@@ -19,8 +19,6 @@ import { useClient } from '../context';
 let currentInit = false;
 
 export function useSource<T>(source: Source<T>, init: T): T {
-  const isMounted = useRef(true);
-
   const [state, setState] = useState(() => {
     currentInit = true;
     let initialValue = init;
@@ -38,16 +36,10 @@ export function useSource<T>(source: Source<T>, init: T): T {
   });
 
   useEffect(() => {
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
     return pipe(
       source,
       subscribe(value => {
-        if (!currentInit && isMounted.current) {
+        if (!currentInit) {
           setState(value);
         }
       })


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/urql/issues/955

## Summary

During fast-refresh effect cleanup is called simulating an unmount, we're removing the isMounted flag to prevent this. Essentially we could also duplicate this flag to the body of the atm removed `useEffect` however I haven't been encountering issues with rogue streams in my tests so it should be safe to remove.

## Set of changes

- Remove ref tracking the mounted-state of the hook