### PR TITLE
allow use of generics in the cacheExchange

### DIFF
--- a/.changeset/itchy-lamps-obey.md
+++ b/.changeset/itchy-lamps-obey.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Allow use of a generic when creating the cacheExchange and the offlineExchange, this also fixes an issue where alternative mutation typenames would not work in our updaters config.

--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -1,16 +1,16 @@
 {
   "name": "urql-exchange-graphcache-default-storage",
   "private": true,
-  "main": "../dist/urql-exchange-graphcache-default-storage",
-  "module": "../dist/urql-exchange-graphcache-default-storage.mjs",
-  "types": "../dist/types/default-storage/index.d.ts",
-  "source": "../src/default-storage/index.ts",
+  "main": "..\\dist\\urql-exchange-graphcache-default-storage",
+  "module": "..\\dist\\urql-exchange-graphcache-default-storage.mjs",
+  "types": "..\\dist\\types\\default-storage\\index.d.ts",
+  "source": "..\\src\\default-storage\\index.ts",
   "exports": {
     ".": {
-      "import": "../dist/urql-exchange-graphcache-default-storage.mjs",
-      "require": "../dist/urql-exchange-graphcache-default-storage.js",
-      "types": "../dist/types/default-storage/index.d.ts",
-      "source": "../src/default-storage/index.ts"
+      "import": "..\\dist\\urql-exchange-graphcache-default-storage.mjs",
+      "require": "..\\dist\\urql-exchange-graphcache-default-storage.js",
+      "types": "..\\dist\\types\\default-storage\\index.d.ts",
+      "source": "..\\src\\default-storage\\index.ts"
     },
     "./package.json": "./package.json"
   },

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -73,21 +73,24 @@ const toRequestPolicy = (
   },
 });
 
-export interface CacheExchangeOpts {
-  updates?: Partial<UpdatesConfig>;
-  resolvers?: ResolverConfig;
-  optimistic?: OptimisticMutationConfig;
-  keys?: KeyingConfig;
+export interface CacheExchangeOpts<Updaters, Resolvers, Optimistic, Keys> {
+  updates?: Partial<Updaters>;
+  resolvers?: Resolvers;
+  optimistic?: Optimistic;
+  keys?: Keys;
   schema?: IntrospectionQuery;
   storage?: StorageAdapter;
 }
 
-export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
-  forward,
-  client,
-  dispatchDebug,
-}) => {
-  const store = new Store(opts);
+export const cacheExchange = <
+  Updaters = UpdatesConfig,
+  Resolvers = ResolverConfig,
+  Optimistic = OptimisticMutationConfig,
+  Keys = KeyingConfig
+>(
+  opts?: CacheExchangeOpts<Updaters, Resolvers, Optimistic, Keys>
+): Exchange => ({ forward, client, dispatchDebug }) => {
+  const store = new Store<Updaters, Resolvers, Optimistic, Keys>(opts);
 
   let hydration: void | Promise<void>;
   if (opts && opts.storage) {

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -20,7 +20,13 @@ import {
 } from './ast';
 
 import { makeDict } from './helpers/dict';
-import { OptimisticMutationConfig, Variables } from './types';
+import {
+  OptimisticMutationConfig,
+  Variables,
+  UpdatesConfig,
+  ResolverConfig,
+  KeyingConfig,
+} from './types';
 import { cacheExchange, CacheExchangeOpts } from './cacheExchange';
 
 /** Determines whether a given query contains an optimistic mutation field */
@@ -58,11 +64,14 @@ const isOfflineError = (error: undefined | CombinedError) =>
       error.networkError.message
     ));
 
-export const offlineExchange = (opts: CacheExchangeOpts): Exchange => ({
-  forward: outerForward,
-  client,
-  dispatchDebug,
-}) => {
+export const offlineExchange = <
+  Updaters = UpdatesConfig,
+  Resolvers = ResolverConfig,
+  Optimistic = OptimisticMutationConfig,
+  Keys = KeyingConfig
+>(
+  opts: CacheExchangeOpts<Updaters, Resolvers, Optimistic, Keys>
+): Exchange => ({ forward: outerForward, client, dispatchDebug }) => {
   const { storage } = opts;
   let forward = outerForward;
 

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -828,6 +828,45 @@ describe('Store with storage', () => {
     expect(warnMessage).toContain('https://bit.ly/2XbVrpR#24');
   });
 
+  it('should use different rootConfigs', function () {
+    const fakeUpdater = jest.fn();
+
+    const store = new Store({
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
+      updates: {
+        Mutation: {
+          toggleTodo: fakeUpdater,
+        },
+      },
+    });
+
+    const mutationData = {
+      __typename: 'mutation_root',
+      toggleTodo: {
+        __typename: 'Todo',
+        id: 1,
+      },
+    };
+    write(store, { query: Todos }, todosData);
+    write(
+      store,
+      {
+        query: gql`
+          mutation {
+            toggleTodo(id: 1) {
+              id
+            }
+          }
+        `,
+      },
+      mutationData
+    );
+
+    expect(fakeUpdater).toBeCalledTimes(1);
+  });
+
   it('should not warn for an introspection result root', function () {
     // NOTE: Do not wrap this require in `minifyIntrospectionQuery`!
     // eslint-disable-next-line

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -30,12 +30,7 @@ import * as SchemaPredicates from '../ast/schemaPredicates';
 
 type RootField = 'query' | 'mutation' | 'subscription';
 
-export interface StoreOpts<
-  Updaters = UpdatesConfig,
-  Resolvers = ResolverConfig,
-  Optimistic = OptimisticMutationConfig,
-  Keys = KeyingConfig
-> {
+export interface StoreOpts<Updaters, Resolvers, Optimistic, Keys> {
   updates?: Partial<Updaters>;
   resolvers?: Resolvers;
   optimistic?: Optimistic;
@@ -43,7 +38,12 @@ export interface StoreOpts<
   schema?: IntrospectionQuery;
 }
 
-export class Store<Updaters, Resolvers, Optimistic, Keys> implements Cache {
+export class Store<
+  Updaters = UpdatesConfig,
+  Resolvers = ResolverConfig,
+  Optimistic = OptimisticMutationConfig,
+  Keys = KeyingConfig
+> implements Cache {
   data: InMemoryData.InMemoryData;
 
   resolvers: ResolverConfig;

--- a/exchanges/graphcache/src/test-utils/altered_root_schema.json
+++ b/exchanges/graphcache/src/test-utils/altered_root_schema.json
@@ -5,7 +5,8 @@
       "__typename": "__Type"
     },
     "mutationType": {
-      "name": "Mutation"
+      "name": "mutation_root",
+      "__typename": "__Type"
     },
     "subscriptionType": null,
     "types": [
@@ -160,7 +161,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "Mutation",
+        "name": "mutation_root",
         "fields": [
           {
             "name": "toggleTodo",


### PR DESCRIPTION
## Summary

Adds generic typings to the cacheExchange and add support for alternative mutation types.

This issue was found by a [Spectrum user](https://spectrum.chat/urql/help/typenames-for-root-types-in-schema-json~4b01bc46-8315-4aaa-ae56-9d06b049e215)

The goal would be to automatically generate these generics from the graphql-schema later one with a tool like graphql-code-generator.

## Set of changes

- Can now use `cacheExchange<UpdaterConfig, ...>`
- We support alternative mutation typenames on the updatersConfig now