### PR TITLE
(graphcache) - Fix handling of conditionless inline fragment

### DIFF
--- a/.changeset/small-worms-bake.md
+++ b/.changeset/small-worms-bake.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix inline fragments being skipped when they were missing a full type condition as per the GraphQL spec (e.g `{ ... { field } }`)

--- a/exchanges/graphcache/src/ast/node.ts
+++ b/exchanges/graphcache/src/ast/node.ts
@@ -26,11 +26,9 @@ export const getSelectionSet = (node: {
   selectionSet?: SelectionSetNode;
 }): SelectionSet => (node.selectionSet ? node.selectionSet.selections : []);
 
-export const getTypeCondition = ({
-  typeCondition,
-}: {
+export const getTypeCondition = (node: {
   typeCondition?: NamedTypeNode;
-}): string | null => (typeCondition ? getName(typeCondition) : null);
+}): string | null => (node.typeCondition ? getName(node.typeCondition) : null);
 
 export const isFieldNode = (node: SelectionNode): node is FieldNode =>
   node.kind === Kind.FIELD;

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -2,6 +2,8 @@ import {
   isNullableType,
   isListType,
   isNonNullType,
+  InlineFragmentNode,
+  FragmentDefinitionNode,
   GraphQLSchema,
   GraphQLAbstractType,
   GraphQLObjectType,
@@ -10,6 +12,7 @@ import {
 } from 'graphql';
 
 import { warn, invariant } from '../helpers/help';
+import { getTypeCondition } from './node';
 import {
   KeyingConfig,
   UpdateResolver,
@@ -51,11 +54,12 @@ export const isFieldAvailableOnType = (
 
 export const isInterfaceOfType = (
   schema: GraphQLSchema,
-  typeCondition: null | string,
+  node: InlineFragmentNode | FragmentDefinitionNode,
   typename: string | void
 ): boolean => {
-  if (!typename || !typeCondition) return false;
-  if (typename === typeCondition) return true;
+  if (!typename) return false;
+  const typeCondition = getTypeCondition(node);
+  if (!typeCondition || typename === typeCondition) return true;
 
   const abstractType = schema.getType(typeCondition);
   const objectType = schema.getType(typename);

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -67,7 +67,7 @@ const isFragmentHeuristicallyMatching = (
 ) => {
   if (!typename) return false;
   const typeCondition = getTypeCondition(node);
-  if (typename === typeCondition) return true;
+  if (!typeCondition || typename === typeCondition) return true;
 
   warn(
     'Heuristic Fragment Matching: A fragment is trying to match against the `' +
@@ -127,11 +127,7 @@ export const makeSelectionIterator = (
               }
 
               const isMatching = ctx.store.schema
-                ? isInterfaceOfType(
-                    ctx.store.schema,
-                    getTypeCondition(fragmentNode),
-                    typename
-                  )
+                ? isInterfaceOfType(ctx.store.schema, fragmentNode, typename)
                 : isFragmentHeuristicallyMatching(
                     fragmentNode,
                     typename,

--- a/exchanges/graphcache/src/test-utils/suite.test.ts
+++ b/exchanges/graphcache/src/test-utils/suite.test.ts
@@ -44,6 +44,44 @@ it('aliased field on query', () => {
   });
 });
 
+it('@skip directive on field on query', () => {
+  expectCacheIntegrity({
+    query: gql`
+      {
+        __typename
+        intA @skip(if: true)
+        intB @skip(if: false)
+      }
+    `,
+    data: { __typename: 'Query', intB: 2 },
+  });
+});
+
+it('@include directive on field on query', () => {
+  expectCacheIntegrity({
+    query: gql`
+      {
+        __typename
+        intA @include(if: true)
+        intB @include(if: false)
+      }
+    `,
+    data: { __typename: 'Query', intA: 2 },
+  });
+});
+
+it('random directive on field on query', () => {
+  expectCacheIntegrity({
+    query: gql`
+      {
+        __typename
+        int @shouldntMatter
+      }
+    `,
+    data: { __typename: 'Query', int: 1 },
+  });
+});
+
 it('json on query', () => {
   expectCacheIntegrity({
     query: gql`

--- a/exchanges/graphcache/src/test-utils/suite.test.ts
+++ b/exchanges/graphcache/src/test-utils/suite.test.ts
@@ -259,6 +259,23 @@ it('entity list on query and inline fragment', () => {
   });
 });
 
+it('conditionless inline fragment', () => {
+  expectCacheIntegrity({
+    query: gql`
+      {
+        __typename
+        ... {
+          test
+        }
+      }
+    `,
+    data: {
+      __typename: 'Query',
+      test: true,
+    },
+  });
+});
+
 it('entity list on query and spread fragment', () => {
   expectCacheIntegrity({
     query: gql`

--- a/exchanges/graphcache/src/test-utils/suite.test.ts
+++ b/exchanges/graphcache/src/test-utils/suite.test.ts
@@ -314,6 +314,22 @@ it('conditionless inline fragment', () => {
   });
 });
 
+it('skipped conditionless inline fragment', () => {
+  expectCacheIntegrity({
+    query: gql`
+      {
+        __typename
+        ... @skip(if: true) {
+          test
+        }
+      }
+    `,
+    data: {
+      __typename: 'Query',
+    },
+  });
+});
+
 it('entity list on query and spread fragment', () => {
   expectCacheIntegrity({
     query: gql`
@@ -335,6 +351,24 @@ it('entity list on query and spread fragment', () => {
     data: {
       __typename: 'Query',
       items: [{ __typename: 'Item', id: 1, test: true }, null],
+    },
+  });
+});
+
+it('skipped spread fragment', () => {
+  expectCacheIntegrity({
+    query: gql`
+      query Test {
+        __typename
+        ...TestFragment @skip(if: true)
+      }
+
+      fragment TestFragment on Query {
+        test
+      }
+    `,
+    data: {
+      __typename: 'Query',
     },
   });
 });


### PR DESCRIPTION
Fix #1039

- Add test suite case for conditionless inline fragment
- Fix `isFragmentHeuristicallyMatching`
- Fix `isInterfaceOfType`
- Use `node` in `isInterfaceOfType` for consistency
- Update tests in `schemaPredicates.test.ts`
- Add test suite case for directives (while I'm at it)