### PR TITLE
Fix typo in normalized caching docs

### DIFF
--- a/docs/graphcache/normalized-caching.md
+++ b/docs/graphcache/normalized-caching.md
@@ -11,7 +11,7 @@ GraphQL deals with connected data in a tree structure, each entity may link to o
 even lists of entities, which we call "links". The scalar fields on entities like numbers, strings,
 etc is what we call "records."
 
-Instead of storing query results whole documents, like `urql` does with [its default "Document
+Instead of storing query results as whole documents, like `urql` does with [its default "Document
 Caching"](../basics/document-caching.md), _Graphcache_ flattens all data it receives automatically.
 If we looked at doing this manually on the following piece of data, we'd separate each object into a
 list of key-value entries per entity.


### PR DESCRIPTION
## Summary

<!-- What's the motivation of this change? What does it solve? -->

- :bug: There was a typo (missing word) in the "normalized caching" docs

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- :memo: Add aforementioned missing word
- :heavy_check_mark: Not a breaking change (just docs)