### PR TITLE
change branch reference to 'main'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,7 @@ git commit -a -m 'Version Packages'
 ```
 
 At this point we have a new commit with packages that have been updated and should be published.
-Please don't push this commit before publishing so that we keep `master` in a pre-release state, in
+Please don't push this commit before publishing so that we keep `main` in a pre-release state, in
 case the publish actually fails!
 
 ```


### PR DESCRIPTION
## Summary

- whilst submitting my first PR (# 999), i noticed that the CONTRIBUTING doc referenced `master`, but it seems that `main` is the primary branch now.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- :memo: changes `master` to `main` in the CONTRIBUTING doc
- :x: not a breaking change