### PR TITLE
(chore) - Add ES5 linting and ensure polyfill-less ES5 support

### DIFF
--- a/.changeset/fuzzy-peas-shop.md
+++ b/.changeset/fuzzy-peas-shop.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix small pieces of code where polyfill-less ES5 usage was compromised. This was unlikely to have affected anyone in production as `Array.prototype.find` (the only usage of an ES6 method) is commonly used and polyfilled.

--- a/exchanges/graphcache/src/ast/traversal.ts
+++ b/exchanges/graphcache/src/ast/traversal.ts
@@ -20,18 +20,18 @@ const isFragmentNode = (node: DefinitionNode): node is FragmentDefinitionNode =>
 export const getMainOperation = (
   doc: DocumentNode
 ): OperationDefinitionNode => {
-  const operation = doc.definitions.find(
-    node => node.kind === Kind.OPERATION_DEFINITION
-  ) as OperationDefinitionNode;
+  for (let i = 0; i < doc.definitions.length; i++) {
+    if (doc.definitions[i].kind === Kind.OPERATION_DEFINITION) {
+      return doc.definitions[i] as OperationDefinitionNode;
+    }
+  }
 
   invariant(
-    !!operation,
+    false,
     'Invalid GraphQL document: All GraphQL documents must contain an OperationDefinition' +
       'node for a query, subscription, or mutation.',
     1
   );
-
-  return operation;
 };
 
 /** Returns a mapping from fragment names to their selections */

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-es5": "^1.5.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",

--- a/packages/next-urql/src/with-urql-client.tsx
+++ b/packages/next-urql/src/with-urql-client.tsx
@@ -60,6 +60,7 @@ export function withUrqlClient(
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return initUrqlClient(clientConfig, shouldBindGetInitialprops)!;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [urqlClient, urqlState, forceUpdate[0]]);
 
       const resetUrqlClient = () => {

--- a/packages/preact-urql/src/hooks/useMutation.ts
+++ b/packages/preact-urql/src/hooks/useMutation.ts
@@ -63,6 +63,7 @@ export const useMutation = <T = any, V = object>(
         return result;
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [client, query, setState]
   );
 

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -62,6 +62,7 @@ export function useMutation<T = any, V = object>(
         return result;
       });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [client, query, setState]
   );
 

