### PR TITLE
(chore) - Update tsconfig.json in storybook-addon to match others

### DIFF
--- a/exchanges/request-policy/package.json
+++ b/exchanges/request-policy/package.json
@@ -16,7 +16,6 @@
     "graphql client",
     "formidablelabs",
     "exchanges",
-    "react",
     "request-policy"
   ],
   "main": "dist/urql-exchange-request-policy",

--- a/exchanges/retry/package.json
+++ b/exchanges/retry/package.json
@@ -16,7 +16,6 @@
     "graphql client",
     "formidablelabs",
     "exchanges",
-    "react",
     "retry"
   ],
   "main": "dist/urql-exchange-retry",
@@ -51,10 +50,7 @@
     "preset": "../../scripts/jest/preset"
   },
   "devDependencies": {
-    "@types/react": "^16.9.19",
-    "graphql": "^15.1.0",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0"
+    "graphql": "^15.1.0"
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/packages/storybook-addon/tsconfig.json
+++ b/packages/storybook-addon/tsconfig.json
@@ -2,10 +2,11 @@
   "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
-    "baseUrl": "src",
+    "baseUrl": "./",
     "paths": {
       "urql": ["../../node_modules/urql/src"],
       "*-urql": ["../../node_modules/*-urql/src"],
+      "@urql/core/*": ["../../node_modules/@urql/core/src/*"],
       "@urql/*": ["../../node_modules/@urql/*/src"]
     }
   }


### PR DESCRIPTION
This previously made CodeSandbox builds fail, I suspect.
Quick sanity check shows that `yarn tsc` (in package and in repo root) and `yarn build` still succeed locally.