### PR TITLE
(graphcache) Fix updates config for renamed root schema types

### DIFF
--- a/.changeset/four-pigs-kneel.md
+++ b/.changeset/four-pigs-kneel.md
@@ -1,0 +1,7 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix updaters config not working when Mutation/Subscription root names were altered.
+For instance, a Mutation named `mutation_root` could cause `store.updates` to be misread and cause a
+runtime error.

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -151,8 +151,8 @@ export function expectValidUpdatesConfig(
 
   const mutation = schema.getMutationType();
   const subscription = schema.getSubscriptionType();
-  const mutationFields = mutation?.getFields() || {};
-  const subscriptionFields = subscription?.getFields() || {};
+  const mutationFields = mutation ? mutation.getFields() : {};
+  const subscriptionFields = subscription ? subscription.getFields() : {};
   const givenMutations = (mutation && updates[mutation.name]) || {};
   const givenSubscription = (subscription && updates[subscription.name]) || {};
 

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -828,6 +828,45 @@ describe('Store with storage', () => {
     expect(warnMessage).toContain('https://bit.ly/2XbVrpR#24');
   });
 
+  it('should use different rootConfigs', function () {
+    const fakeUpdater = jest.fn();
+
+    const store = new Store({
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/altered_root_schema.json')
+      ),
+      updates: {
+        Mutation: {
+          toggleTodo: fakeUpdater,
+        },
+      },
+    });
+
+    const mutationData = {
+      __typename: 'mutation_root',
+      toggleTodo: {
+        __typename: 'Todo',
+        id: 1,
+      },
+    };
+    write(store, { query: Todos }, todosData);
+    write(
+      store,
+      {
+        query: gql`
+          mutation {
+            toggleTodo(id: 1) {
+              id
+            }
+          }
+        `,
+      },
+      mutationData
+    );
+
+    expect(fakeUpdater).toBeCalledTimes(1);
+  });
+
   it('should not warn for an introspection result root', function () {
     // NOTE: Do not wrap this require in `minifyIntrospectionQuery`!
     // eslint-disable-next-line

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -66,9 +66,11 @@ export class Store implements Cache {
       const queryType = schema.getQueryType();
       const mutationType = schema.getMutationType();
       const subscriptionType = schema.getSubscriptionType();
-      if (queryType) queryName = queryType.name;
-      if (mutationType) mutationName = mutationType.name;
-      if (subscriptionType) subscriptionName = subscriptionType.name;
+      queryName = queryType ? queryType.name : queryName;
+      mutationName = mutationType ? mutationType.name : mutationName;
+      subscriptionName = subscriptionType
+        ? subscriptionType.name
+        : subscriptionName;
     }
 
     this.updates = {

--- a/exchanges/graphcache/src/test-utils/altered_root_schema.json
+++ b/exchanges/graphcache/src/test-utils/altered_root_schema.json
@@ -5,7 +5,8 @@
       "__typename": "__Type"
     },
     "mutationType": {
-      "name": "Mutation"
+      "name": "mutation_root",
+      "__typename": "__Type"
     },
     "subscriptionType": null,
     "types": [
@@ -160,7 +161,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "Mutation",
+        "name": "mutation_root",
         "fields": [
           {
             "name": "toggleTodo",


### PR DESCRIPTION
###  Summary

When the schema contained differently named root types, e.g. `root_mutation` instead of just `Mutation` the `store.updates` config would be malformed and would even at times cause runtime crashes. This is now fixed by reformatting the `updates` config to contain the correct keys.

## Set of changes

- Use actual root names in `store.updates` keys
- Update schema predicates to use new updates
- Simplify schema predicates calls in `store.ts`
