### PR TITLE
(graphcache) - Fix offline queries not delivering any results on cache-miss and offline

### DIFF
--- a/.changeset/pretty-pans-doubt.md
+++ b/.changeset/pretty-pans-doubt.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix operation results being obstructed by the `offlineExchange` when the network request has failed due to being offline and no cache result has been issued. Instead the `offlineExchange` will now retry with `cache-only` policy

--- a/docs/graphcache/offline.md
+++ b/docs/graphcache/offline.md
@@ -12,9 +12,6 @@ Updates](./custom-updates.md#optimistic-updates) this can be used to build an ap
 serves cached data entirely from memory when a user's device is offline and still display
 optimistically executed mutations.
 
-> **NOTE:** Offline Support is currently experimental! It hasn't been extensively tested yet and
-> may not always behave as expected. Please try it out with caution!
-
 ## Setup
 
 Everything that's needed to set up offline-support is already packaged in the

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -27,6 +27,7 @@ import {
 
 import { query, write, writeOptimistic } from './operations';
 import { makeDict, isDictEmpty } from './helpers/dict';
+import { addCacheOutcome, toRequestPolicy } from './helpers/operation';
 import { filterVariables, getMainOperation } from './ast';
 import { Store, noopDataState, hydrateData, reserveLayer } from './store';
 
@@ -48,30 +49,6 @@ type Operations = Set<number>;
 type OperationMap = Map<number, Operation>;
 type OptimisticDependencies = Map<number, Dependencies>;
 type DependentOperations = Record<string, number[]>;
-
-// Returns the given operation result with added cacheOutcome meta field
-const addCacheOutcome = (op: Operation, outcome: CacheOutcome): Operation => ({
-  ...op,
-  context: {
-    ...op.context,
-    meta: {
-      ...op.context.meta,
-      cacheOutcome: outcome,
-    },
-  },
-});
-
-// Copy an operation and change the requestPolicy to skip the cache
-const toRequestPolicy = (
-  operation: Operation,
-  requestPolicy: RequestPolicy
-): Operation => ({
-  ...operation,
-  context: {
-    ...operation.context,
-    requestPolicy,
-  },
-});
 
 export interface CacheExchangeOpts {
   updates?: Partial<UpdatesConfig>;

--- a/exchanges/graphcache/src/helpers/operation.ts
+++ b/exchanges/graphcache/src/helpers/operation.ts
@@ -1,0 +1,28 @@
+import { Operation, RequestPolicy, CacheOutcome } from '@urql/core';
+
+// Returns the given operation result with added cacheOutcome meta field
+export const addCacheOutcome = (
+  op: Operation,
+  outcome: CacheOutcome
+): Operation => ({
+  ...op,
+  context: {
+    ...op.context,
+    meta: {
+      ...op.context.meta,
+      cacheOutcome: outcome,
+    },
+  },
+});
+
+// Copy an operation and change the requestPolicy to skip the cache
+export const toRequestPolicy = (
+  operation: Operation,
+  requestPolicy: RequestPolicy
+): Operation => ({
+  ...operation,
+  context: {
+    ...operation.context,
+    requestPolicy,
+  },
+});

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -192,7 +192,7 @@ describe('offline', () => {
     });
   });
 
-  it('should intercept errored queries', () => {
+  it('should intercept errored queries', async () => {
     const client = createClient({ url: 'http://0.0.0.0' });
     const onlineSpy = jest
       .spyOn(navigator, 'onLine', 'get')
@@ -229,6 +229,10 @@ describe('offline', () => {
     );
 
     next(queryOp);
+    expect(result).toBeCalledTimes(0);
+    expect(response).toBeCalledTimes(1);
+
+    await Promise.resolve();
     expect(result).toBeCalledTimes(1);
     expect(response).toBeCalledTimes(1);
 

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -197,7 +197,6 @@ describe('offline', () => {
     const onlineSpy = jest
       .spyOn(navigator, 'onLine', 'get')
       .mockReturnValueOnce(false);
-    const reexecuteOperation = jest.spyOn(client, 'reexecuteOperation');
 
     const queryOp = client.createRequestOperation('query', {
       key: 1,
@@ -230,8 +229,20 @@ describe('offline', () => {
     );
 
     next(queryOp);
-    expect(result).toBeCalledTimes(0);
-    expect(reexecuteOperation).toBeCalledTimes(1);
+    expect(result).toBeCalledTimes(1);
+    expect(response).toBeCalledTimes(1);
+
+    expect(result.mock.calls[0][0]).toEqual({
+      data: null,
+      error: undefined,
+      extensions: undefined,
+      operation: expect.any(Object),
+    });
+
+    expect(result.mock.calls[0][0]).toHaveProperty(
+      'operation.context.meta.cacheOutcome',
+      'miss'
+    );
   });
 
   it('should flush the queue when we become online', () => {

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -22,6 +22,7 @@ import {
 import { makeDict } from './helpers/dict';
 import { OptimisticMutationConfig, Variables } from './types';
 import { cacheExchange, CacheExchangeOpts } from './cacheExchange';
+import { toRequestPolicy } from './helpers/operation';
 
 /** Determines whether a given query contains an optimistic mutation field */
 const isOptimisticMutation = (
@@ -112,12 +113,16 @@ export const offlineExchange = (opts: CacheExchangeOpts): Exchange => ({
               failedQueue.push(res.operation);
               updateMetadata();
               return false;
-            } else {
-              return true;
             }
-          } else {
-            return false;
+
+            return true;
           }
+
+          client.reexecuteOperation(
+            toRequestPolicy(res.operation, 'cache-only')
+          );
+
+          return false;
         })
       );
     };


### PR DESCRIPTION
## Summary

Previously when the user was offline and the cache would fail with a complete cache miss for offline queries then no result would be delivered to the client and instead would fetch infinitely. Instead the `offlineExchange` now retries with `cac he-only`.
