### PR TITLE
(introspection) - Implement initial @urql/introspection package

### DIFF
--- a/docs/graphcache/schema-awareness.md
+++ b/docs/graphcache/schema-awareness.md
@@ -7,22 +7,26 @@ order: 4
 
 As mentioned in the docs we allow for the schema to be passed
 to the `cacheExchange`. This allows for partial results and deterministic
-fragment matching.
-With deterministic fragment matching we mean that if you use an interface
-or a union we will be 100% sure you're allowed to do so, therefore we'll check if the
-type you request can actually be returned from this union/interface.
+fragment matching. This schema argument is of type `IntrospectionQuery`, as JSON structure that
+describes your entire server-side `GraphQLSchema`.
+
+With deterministic fragment matching if we use an interface or a union _Graphcache_ can be 100% sure
+what the expected types and shape of the data must be and whether the match is permitted. It also
+enables a feature called ["Partial Results"](#partial-results).
 
 ## Getting your schema
 
-But how do you get this schema? Well let's consider some steps, first
-make sure `introspection` is turned on on your server. This is very crucial
-else your server won't allow the schema to be shown.
+But how do you get this introspected schema? The process of introspecting a schema is running an
+introspection query on the GraphQL API, which will give us our `IntrospectionQuery` result. So an
+introspection is just another query we can run against our GraphQL APIs or schemas.
 
-We can run a script that generates the introspection result like this:
+As long as `introspection` as turned on and permitted, we can download an introspectin schema by
+running a normal GraphQL query against the API and save the result in a JSON file.
 
 ```js
-// import a fetch library for node.
 import { getIntrospectionQuery } from 'graphql';
+import fetch from 'node-fetch'; // or your preferred request in Node.js
+import * as fs from 'fs';
 
 fetch('http://localhost:3000/graphql', {
   method: 'POST',
@@ -44,9 +48,73 @@ fetch('http://localhost:3000/graphql', {
   });
 ```
 
-## Integrating
+Alternatively, if you're already using [GraphQL Code Generator](https://graphql-code-generator.com/)
+you can use [their `@graphql-codegen/introspection`
+plugin](https://graphql-code-generator.com/docs/plugins/introspection) to do the same automatically
+against a local schema. Furthermore it's also possible to
+[`execute`](https://graphql.org/graphql-js/execution/#execute) the introspection query directly
+against your `GraphQLSchema`.
 
-next up we can just import this schema and add it to the cacheExchange:
+## Optimizing a schema
+
+An `IntrospectionQuery` JSON blob from a GraphQL API can without modification become quite large.
+The shape of this data is `{ "__schema": ... }` and this _schema_ data will contain information on
+all directives, types, input objects, scalars, deprecation, enums, and more. This can quickly add up and one of the
+largest schemas, the GitHub GraphQL API's schema, has an introspection size of about 1.1MB, or about
+50KB gzipped.
+
+However, we can use the `@urql/introspection` package's `minifyIntrospectionQuery` helper to reduce
+the size of this introspection data. This helper strips out information on directives, scalars,
+input types, deprecation, enums, and redundant fields to only leave information that _Graphcache_
+actually requires.
+
+In the example of the GitHub GraphQL API this reduces the introspected data to around 20kB gzipped,
+which is much more acceptable.
+
+### Installation & Setup
+
+First, install the `@urql/introspection` package:
+
+```sh
+yarn add @urql/introspection
+# or
+npm install --save @urql/introspection
+```
+
+You'll then need to integrate it into your introspection script or in another place where it can
+optimise the introspection data. For this example, we'll just add it to the fetching script from
+[above](#getting-your-schema).
+
+```js
+import { getIntrospectionQuery } from 'graphql';
+import fetch from 'node-fetch'; // or your preferred request in Node.js
+import * as fs from 'fs';
+
+import { getIntrospectedSchema, minifyIntrospectionQuery } from '@urql/introspection';
+
+fetch('http://localhost:3000/graphql', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    variables: {},
+    query: getIntrospectionQuery({ descriptions: false }),
+  }),
+})
+  .then(result => result.json())
+  .then(({ data }) => {
+    const minified = minifyIntrospectionQuery(getIntrospectedSchema(data));
+    fs.writeFile('./schema.json', JSON.stringify(minified));
+  });
+```
+
+The `getIntrospectionQuery` doesn't only accept `IntrospectionQuery` JSON data as inputs, but also
+allows you to pass a JSON string, `GraphQLSchema`, or GraphQL Schema SDL strings. It's a convenience
+helper and not needed in the above example.
+
+## Integrating a schema
+
+Once we have a schema that's already saved to a JSON file, we can load it and pass it to the
+`cacheExchange`'s `schema` option:
 
 ```js
 import schema from './schema.json';
@@ -54,12 +122,31 @@ import schema from './schema.json';
 const cache = cacheExchange({ schema });
 ```
 
-So what benefits do we have now that graphCache is aware of the shape of our schema?
+It may be worth checking what your bundler or framework does when you import a JSON file. Typically
+you can reduce the parsing time by making sure it's turned into a string and parsed using
+`JSON.parse`
 
-### Partial results
+**What do we get from adding the schema to _Graphcache_?**
 
-Let's approach this with the example from [Computed queries](./computed-queries.md#resolve) we have
-our `TodosQuery` result (a list) and now we want to get a specific `Todo` we wire these up through
-`resolve` but we are missing an optional field for this, without a schema we don't know this is optional
-and we will not show you the partial result. Now that we have a schema we can check if this is allowed to
-be left out, we'll return you the entity and fetch the missing properties in the background.
+### Partial Results
+
+Once _Schema Awareness_ is activated in _Graphcache_, it can use the schema to check which fields
+and lists are marked as optional fields. This is then used to delivery partial results when
+possible, which means that different queries may give you partial data where some uncached fields
+have been replaced with `null`, while loading more data in the background, instead of our apps
+having to wait for all data to be available.
+
+Let's approach this with the example from ["Computed Queries"](./computed-queries.md#resolve): We
+have our `TodosQuery` result which loads a list, and our app may want to get a specific `Todo` when
+the app transitions to a details page. We may have already written a resolver that tells
+_Graphcache_ what `Query.todo` does, but it may be missing some optional field to actuall give us
+the full detailed `Todo`.
+
+Without a schema _Graphcache_ would assume that because some fields are uncached and missing, it
+can't serve this query's data. But if it has a schema, it may see that the uncached fields are
+optional anyway and it can return a partial result for the `Todo` while it's fetching the full query
+in the background, which in the `OperationResult` also causes `stale` to be set to `true`.
+
+This means that _Schema Awareness_ can enable us to create apps that can display already cached data
+on page transitions, while the page's full data loads in the background, which can often feel much
+faster to the user.

--- a/docs/graphcache/schema-awareness.md
+++ b/docs/graphcache/schema-awareness.md
@@ -103,7 +103,7 @@ fetch('http://localhost:3000/graphql', {
   .then(result => result.json())
   .then(({ data }) => {
     const minified = minifyIntrospectionQuery(getIntrospectedSchema(data));
-    fs.writeFile('./schema.json', JSON.stringify(minified));
+    fs.writeFileSync('./schema.json', JSON.stringify(minified));
   });
 ```
 

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1,10 +1,12 @@
 import gql from 'graphql-tag';
+
 import {
   createClient,
   ExchangeIO,
   Operation,
   OperationResult,
 } from '@urql/core';
+
 import {
   Source,
   pipe,
@@ -18,6 +20,8 @@ import {
   publish,
   delay,
 } from 'wonka';
+
+import { minifyIntrospectionQuery } from '@urql/introspection';
 import { cacheExchange } from './cacheExchange';
 
 const queryOne = gql`
@@ -1412,8 +1416,10 @@ describe('schema awareness', () => {
 
     pipe(
       cacheExchange({
-        // eslint-disable-next-line
-        schema: require('./test-utils/simple_schema.json'),
+        schema: minifyIntrospectionQuery(
+          // eslint-disable-next-line
+          require('./test-utils/simple_schema.json')
+        ),
       })({ forward, client, dispatchDebug })(ops$),
       tap(result),
       publish

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -1,5 +1,9 @@
-import { Store } from '../store';
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 import gql from 'graphql-tag';
+import { minifyIntrospectionQuery } from '@urql/introspection';
+
+import { Store } from '../store';
 import { write } from './write';
 import { query } from './query';
 
@@ -24,8 +28,12 @@ describe('Query', () => {
   let schema, store, alteredRoot;
 
   beforeAll(() => {
-    schema = require('../test-utils/simple_schema.json');
-    alteredRoot = require('../test-utils/altered_root_schema.json');
+    schema = minifyIntrospectionQuery(
+      require('../test-utils/simple_schema.json')
+    );
+    alteredRoot = minifyIntrospectionQuery(
+      require('../test-utils/altered_root_schema.json')
+    );
   });
 
   beforeEach(() => {

--- a/exchanges/graphcache/src/operations/write.test.ts
+++ b/exchanges/graphcache/src/operations/write.test.ts
@@ -1,4 +1,8 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 import gql from 'graphql-tag';
+import { minifyIntrospectionQuery } from '@urql/introspection';
+
 import { write } from './write';
 import * as InMemoryData from '../store/data';
 import { Store } from '../store';
@@ -24,7 +28,9 @@ describe('Query', () => {
   let schema, store;
 
   beforeAll(() => {
-    schema = require('../test-utils/simple_schema.json');
+    schema = minifyIntrospectionQuery(
+      require('../test-utils/simple_schema.json')
+    );
   });
 
   beforeEach(() => {

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -1,5 +1,9 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 import gql from 'graphql-tag';
+import { minifyIntrospectionQuery } from '@urql/introspection';
 import { mocked } from 'ts-jest/utils';
+
 import { Data, StorageAdapter } from '../types';
 import { query } from '../operations/query';
 import { write, writeOptimistic } from '../operations/write';
@@ -115,7 +119,9 @@ describe('Store with UpdatesConfig', () => {
 
   it('should not warn if Mutation/Subscription operations do exist in the schema', function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       updates: {
         Mutation: {
           toggleTodo: noop,
@@ -131,7 +137,9 @@ describe('Store with UpdatesConfig', () => {
 
   it("should warn if Mutation operations don't exist in the schema", function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       updates: {
         Mutation: {
           doTheChaChaSlide: noop,
@@ -149,7 +157,9 @@ describe('Store with UpdatesConfig', () => {
 
   it("should warn if Subscription operations don't exist in the schema", function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       updates: {
         Subscription: {
           someoneDidTheChaChaSlide: noop,
@@ -186,7 +196,9 @@ describe('Store with KeyingConfig', () => {
 
   it('should not warn if keys do exist in the schema', function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       keys: {
         Todo: () => 'Todo',
       },
@@ -197,7 +209,9 @@ describe('Store with KeyingConfig', () => {
 
   it("should warn if a key doesn't exist in the schema", function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       keys: {
         Todo: () => 'todo',
         NotInSchema: () => 'foo',
@@ -236,7 +250,9 @@ describe('Store with ResolverConfig', () => {
 
   it('should not warn if resolvers do exist in the schema', function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       resolvers: {
         Query: {
           latestTodo: () => 'todo',
@@ -254,7 +270,9 @@ describe('Store with ResolverConfig', () => {
 
   it("should warn if a Query doesn't exist in the schema", function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       resolvers: {
         Query: {
           todos: () => ['todo 1', 'todo 2'],
@@ -274,7 +292,9 @@ describe('Store with ResolverConfig', () => {
 
   it("should warn if a type doesn't exist in the schema", function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       resolvers: {
         Todo: {
           complete: () => true,
@@ -296,7 +316,9 @@ describe('Store with ResolverConfig', () => {
 
   it("should warn if a type's property doesn't exist in the schema", function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       resolvers: {
         Todo: {
           complete: () => true,
@@ -783,7 +805,9 @@ describe('Store with storage', () => {
 
   it("should warn if an optimistic field doesn't exist in the schema's mutations", function () {
     new Store({
-      schema: require('../test-utils/simple_schema.json'),
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
       updates: {
         Mutation: {
           toggleTodo: noop,
@@ -805,6 +829,7 @@ describe('Store with storage', () => {
   });
 
   it('should not warn for an introspection result root', function () {
+    // NOTE: Do not wrap this require in `minifyIntrospectionQuery`!
     // eslint-disable-next-line
     const schema = require('../test-utils/simple_schema.json');
     const store = new Store({ schema });

--- a/packages/introspection/CHANGELOG.md
+++ b/packages/introspection/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @urql/introspection
+
+## 0.1.0
+
+**Initial Release**

--- a/packages/introspection/README.md
+++ b/packages/introspection/README.md
@@ -1,0 +1,3 @@
+<h2 align="center">@urql/introspection</h2>
+
+<p align="center"><strong>Utilities for dealing with Introspection Queries and Client Schemas</strong></p>

--- a/packages/introspection/package.json
+++ b/packages/introspection/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@urql/introspection",
+  "version": "0.1.0",
+  "description": "Utilities for dealing with Introspection Queries and Client Schemas",
+  "sideEffects": false,
+  "homepage": "https://formidable.com/open-source/urql/docs/",
+  "bugs": "https://github.com/FormidableLabs/urql/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/urql.git",
+    "directory": "packages/introspection"
+  },
+  "keywords": [
+    "graphql client",
+    "graphql schema",
+    "schema",
+    "formidablelabs"
+  ],
+  "main": "dist/urql-introspection",
+  "module": "dist/urql-introspection.mjs",
+  "types": "dist/types/index.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/urql-introspection.mjs",
+      "require": "./dist/urql-introspection.js",
+      "types": "./dist/types/index.d.ts",
+      "source": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist/"
+  ],
+  "scripts": {
+    "test": "jest",
+    "clean": "rimraf dist",
+    "check": "tsc --noEmit",
+    "lint": "eslint --ext=js,jsx,ts,tsx .",
+    "build": "rollup -c ../../scripts/rollup/config.js",
+    "prepare": "node ../../scripts/prepare/index.js",
+    "prepublishOnly": "run-s clean build"
+  },
+  "jest": {
+    "preset": "../../scripts/jest/preset"
+  },
+  "devDependencies": {
+    "graphql": "^15.1.0",
+    "graphql-tag": "^2.10.1"
+  },
+  "peerDependencies": {
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+  },
+  "dependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/introspection/src/getIntrospectedSchema.ts
+++ b/packages/introspection/src/getIntrospectedSchema.ts
@@ -1,0 +1,37 @@
+import {
+  IntrospectionQuery,
+  GraphQLSchema,
+  parse,
+  buildSchema,
+  executeSync,
+  getIntrospectionQuery,
+} from 'graphql';
+
+export const getIntrospectedSchema = (
+  input: string | IntrospectionQuery | GraphQLSchema
+): IntrospectionQuery => {
+  if (typeof input === 'string') {
+    try {
+      input = JSON.parse(input);
+    } catch (_error) {
+      input = buildSchema(input as string);
+    }
+  }
+
+  if (typeof input === 'object' && '__schema' in input) {
+    return input;
+  }
+
+  const initialIntrospection = executeSync({
+    document: parse(getIntrospectionQuery({ descriptions: false })),
+    schema: input as GraphQLSchema,
+  });
+
+  if (!initialIntrospection.data || !initialIntrospection.data.__schema) {
+    throw new TypeError(
+      'GraphQL could not generate an IntrospectionQuery from the given schema.'
+    );
+  }
+
+  return initialIntrospection.data as IntrospectionQuery;
+};

--- a/packages/introspection/src/index.ts
+++ b/packages/introspection/src/index.ts
@@ -1,0 +1,2 @@
+export * from './getIntrospectedSchema';
+export * from './minifyIntrospectionQuery';

--- a/packages/introspection/src/minifyIntrospectionQuery.ts
+++ b/packages/introspection/src/minifyIntrospectionQuery.ts
@@ -88,14 +88,18 @@ const minifyIntrospectionType = (
                 })),
             } as any)
         ),
-        interfaces: type.interfaces.map(int => ({
-          kind: 'INTERFACE',
-          name: int.name,
-        })),
-        possibleTypes: type.possibleTypes.map(type => ({
-          kind: type.kind,
-          name: type.name,
-        })),
+        interfaces:
+          type.interfaces &&
+          type.interfaces.map(int => ({
+            kind: 'INTERFACE',
+            name: int.name,
+          })),
+        possibleTypes:
+          type.possibleTypes &&
+          type.possibleTypes.map(type => ({
+            kind: type.kind,
+            name: type.name,
+          })),
       };
     }
 
@@ -134,6 +138,8 @@ export const minifyIntrospectionQuery = (
         type.kind === 'UNION'
     )
     .map(minifyIntrospectionType);
+
+  minifiedTypes.push({ kind: 'SCALAR', name: anyType.name });
 
   return {
     __schema: {

--- a/packages/introspection/src/minifyIntrospectionQuery.ts
+++ b/packages/introspection/src/minifyIntrospectionQuery.ts
@@ -1,0 +1,147 @@
+import {
+  IntrospectionQuery,
+  IntrospectionType,
+  IntrospectionTypeRef,
+} from 'graphql';
+
+const anyType: IntrospectionTypeRef = {
+  kind: 'SCALAR',
+  name: 'Any',
+};
+
+const mapType = (
+  fromType: any,
+  toType: IntrospectionTypeRef
+): IntrospectionTypeRef => {
+  switch (fromType.kind) {
+    case 'NON_NULL':
+    case 'LIST':
+      return {
+        kind: fromType.kind,
+        ofType: mapType(fromType.ofType, toType),
+      };
+
+    case 'SCALAR':
+    case 'INPUT_OBJECT':
+    case 'ENUM':
+      return toType;
+
+    case 'OBJECT':
+    case 'INTERFACE':
+    case 'UNION':
+      return {
+        kind: fromType.kind,
+        name: fromType.name,
+      };
+
+    default:
+      throw new TypeError(
+        `Unrecognized type reference of type: ${(fromType as any).kind}.`
+      );
+  }
+};
+
+const minifyIntrospectionType = (
+  type: IntrospectionType
+): IntrospectionType => {
+  switch (type.kind) {
+    case 'OBJECT': {
+      return {
+        kind: 'OBJECT',
+        name: type.name,
+        fields: type.fields.map(
+          field =>
+            ({
+              name: field.name,
+              type: field.type && mapType(field.type, anyType),
+              args:
+                field.args &&
+                field.args.map(arg => ({
+                  ...arg,
+                  type: mapType(arg.type, anyType),
+                  defaultValue: undefined,
+                })),
+            } as any)
+        ),
+        interfaces: type.interfaces.map(int => ({
+          kind: 'INTERFACE',
+          name: int.name,
+        })),
+      };
+    }
+
+    case 'INTERFACE': {
+      return {
+        kind: 'INTERFACE',
+        name: type.name,
+        fields: type.fields.map(
+          field =>
+            ({
+              name: field.name,
+              type: field.type && mapType(field.type, anyType),
+              args:
+                field.args &&
+                field.args.map(arg => ({
+                  ...arg,
+                  type: mapType(arg.type, anyType),
+                  defaultValue: undefined,
+                })),
+            } as any)
+        ),
+        interfaces: type.interfaces.map(int => ({
+          kind: 'INTERFACE',
+          name: int.name,
+        })),
+        possibleTypes: type.possibleTypes.map(type => ({
+          kind: type.kind,
+          name: type.name,
+        })),
+      };
+    }
+
+    case 'UNION': {
+      return {
+        kind: 'UNION',
+        name: type.name,
+        possibleTypes: type.possibleTypes.map(type => ({
+          kind: type.kind,
+          name: type.name,
+        })),
+      };
+    }
+
+    default:
+      return type;
+  }
+};
+
+export const minifyIntrospectionQuery = (
+  schema: IntrospectionQuery
+): IntrospectionQuery => {
+  if (!schema || !('__schema' in schema)) {
+    throw new TypeError('Expected to receive an IntrospectionQuery.');
+  }
+
+  const {
+    __schema: { queryType, mutationType, subscriptionType, types },
+  } = schema;
+
+  const minifiedTypes = types
+    .filter(
+      type =>
+        type.kind === 'OBJECT' ||
+        type.kind === 'INTERFACE' ||
+        type.kind === 'UNION'
+    )
+    .map(minifyIntrospectionType);
+
+  return {
+    __schema: {
+      queryType,
+      mutationType,
+      subscriptionType,
+      types: minifiedTypes,
+      directives: [],
+    },
+  };
+};

--- a/packages/introspection/src/minifyIntrospectionQuery.ts
+++ b/packages/introspection/src/minifyIntrospectionQuery.ts
@@ -63,10 +63,12 @@ const minifyIntrospectionType = (
                 })),
             } as any)
         ),
-        interfaces: type.interfaces.map(int => ({
-          kind: 'INTERFACE',
-          name: int.name,
-        })),
+        interfaces:
+          type.interfaces &&
+          type.interfaces.map(int => ({
+            kind: 'INTERFACE',
+            name: int.name,
+          })),
       };
     }
 

--- a/packages/introspection/tsconfig.json
+++ b/packages/introspection/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "urql": ["../../node_modules/urql/src"],
+      "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/core/*": ["../../node_modules/@urql/core/src/*"],
+      "@urql/*": ["../../node_modules/@urql/*/src"]
+    }
+  }
+}


### PR DESCRIPTION
Related #974

The new `@urql/introspection` utilities aim to contain all kinds of functions that may be used to treat client-side GraphQL schemas, currently: to minify them. This may be used to minify an `IntrospectionQuery` to get it down to a minimum possible size.

This has been tested against the GitHub GraphQL API schema and it brings it down from `49.4kB` minzipped to `29.6kB` minzipped. The uncompressed sizes are `1.1MB` and `551KB`.

We've determined that it's _not_ effective to translate the GraphQL Introspection Query to a schema string and turning that back to a `GraphQLSchema`. The reduction is about a third of size, but this does pull in about 15-20KB more from `graphql`. Since we're dealing with a worst-case scenario sized schema here, this doesn't seem worth it, since that extra code increases the parsing time much more (including the GraphQL schema parsing time) than pure JSON.