### PR TITLE
Fix Windows overflow-x style

### DIFF
--- a/packages/site/src/components/mdx.js
+++ b/packages/site/src/components/mdx.js
@@ -197,7 +197,7 @@ const TableCell = styled.td`
 `;
 
 const TableOverflow = styled.div`
-  overflow-x: scroll;
+  overflow-x: auto;
 `;
 
 const Table = styled.table`


### PR DESCRIPTION
## Summary

On Windows I can see this:

![image](https://user-images.githubusercontent.com/41120635/94996369-aa9b1e00-05a4-11eb-92a9-42c5784e1e75.png)

## Set of changes

I think it is better to use `auto`, see:

![image](https://user-images.githubusercontent.com/41120635/94996420-d9b18f80-05a4-11eb-9736-d29507f32f7c.png)

