### PR TITLE
(graphcache) - Fix offline queries not flowing through the entire cacheExchange

### DIFF
--- a/.changeset/strange-waves-confess.md
+++ b/.changeset/strange-waves-confess.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix queries that have erroed with a `NetworkError` (`isOfflineError`) not flowing back completely through the `cacheExchange`.

--- a/.changeset/strange-waves-confess.md
+++ b/.changeset/strange-waves-confess.md
@@ -3,3 +3,4 @@
 ---
 
 Fix queries that have erroed with a `NetworkError` (`isOfflineError`) not flowing back completely through the `cacheExchange`.
+These queries should also now be reexecuted when the client comes back online.

--- a/.changeset/tidy-bobcats-sniff.md
+++ b/.changeset/tidy-bobcats-sniff.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Allow `client.reexecuteOperation` to be called with mutations which skip the active operation minimums.

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -229,10 +229,7 @@ describe('offline', () => {
     );
 
     next(queryOp);
-    expect(result).toBeCalledTimes(0);
-    expect(response).toBeCalledTimes(1);
 
-    await Promise.resolve();
     expect(result).toBeCalledTimes(1);
     expect(response).toBeCalledTimes(1);
 

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -61,7 +61,9 @@ describe('storage', () => {
 
   it('should read the metadata and dispatch operations on initialization', () => {
     const client = createClient({ url: 'http://0.0.0.0' });
-    const dispatchOperationSpy = jest.spyOn(client, 'dispatchOperation');
+    const reexecuteOperation = jest
+      .spyOn(client, 'reexecuteOperation')
+      .mockImplementation(() => undefined);
     const op = client.createRequestOperation('mutation', {
       key: 1,
       query: mutationOne,
@@ -81,7 +83,7 @@ describe('storage', () => {
 
     storage.readData.mockReturnValueOnce({ then: () => undefined });
     storage.readMetadata.mockReturnValueOnce({ then: cb => cb([op]) });
-    dispatchOperationSpy.mockImplementation(() => undefined);
+    reexecuteOperation.mockImplementation(() => undefined);
 
     jest.useFakeTimers();
     pipe(
@@ -92,8 +94,8 @@ describe('storage', () => {
     jest.runAllTimers();
 
     expect(storage.readMetadata).toBeCalledTimes(1);
-    expect(dispatchOperationSpy).toBeCalledTimes(1);
-    expect(dispatchOperationSpy).toBeCalledWith({
+    expect(reexecuteOperation).toBeCalledTimes(1);
+    expect(reexecuteOperation).toBeCalledWith({
       ...op,
       key: expect.any(Number),
     });
@@ -255,8 +257,8 @@ describe('offline', () => {
     const onlineSpy = jest.spyOn(navigator, 'onLine', 'get');
 
     const client = createClient({ url: 'http://0.0.0.0' });
-    const dispatchOperationSpy = jest
-      .spyOn(client, 'dispatchOperation')
+    const reexecuteOperation = jest
+      .spyOn(client, 'reexecuteOperation')
       .mockImplementation(() => undefined);
 
     const mutationOp = client.createRequestOperation('mutation', {
@@ -316,9 +318,9 @@ describe('offline', () => {
     ]);
 
     flush!();
-    expect(dispatchOperationSpy).toHaveBeenCalledTimes(1);
-    expect((dispatchOperationSpy.mock.calls[0][0] as any).key).toEqual(1);
-    expect((dispatchOperationSpy.mock.calls[0][0] as any).query).toEqual(
+    expect(reexecuteOperation).toHaveBeenCalledTimes(1);
+    expect((reexecuteOperation.mock.calls[0][0] as any).key).toEqual(1);
+    expect((reexecuteOperation.mock.calls[0][0] as any).query).toEqual(
       formatDocument(mutationOp.query)
     );
   });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -135,7 +135,10 @@ export class Client {
     this.reexecuteOperation = (operation: Operation) => {
       // Reexecute operation only if any subscribers are still subscribed to the
       // operation's exchange results
-      if ((this.activeOperations[operation.key] || 0) > 0) {
+      if (
+        operation.operationName === 'mutation' ||
+        (this.activeOperations[operation.key] || 0) > 0
+      ) {
         this.queue.push(operation);
         if (!isOperationBatchActive) {
           Promise.resolve().then(this.dispatchOperation);


### PR DESCRIPTION
Test against: https://codesandbox.io/s/urql-crud-router-doesnt-update-forked-3nf19

This change updates when queries that have received an offline / network error are dispatched as `cache-only` operations again, and adds support for them being retried automatically (in case they're still active) when the client comes back online.

A small change has also been made to `@urql/core` to allow `client.reexecuteOperation` to be called with mutations.