### PR TITLE
(chore) - fix circleci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <br />
   <br />
   <a href="https://circleci.com/gh/FormidableLabs/urql">
-    <img alt="Test Status" src="https://badgen.net/github/status/FormidableLabs/urql/master/ci/circleci?label=circleci" />
+    <img alt="Test Status" src="https://badgen.net/github/status/FormidableLabs/urql/main/ci/circleci?label=circleci" />
   </a>
   <a href="https://github.com/FormidableLabs/urql#maintenance-status">
     <img alt="Maintenance Status" src="https://badgen.net/badge/maintenance/active/green" />


### PR DESCRIPTION
Just noticed the CircleCI badge wasn't showing up, because it was still pointing to the `master` branch, which we no longer have.