### PR TITLE
Fix some typos in auth exchange readme

### DIFF
--- a/exchanges/auth/README.md
+++ b/exchanges/auth/README.md
@@ -78,9 +78,9 @@ const client = createClient({
         }
 
         /**
-         * the following code gets exetuted when an auth error has occurred
+         * the following code gets executed when an auth error has occurred
          * we should refresh the token if possible and return a new auth state
-         * If refrsh fails, we should log out
+         * If refresh fails, we should log out
          **/
 
         // if your refresh logic is in graphQL, you must use this mutate function to call it
@@ -125,8 +125,8 @@ import { errorExchange } from 'urql';
 
 // this needs to be placed ABOVE the authExchange in the exchanges array, otherwise the auth error will show up hear before the auth exchange has had the chance to handle it
 errorExchange({
-  onError: ({ error }) => {
-    // we only get an auth error here when the auth excahnge had attempted to refresh auth and getting an auth error again for the second time
+  onError: (error) => {
+    // we only get an auth error here when the auth exchange had attempted to refresh auth and getting an auth error again for the second time
     const isAuthError = error.graphQLErrors.some(
       e => e.extensions?.code === 'FORBIDDEN',
     );


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

Just fixing some typos.

As for `errorExchange` change, typescript throws type error, so I presume that it should be changed too:
![image](https://user-images.githubusercontent.com/16621507/92627209-b4966d80-f2d3-11ea-816a-f68eab41ec98.png)
