### PR TITLE
(svelte) - cache & network query should reset stale to false

### DIFF
--- a/.changeset/honest-turkeys-begin.md
+++ b/.changeset/honest-turkeys-begin.md
@@ -1,0 +1,5 @@
+---
+"@urql/svelte": patch
+---
+
+Fix `stale` keeping a `truthy` on a `cache-and-network` operation.

--- a/.changeset/honest-turkeys-begin.md
+++ b/.changeset/honest-turkeys-begin.md
@@ -2,4 +2,4 @@
 "@urql/svelte": patch
 ---
 
-Fix `stale` keeping a `truthy` on a `cache-and-network` operation.
+Fix `stale` keeping a `truthy` value on a `cache-and-network` operation.

--- a/packages/svelte-urql/src/operationStore.test.ts
+++ b/packages/svelte-urql/src/operationStore.test.ts
@@ -96,7 +96,7 @@ it('adds stale when not present in update', () => {
   expect(subscriber).toHaveBeenCalledTimes(1);
 
   const state = subscriber.mock.calls[0][0];
-  expect(state.stale).toBe(true);
+  expect(state.stale).toBe(false);
   expect(state.query).toBe('{ update }');
 
   store.query = '{ imperative }';

--- a/packages/svelte-urql/src/operationStore.test.ts
+++ b/packages/svelte-urql/src/operationStore.test.ts
@@ -64,6 +64,46 @@ it('adds getters and setters for known values', () => {
   expect(store.query).toBe('{ imperative }');
 });
 
+it('adds stale when not present in update', () => {
+  const variables = {};
+  const context = {};
+  const store = operationStore('{ test }', variables, context);
+
+  const update = {
+    query: '{ update }',
+    variables: undefined,
+    context: { requestPolicy: 'cache-and-network' },
+    fetching: true,
+    data: { update: true },
+    error: undefined,
+    extensions: undefined,
+  };
+
+  _markStoreUpdate(update);
+  store.set(update as any);
+
+  expect(store.query).toBe(update.query);
+  expect(store.variables).toBe(update.variables);
+  expect(store.context).toBe(update.context);
+  expect(store.stale).toBe(false);
+  expect(store.fetching).toBe(update.fetching);
+  expect(store.data).toBe(update.data);
+  expect(store.error).toBe(update.error);
+  expect(store.extensions).toBe(update.extensions);
+
+  const subscriber = jest.fn();
+  store.subscribe(subscriber);
+  expect(subscriber).toHaveBeenCalledTimes(1);
+
+  const state = subscriber.mock.calls[0][0];
+  expect(state.stale).toBe(true);
+  expect(state.query).toBe('{ update }');
+
+  store.query = '{ imperative }';
+  expect(subscriber).toHaveBeenCalledTimes(2);
+  expect(store.query).toBe('{ imperative }');
+});
+
 it('throws when illegal values are set', () => {
   const store = operationStore('{ test }');
 

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -72,12 +72,14 @@ export function operationStore<Data = any, Vars = object>(
     for (const key in value) {
       if (key === 'query' || key === 'variables' || key === 'context') {
         (internal as any)[key] = value[key];
-      } else if (key === 'stale' || key === 'fetching') {
+      } else if (key === 'fetching') {
         (state as any)[key] = !!value[key];
       } else if (key in state) {
         state[key] = value[key];
       }
     }
+
+    (state as any).stale = !!value!.stale;
 
     _internalUpdate = false;
     svelteStore.set(state);

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -53,7 +53,7 @@ export function query<T = any, V = object>(
         fromValue({ fetching: true, stale: false }),
         pipe(
           client.executeQuery(request, store.context!),
-          map(result => ({ fetching: false, ...result }))
+          map(result => ({ fetching: false, ...result, stale: !!result.stale }))
         ),
         fromValue({ fetching: false, stale: false }),
       ]);

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -53,7 +53,7 @@ export function query<T = any, V = object>(
         fromValue({ fetching: true, stale: false }),
         pipe(
           client.executeQuery(request, store.context!),
-          map(result => ({ fetching: false, ...result, stale: !!result.stale }))
+          map(result => ({ fetching: false, ...result }))
         ),
         fromValue({ fetching: false, stale: false }),
       ]);


### PR DESCRIPTION
## Summary

Fix for `stale` remaining `true`, with a `cache-and-network` query.

Fixes: https://github.com/FormidableLabs/urql/issues/1031

## Set of changes

- Adds `stale` Boolean cast to the query result since `stale` isn't  always present on the `OperationResult`, this indicates a false value.