### PR TITLE
(next-urql) Expose initUrqlClient function for manual usage in Next’s getServerSideProps methods

### DIFF
--- a/.changeset/great-dragons-study.md
+++ b/.changeset/great-dragons-study.md
@@ -1,0 +1,5 @@
+---
+'next-urql': minor
+---
+
+Expose `initUrqlClient` function so that a `Client` can be created manually for use in Next's newer SSR methods manually, such as `getServerSideProps`

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -225,7 +225,7 @@ export const getServerSideProps = async (ctx) => {
     url: /graphql',
   }, false /* set to false to disable suspense */);
 
-  const result= await client.query(QUERY, {}).toPromise();
+  const result = await client.query(QUERY, {}).toPromise();
 
   return {
     props: { data: result.data }

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -213,6 +213,38 @@ let default = (withUrqlClient(. clientOptions))(. make);
 
 The great part about writing thin bindings like this is that they are zero cost – in fact, the above bindings get totally compiled away by BuckleScript, so you get the full benefits of type safety with absolutely zero runtime cost!
 
+### Restricting Data Fetching to the Server
+
+If you want to use the Urql client in server-side-rendered mode of NextJS you have to load data in `getServerSideProps` lifecycle method. This will load your data while rendering a page on server.
+
+```
+// pages/index.tsx
+
+import { initUrqlClient, NextUrqlPageContext } from 'next-urql';
+
+export const getServerSideProps = async (ctx: NextUrqlPageContext): Promise<GetServerSidePropsResult<InitialProps>> => {
+  const graphQLClient = initUrqlClient({
+    url: 'https://graphql-pokemon.now.sh',
+    fetchOptions: {
+      headers: {
+        Authorization: `Bearer ${ctx?.req?.headers?.authorization ?? ''}`,
+      },
+    }
+  }, true) as Client;
+  const response = await graphQLClient.query(queryPokémon as unknown as string, { first: 20 }).toPromise();
+
+
+  return {
+    props: {
+      title: 'Pokédex',
+      data: response?.data?.pokemons
+    },
+  };
+};
+```
+
+The params passed into `initUrqlClient` function are the same you're passing into the `withUrqlClient` higher order component (it has the type of `ClientOptions`). See details here: [client options](https://github.com/FormidableLabs/urql/tree/main/packages/next-urql#clientoptions-required)
+
 ### Examples
 
 You can see simple example projects using `next-urql` in the `examples` directory or on [CodeSandbox](https://codesandbox.io/s/next-urql-pokedex-oqj3x).

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -215,7 +215,7 @@ The great part about writing thin bindings like this is that they are zero cost 
 
 ### Restricting Data Fetching to the Server
 
-If you want to use the Urql client in server-side-rendered mode of NextJS you have to load data in `getServerSideProps` lifecycle method. This will load your data while rendering a page on server.
+If you want to use a `Client` in Next.js' newer methods like `getServerSideProps` you may use the `initUrqlClient` method to create a client on the fly. THis will need to be done per request.
 
 ```
 import { initUrqlClient, NextUrqlPageContext } from 'next-urql';

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -233,7 +233,8 @@ export const getServerSideProps = async (ctx) => {
 };
 ```
 
-The params passed into `initUrqlClient` function are the same you're passing into the `withUrqlClient` higher order component (it has the type of `ClientOptions`). See details here: [client options](https://github.com/FormidableLabs/urql/tree/main/packages/next-urql#clientoptions-required)
+The first option for `initUrqlClient` function are the same that we'd pass to `createClient`.
+The second option is there to either enable or disable `suspense`, which we'd typically disable for manual usage.
 
 ### Examples
 

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -234,7 +234,7 @@ export const getServerSideProps = async (ctx) => {
 ```
 
 The first argument passed to the `initUrqlClient` function is the same object that we'd normally pass to `createClient`.
-The second option is there to either enable or disable `suspense`, which we'd typically disable for manual usage.
+The second argument is a `boolean` flag indicating whether or not to enable `suspense`; typically, we'd disable it for manual usage.
 
 ### Examples
 

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -215,7 +215,7 @@ The great part about writing thin bindings like this is that they are zero cost 
 
 ### Restricting Data Fetching to the Server
 
-If you want to use a `Client` in Next.js' newer methods like `getServerSideProps` you may use the `initUrqlClient` method to create a client on the fly. THis will need to be done per request.
+If you want to use a `Client` in Next.js' newer methods like `getServerSideProps` you may use the `initUrqlClient` function to create a client on the fly. This will need to be done per request.
 
 ```
 import { initUrqlClient, NextUrqlPageContext } from 'next-urql';

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -233,7 +233,7 @@ export const getServerSideProps = async (ctx) => {
 };
 ```
 
-The first option for `initUrqlClient` function are the same that we'd pass to `createClient`.
+The first argument passed to the `initUrqlClient` function is the same object that we'd normally pass to `createClient`.
 The second option is there to either enable or disable `suspense`, which we'd typically disable for manual usage.
 
 ### Examples

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -218,27 +218,17 @@ The great part about writing thin bindings like this is that they are zero cost 
 If you want to use the Urql client in server-side-rendered mode of NextJS you have to load data in `getServerSideProps` lifecycle method. This will load your data while rendering a page on server.
 
 ```
-// pages/index.tsx
-
 import { initUrqlClient, NextUrqlPageContext } from 'next-urql';
 
-export const getServerSideProps = async (ctx: NextUrqlPageContext): Promise<GetServerSidePropsResult<InitialProps>> => {
-  const graphQLClient = initUrqlClient({
-    url: 'https://graphql-pokemon.now.sh',
-    fetchOptions: {
-      headers: {
-        Authorization: `Bearer ${ctx?.req?.headers?.authorization ?? ''}`,
-      },
-    }
-  }, true) as Client;
-  const response = await graphQLClient.query(queryPokémon as unknown as string, { first: 20 }).toPromise();
+export const getServerSideProps = async (ctx) => {
+  const client = initUrqlClient({
+    url: /graphql',
+  }, false /* set to false to disable suspense */);
 
+  const result= await client.query(QUERY, {}).toPromise();
 
   return {
-    props: {
-      title: 'Pokédex',
-      data: response?.data?.pokemons
-    },
+    props: { data: result.data }
   };
 };
 ```

--- a/packages/next-urql/src/index.ts
+++ b/packages/next-urql/src/index.ts
@@ -1,2 +1,3 @@
 export { withUrqlClient } from './with-urql-client';
+export { initUrqlClient } from './init-urql-client';
 export * from './types';


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Expose `initUrqlClient` function in order to allow fetching data in SSR mode. Without it data can be fetched only in client-side rendered apps and in static pages.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- [x] Exposed `initUrqlClient` function in the `packages/next-urql/src/index.ts` file.
- [x] Added a sample implementation demo (based on `1-with-urql-client` demo)

__Notes:__ The GraphQL server doesn't work, I had to use different ones in order to test the functionality. I kept the old Pokemon endpoints for consistency. 
