### PR TITLE
Update CircleCI to skip install on cache hit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,32 +5,22 @@ executors:
     docker:
       - image: circleci/node:12-buster
 
-aliases:
-  - &node_modules
-    attach_workspace:
-      at: .
-
 jobs:
   setup:
     executor: node
     steps:
       - checkout
       - restore_cache:
-          name: Restore Yarn cache
           keys:
-            - yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - yarn-{{ .Branch }}-
-            - yarn-main-
+            - module_cache-{{ checksum "yarn.lock" }}
+      - run:
+          name: Check for dependencies
+          command: "([[ -d node_modules ]] && circleci-agent step halt) || exit 0"
       - run:
           name: Install Packages
           command: yarn --frozen-lockfile --non-interactive
       - save_cache:
-          name: Save Yarn cache
-          key: yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-      - persist_to_workspace:
-          root: .
+          key: module_cache-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
 
@@ -38,7 +28,9 @@ jobs:
     executor: node
     steps:
       - checkout
-      - *node_modules
+      - restore_cache:
+          keys:
+            - module_cache-{{ checksum "yarn.lock" }}
       - run:
           name: TypeScript
           command: yarn run check
@@ -54,7 +46,9 @@ jobs:
     parallelism: 4
     steps:
       - checkout
-      - *node_modules
+      - restore_cache:
+          keys:
+            - module_cache-{{ checksum "yarn.lock" }}
       - run:
           name: Build
           command: yarn run build
@@ -63,7 +57,9 @@ jobs:
     executor: node
     steps:
       - checkout
-      - *node_modules
+      - restore_cache:
+          keys:
+            - module_cache-{{ checksum "yarn.lock" }}
       - run:
           name: Build Staging Site
           command: |
@@ -82,7 +78,9 @@ jobs:
           name: Install AWS CLI
           command: sudo apt-get -y -qq install awscli
       - checkout
-      - *node_modules
+      - restore_cache:
+          keys:
+            - module_cache-{{ checksum "yarn.lock" }}
       - run:
           name: Build Production Site
           command: |


### PR DESCRIPTION
## About

Skips the install step if a cache for the current lockfile exists

[First run](https://app.circleci.com/pipelines/github/FormidableLabs/urql/1972/workflows/5c23d493-bc3a-4981-b76b-96ca01d2a7e1/jobs/7443)
[Cache hit](https://app.circleci.com/pipelines/github/FormidableLabs/urql/1972/workflows/f37c0819-38ac-45d1-809b-61867bdc2799/jobs/7447)

---

Heads up - I haven't looked too deeply into how this affects imports with yarn workspaces. Might need some tweaks