### PR TITLE
(next) - Move urql to peerDependencies and remove fetch polyfill

### DIFF
--- a/.changeset/shy-lemons-hug.md
+++ b/.changeset/shy-lemons-hug.md
@@ -1,0 +1,11 @@
+---
+'next-urql': major
+---
+
+Move the `urql` dependency to a peerDependency, migrating can be done by performing:
+
+```sh
+npm i --save urql
+## OR
+yarn add urql
+```

--- a/.changeset/weak-seas-reflect.md
+++ b/.changeset/weak-seas-reflect.md
@@ -1,0 +1,9 @@
+---
+'next-urql': major
+---
+
+Remove the automatic polyfilling of `fetch` since this is done automatically starting at
+[`Next v9.4`](https://nextjs.org/blog/next-9-4#improved-built-in-fetch-support)
+
+If you are using a version before 9.4 you can upgrade by installing [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch)
+and importing it to polyfill the behavior.

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -181,18 +181,19 @@ We have a custom integration with [`Next.js`](https://nextjs.org/), being [`next
 this integration contains convenience methods specifically for `Next.js`.
 These will simplify the above setup for SSR.
 
-To setup `next-urql`, first we'll install `next-urql` with `react-is` and `isomorphic-unfetch` as
+To setup `next-urql`, first we'll install `next-urql` with `react-is` and `urql` as
 peer dependencies:
 
 ```sh
-yarn add next-urql react-is isomorphic-unfetch
+yarn add next-urql react-is urql
 # or
-npm install --save next-urql react-is isomorphic-unfetch
+npm install --save next-urql react-is urql
 ```
 
-The peer dependency on `react-is` is inherited from `react-ssr-prepass` requiring it, and the peer
-dependency on `isomorphic-unfetch` exists, since `next-urql` automatically injects it as a `fetch`
-polyfill.
+The peer dependency on `react-is` is inherited from `react-ssr-prepass` requiring it.
+
+Note that if you are using Next before v9.4 you'll need to polyfill fetch, this can be
+done through [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch), ...
 
 We're now able to wrap any page or `_app.js` using the `withUrqlClient` higher-order component. If
 we wrap `_app.js` we won't have to wrap any individual page, but we also won't be able to make use
@@ -241,7 +242,7 @@ export default withUrqlClient(ssrExchange => ({
 Unless the component that is being wrapped already has a `getInitialProps` method, `next-urql` won't add its own SSR logic, which automatically fetches queries during
 server-side rendering. This can be explicitly enabled by passing the `{ ssr: true }` option as a second argument to `withUrqlClient`.
 
-When you are using `getStaticProps`, `getServerSideProps`, or `getStaticPaths`,  you should opt-out of `Suspense` by setting the `neverSuspend` option to `true` in your `withUrqlClient` configuration.
+When you are using `getStaticProps`, `getServerSideProps`, or `getStaticPaths`, you should opt-out of `Suspense` by setting the `neverSuspend` option to `true` in your `withUrqlClient` configuration.
 your `withUrqlClient`.
 During the prepass of your component tree `next-urql` can't know how these functions will alter the props passed to your page component. This injection
 could change the `variables` used in your `useQuery`. This will lead to error being thrown during the subsequent `toString` pass, which isn't supported in React 16.

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -193,7 +193,7 @@ npm install --save next-urql react-is urql
 The peer dependency on `react-is` is inherited from `react-ssr-prepass` requiring it.
 
 Note that if you are using Next before v9.4 you'll need to polyfill fetch, this can be
-done through [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch), ...
+done through [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch).
 
 We're now able to wrap any page or `_app.js` using the `withUrqlClient` higher-order component. If
 we wrap `_app.js` we won't have to wrap any individual page, but we also won't be able to make use
@@ -243,7 +243,6 @@ Unless the component that is being wrapped already has a `getInitialProps` metho
 server-side rendering. This can be explicitly enabled by passing the `{ ssr: true }` option as a second argument to `withUrqlClient`.
 
 When you are using `getStaticProps`, `getServerSideProps`, or `getStaticPaths`, you should opt-out of `Suspense` by setting the `neverSuspend` option to `true` in your `withUrqlClient` configuration.
-your `withUrqlClient`.
 During the prepass of your component tree `next-urql` can't know how these functions will alter the props passed to your page component. This injection
 could change the `variables` used in your `useQuery`. This will lead to error being thrown during the subsequent `toString` pass, which isn't supported in React 16.
 

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -25,10 +25,15 @@ Using GraphQL with server-side rendering in React is a challenging problem. Curr
 Install `next-urql` along with its `peerDependencies`.
 
 ```sh
-npm install --save next-urql urql react-is isomorphic-unfetch
+yarn add next-urql react-is urql
+# or
+npm install --save next-urql react-is urql
 ```
 
 `react-is` helps to support server-side `Suspense` with `react-ssr-prepass`. This assumes you have followed the basic installation steps for `urql` [here](https://github.com/FormidableLabs/urql#installation).
+
+Note that if you are using Next before v9.4 you'll need to polyfill fetch, this can be
+done through [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch), ...
 
 ### Usage
 
@@ -247,7 +252,7 @@ component has children using `getInitialProps` but that component itself is not 
 `withUrqlClient`, this means `withUrqlClient(() => clientOptiosn, { ssr:true })`.
 This measure is available so we can support `getStaticProps`, ...
 
-When you are using `getStaticProps`, `getServerSideProps`, or `getStaticPaths`,  you should opt-out of `Suspense` by setting the `neverSuspend` option to `true` in your `withUrqlClient` configuration.
+When you are using `getStaticProps`, `getServerSideProps`, or `getStaticPaths`, you should opt-out of `Suspense` by setting the `neverSuspend` option to `true` in your `withUrqlClient` configuration.
 your `withUrqlClient`.
 During the prepass of your component tree `next-urql` can't know how these functions will alter the props passed to your page component. This injection
 could change the `variables` used in your `useQuery`. This will lead to error being thrown during the subsequent `toString` pass, which isn't supported in React 16.

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -33,7 +33,7 @@ npm install --save next-urql react-is urql
 `react-is` helps to support server-side `Suspense` with `react-ssr-prepass`. This assumes you have followed the basic installation steps for `urql` [here](https://github.com/FormidableLabs/urql#installation).
 
 Note that if you are using Next before v9.4 you'll need to polyfill fetch, this can be
-done through [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch), ...
+done through [`isomorphic-unfetch`](https://www.npmjs.com/package/isomorphic-unfetch).
 
 ### Usage
 

--- a/packages/next-urql/package.json
+++ b/packages/next-urql/package.json
@@ -50,11 +50,11 @@
     "react-is": "^16.12.0"
   },
   "dependencies": {
-    "react-ssr-prepass": "^1.2.1",
-    "urql": ">=1.10.0"
+    "react-ssr-prepass": "^1.2.1"
   },
   "peerDependencies": {
     "isomorphic-unfetch": "^3.0.0",
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "urql": "^1.10.0"
   }
 }

--- a/packages/next-urql/package.json
+++ b/packages/next-urql/package.json
@@ -43,7 +43,6 @@
     "enzyme-adapter-react-16": "^1.15.2",
     "graphql": "^15.1.0",
     "graphql-tag": "^2.10.3",
-    "isomorphic-unfetch": "^3.0.0",
     "next": "^9.2.1",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
@@ -53,7 +52,6 @@
     "react-ssr-prepass": "^1.2.1"
   },
   "peerDependencies": {
-    "isomorphic-unfetch": "^3.0.0",
     "react": ">=16.8.0",
     "urql": "^1.10.0"
   }

--- a/packages/next-urql/src/init-urql-client.ts
+++ b/packages/next-urql/src/init-urql-client.ts
@@ -1,5 +1,4 @@
 import { createClient, Client, ClientOptions } from 'urql';
-import 'isomorphic-unfetch';
 
 let urqlClient: Client | null = null;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9802,14 +9802,6 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
-isomorphic-unfetch@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
-  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
-  dependencies:
-    node-fetch "^2.6.1"
-    unfetch "^4.2.0"
-
 isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -11665,7 +11657,7 @@ node-fetch@2.6.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
-node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.5.0, node-fetch@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -16506,7 +16498,7 @@ unbzip2-stream@^1.0.9:
     buffer "^5.2.1"
     through "^2.3.8"
 
-unfetch@^4.1.0, unfetch@^4.2.0:
+unfetch@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
   integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==


### PR DESCRIPTION
## Summary

Having `urql` as a dependency seemed to confuse some package managers about what version of `@urql/core` to take and would often result in duplicates.

Removes the `fetch` polyfill since Next handles this [as of 9.4](https://nextjs.org/blog/next-9-4#improved-built-in-fetch-support)

## Set of changes

- Move `urql` to the peerDependencies (breaking)
- Remove `fetch` polyfill (breaking pre Next 9.4)