--- a/scripts/eslint/common.js
+++ b/scripts/eslint/common.js
@@ -1,0 +1,49 @@
+module.exports = {
+  parserOptions: {
+    ecmaVersion: 9,
+    sourceType: 'module',
+    ecmaFeatures: {
+      modules: true,
+      jsx: true,
+    },
+  },
+  extends: [
+    'plugin:react/recommended',
+    'prettier',
+  ],
+  ignorePatterns: [
+    'node_modules/',
+    'dist/',
+    'build/',
+    'coverage/',
+    'benchmark/',
+    'example/',
+    'examples/',
+    'scripts/'
+  ],
+  plugins: [
+    'react-hooks',
+    'prettier',
+  ],
+  rules: {
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+    'react/no-children-prop': 'off',
+    'sort-keys': 'off',
+    'no-console': ['error', { allow: ['warn', 'error'] }],
+    'prefer-arrow/prefer-arrow-functions': 'off',
+
+    'prettier/prettier': ['error', {
+      singleQuote: true,
+      arrowParens: 'avoid',
+      trailingComma: 'es5',
+    }],
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+};

--- a/scripts/eslint/common.js
+++ b/scripts/eslint/common.js
@@ -24,6 +24,7 @@ module.exports = {
   plugins: [
     'react-hooks',
     'prettier',
+    'es5',
   ],
   rules: {
     'react-hooks/rules-of-hooks': 'error',
@@ -35,12 +36,37 @@ module.exports = {
     'no-console': ['error', { allow: ['warn', 'error'] }],
     'prefer-arrow/prefer-arrow-functions': 'off',
 
+    'es5/no-for-of': 'error',
+    'es5/no-generators': 'error',
+    'es5/no-typeof-symbol': 'error',
+    'es5/no-es6-methods': 'error',
+
+    'es5/no-es6-static-methods': ['error', {
+      exceptMethods: ['Object.assign']
+    }],
+
     'prettier/prettier': ['error', {
       singleQuote: true,
       arrowParens: 'avoid',
       trailingComma: 'es5',
     }],
   },
+
+  overrides: [
+    {
+      files: [
+        '*.test.ts',
+        '*.test.tsx',
+        '*.spec.ts',
+        '*.spec.tsx',
+      ],
+      rules: {
+        'es5/no-es6-methods': 'off',
+        'es5/no-es6-static-methods': 'off',
+      }
+    }
+  ],
+
   settings: {
     react: {
       version: 'detect',

--- a/scripts/eslint/js-preset.js
+++ b/scripts/eslint/js-preset.js
@@ -9,5 +9,6 @@ module.exports = {
     'react/jsx-key': 'off',
     'react/jsx-handler-names': 'off',
     'import/no-internal-modules': 'off',
+    'es5/no-es6-methods': 'off',
   },
 };

--- a/scripts/eslint/js-preset.js
+++ b/scripts/eslint/js-preset.js
@@ -1,54 +1,13 @@
 module.exports = {
-  parserOptions: {
-    ecmaVersion: 9,
-    sourceType: 'module',
-    ecmaFeatures: {
-      modules: true,
-      jsx: true,
-    },
-  },
   extends: [
-    'plugin:react/recommended',
+    './common.js',
     'plugin:import/errors',
-    'prettier',
-  ],
-  ignorePatterns: [
-    'node_modules/',
-    'dist/',
-    'build/',
-    'coverage/',
-    'benchmark/',
-    'example/',
-    'examples/',
-    'scripts/'
-  ],
-  plugins: [
-    'react-hooks',
-    'prettier',
   ],
   rules: {
     'consistent-return': 'warn',
     'no-magic-numbers': 'off', // TODO
     'react/jsx-key': 'off',
     'react/jsx-handler-names': 'off',
-    'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn',
-    'react/react-in-jsx-scope': 'off',
-    'react/prop-types': 'off',
-    'react/no-children-prop': 'off',
-    'sort-keys': 'off',
-    'no-console': ['error', { allow: ['warn', 'error'] }],
-    'prefer-arrow/prefer-arrow-functions': 'off',
-
-    'prettier/prettier': ['error', {
-      singleQuote: true,
-      arrowParens: 'avoid',
-      trailingComma: 'es5',
-    }],
-  },
-  settings: {
-    react: {
-      version: 'detect',
-    },
+    'import/no-internal-modules': 'off',
   },
 };

--- a/scripts/eslint/preset.js
+++ b/scripts/eslint/preset.js
@@ -1,32 +1,9 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaVersion: 9,
-    sourceType: 'module',
-    ecmaFeatures: {
-      modules: true,
-      jsx: true,
-    },
-  },
   extends: [
+    './common.js',
     'plugin:@typescript-eslint/recommended',
-    'plugin:react/recommended',
-    'prettier',
     'prettier/@typescript-eslint',
-  ],
-  ignorePatterns: [
-    'node_modules/',
-    'dist/',
-    'build/',
-    'coverage/',
-    'benchmark/',
-    'example/',
-    'examples/',
-    'scripts/'
-  ],
-  plugins: [
-    'react-hooks',
-    'prettier',
   ],
   rules: {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
@@ -41,25 +18,6 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/array-type': 'off',
-    'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn',
-    'react/react-in-jsx-scope': 'off',
-    'react/prop-types': 'off',
-    'react/no-children-prop': 'off',
-    'sort-keys': 'off',
-    'no-console': ['error', { allow: ['warn', 'error'] }],
     'import/no-internal-modules': 'off',
-    'prefer-arrow/prefer-arrow-functions': 'off',
-
-    'prettier/prettier': ['error', {
-      singleQuote: true,
-      arrowParens: 'avoid',
-      trailingComma: 'es5',
-    }],
-  },
-  settings: {
-    react: {
-      version: 'detect',
-    },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7087,6 +7087,11 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-es5@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz#aab19af3d4798f7924bba309bc4f87087280fbba"
+  integrity sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==
+
 eslint-plugin-import@^2.22.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"


### PR DESCRIPTION
### Summary

This adds some ESLint refactors and the `eslint-plugin-es5` rules to ensure that we continue to support polyfill-less ES5 support. The exception here are of course `Map`, `Set`, `WeakSet`, and `WeakMap` which React also requires to be polyfilled but overall these are very non-intrusive polyfills.

There were some cases where we used some stuff that we probably shouldn't have used but I did fix them up. Overall it seems like we kept our self-imposed rule in check quite well and there were only two files where we slipped up.

## Context

Just as a clarification. We've always aimed to not include any polyfills for static methods or methods that were added in ES6+, which also keeps our bundle size low. We've seen this as a minor overhead to our work and it doesn't have a huge impact on how we write our code.

But this plugin does reduce friction for external contributions and ensures that we don't have to explicitly look out for this.

The only method that is unaffected as mentioned below is `Object.assign` and hence object literal spreading. This is well transpiled and we do add a polyfill for this.

So the only change of this PR is really to enforce a rule we already had implicitly.

## Set of changes

- Add `common` preset for ESLint configs
- Mute some ESLint warnings (related to React)
- Add `eslint-plugin-es5` for non-test files with only polyfill-related rules
- Add exception for `Object.assign`
- Fix up `schemaPredicates.ts` (not critical because it's only used in development)
- Fix up `traversal.ts` (only one use of `Array.prototype.find` but that's an easy fix)
- Reduced `Object.keys` usage in `schemaPredicates.ts` (totally unrelated but I saw that it could be simplified)
