### PR TITLE
(docs) - Add Comparison page

### DIFF
--- a/docs/advanced/debugging.md
+++ b/docs/advanced/debugging.md
@@ -70,12 +70,12 @@ It also contains a `dispatchDebug` property.
 
 It is called with an object containing the following properties:
 
-| Prop      | Type        | Description                                                                           |
-| --------- | ----------- | ------------------------------------------------------------------------------------- |
-| type      | `string`    | A unique type identifier for the Debug Event.                                         |
-| message   | `string`    | A human readable description of the event.                                            |
-| operation | `Operation` | The [`Operation`](../api/core.md#operation) that the event targets.                   |
-| data      | `?object`   | This is an optional payload to include any data that may become useful for debugging. |
+| Prop        | Type        | Description                                                                           |
+| ----------- | ----------- | ------------------------------------------------------------------------------------- |
+| `type`      | `string`    | A unique type identifier for the Debug Event.                                         |
+| `message`   | `string`    | A human readable description of the event.                                            |
+| `operation` | `Operation` | The [`Operation`](../api/core.md#operation) that the event targets.                   |
+| `data`      | `?object`   | This is an optional payload to include any data that may become useful for debugging. |
 
 For instance, we may call `dispatchDebug` with our `fetchRequest` event. This is the event that the
 `fetchExchange` uses to notify us that a request has commenced:

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,6 +1,6 @@
 ---
 title: API
-order: 8
+order: 9
 ---
 
 # API

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -20,16 +20,16 @@ It accepts several options on creation.
 
 `@urql/core` also exposes `createClient()` that is just a convenient alternative to calling `new Client()`.
 
-| Input           | Type                               | Description                                                                                                                                                                            |
-| --------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| exchanges       | `Exchange[]`                       | An array of `Exchange`s that the client should use instead of the list of `defaultExchanges`                                                                                           |
-| url             | `string`                           | The GraphQL API URL as used by `fetchExchange`                                                                                                                                         |
-| fetchOptions    | `RequestInit \| () => RequestInit` | Additional `fetchOptions` that `fetch` in `fetchExchange` should use to make a request                                                                                                 |
-| fetch           | `typeof fetch`                     | An alternative implementation of `fetch` that will be used by the `fetchExchange` instead of `window.fetch`                                                                            |
-| suspense        | `?boolean`                         | Activates the experimental React suspense mode, which can be used during server-side rendering to prefetch data                                                                        |
-| requestPolicy   | `?RequestPolicy`                   | Changes the default request policy that will be used. By default this will be `cache-first`.                                                                                           |
-| preferGetMethod | `?boolean`                         | This is picked up by the `fetchExchange` and will force all queries (not mutations) to be sent using the HTTP GET method instead of POST.                                              |
-| maskTypename    | `?boolean`                         | Enables the `Client` to automatically apply the `maskTypename` utility to all `data` on [`OperationResult`s](#operationresult). This makes the `__typename` properties non-enumerable. |
+| Input             | Type                               | Description                                                                                                                                                                            |
+| ----------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `exchanges`       | `Exchange[]`                       | An array of `Exchange`s that the client should use instead of the list of `defaultExchanges`                                                                                           |
+| `url`             | `string`                           | The GraphQL API URL as used by `fetchExchange`                                                                                                                                         |
+| `fetchOptions`    | `RequestInit \| () => RequestInit` | Additional `fetchOptions` that `fetch` in `fetchExchange` should use to make a request                                                                                                 |
+| `fetch`           | `typeof fetch`                     | An alternative implementation of `fetch` that will be used by the `fetchExchange` instead of `window.fetch`                                                                            |
+| `suspense`        | `?boolean`                         | Activates the experimental React suspense mode, which can be used during server-side rendering to prefetch data                                                                        |
+| `requestPolicy`   | `?RequestPolicy`                   | Changes the default request policy that will be used. By default this will be `cache-first`.                                                                                           |
+| `preferGetMethod` | `?boolean`                         | This is picked up by the `fetchExchange` and will force all queries (not mutations) to be sent using the HTTP GET method instead of POST.                                              |
+| `maskTypename`    | `?boolean`                         | Enables the `Client` to automatically apply the `maskTypename` utility to all `data` on [`OperationResult`s](#operationresult). This makes the `__typename` properties non-enumerable. |
 
 ### client.executeQuery
 
@@ -123,11 +123,11 @@ For an example, this method is used by the `cacheExchange` when an
 The `CombinedError` is used in `urql` to normalize network errors and `GraphQLError`s if anything
 goes wrong during a GraphQL request.
 
-| Input         | Type                             | Description                                                                        |
-| ------------- | -------------------------------- | ---------------------------------------------------------------------------------- |
-| networkError  | `?Error`                         | An unexpected error that might've occurred when trying to send the GraphQL request |
-| graphQLErrors | `?Array<string \| GraphQLError>` | GraphQL Errors (if any) that were returned by the GraphQL API                      |
-| response      | `?any`                           | The raw response object (if any) from the `fetch` call                             |
+| Input           | Type                             | Description                                                                        |
+| --------------- | -------------------------------- | ---------------------------------------------------------------------------------- |
+| `networkError`  | `?Error`                         | An unexpected error that might've occurred when trying to send the GraphQL request |
+| `graphQLErrors` | `?Array<string \| GraphQLError>` | GraphQL Errors (if any) that were returned by the GraphQL API                      |
+| `response`      | `?any`                           | The raw response object (if any) from the `fetch` call                             |
 
 [Read more about errors in `urql` on the "Error" page.](../basics/errors.md)
 
@@ -138,11 +138,11 @@ goes wrong during a GraphQL request.
 This often comes up as the **input** for every GraphQL request.
 It consists of `query` and optionally `variables`.
 
-| Prop      | Type           | Description                                                                                                           |
-| --------- | -------------- | --------------------------------------------------------------------------------------------------------------------- |
-| key       | `number`       | A unique key that identifies this exact combination of `query` and `variables`, which is derived using a stable hash. |
-| query     | `DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.                                    |
-| variables | `?object`      | The variables to be used with the GraphQL request.                                                                    |
+| Prop        | Type           | Description                                                                                                           |
+| ----------- | -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `key`       | `number`       | A unique key that identifies this exact combination of `query` and `variables`, which is derived using a stable hash. |
+| `query`     | `DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.                                    |
+| `variables` | `?object`      | The variables to be used with the GraphQL request.                                                                    |
 
 The `key` property is a hash of both the `query` and the `variables`, to uniquely
 identify the request. When `variables` are passed it is ensured that they're stably stringified so
@@ -170,10 +170,10 @@ received.
 The input for every exchange that informs GraphQL requests.
 It extends the [GraphQLRequest](#graphqlrequest) type and contains these additional properties:
 
-| Prop          | Type               | Description                                   |
-| ------------- | ------------------ | --------------------------------------------- |
-| operationName | `OperationType`    | The type of GraphQL operation being executed. |
-| context       | `OperationContext` | Additional metadata passed to exchange.       |
+| Prop            | Type               | Description                                   |
+| --------------- | ------------------ | --------------------------------------------- |
+| `operationName` | `OperationType`    | The type of GraphQL operation being executed. |
+| `context`       | `OperationContext` | Additional metadata passed to exchange.       |
 
 > **Note:** In `urql` the `operationName` on the `Operation` isn't the actual name of an operation
 > and derived from the GraphQL `DocumentNode`, but instead a type of operation, like `'query'` or
@@ -201,17 +201,17 @@ data that can be passed from almost all API methods in `urql` that deal with
 Some of these options are set when the `Client` is initialised, so in the following list of
 properties you'll likely see some options that exist on the `Client` as well.
 
-| Prop                | Type                                  | Description                                                                                                           |
-| ------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| fetchOptions        | `?RequestInit \| (() => RequestInit)` | Additional `fetchOptions` that `fetch` in `fetchExchange` should use to make a request.                               |
-| fetch               | `typeof fetch`                        | An alternative implementation of `fetch` that will be used by the `fetchExchange` instead of `window.fetch`           |
-| requestPolicy       | `RequestPolicy`                       | An optional [request policy](/basics/querying-data#request-policy) that should be used specifying the cache strategy. |
-| url                 | `string`                              | The GraphQL endpoint                                                                                                  |
-| pollInterval        | `?number`                             | Every `pollInterval` milliseconds the query will be refetched.                                                        |
-| meta                | `?OperationDebugMeta`                 | Metadata that is only available in development for devtools.                                                          |
-| suspense            | `?boolean`                            | Whether suspense is enabled.                                                                                          |
-| preferGetMethod     | `?number`                             | Instructs the `fetchExchange` to use HTTP GET for queries.                                                            |
-| additionalTypenames | `?number`                             | Allows you to tell the operation that it depends on certain typenames (used in document-cache.)                       |
+| Prop                  | Type                                  | Description                                                                                                           |
+| --------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `fetchOptions`        | `?RequestInit \| (() => RequestInit)` | Additional `fetchOptions` that `fetch` in `fetchExchange` should use to make a request.                               |
+| `fetch`               | `typeof fetch`                        | An alternative implementation of `fetch` that will be used by the `fetchExchange` instead of `window.fetch`           |
+| `requestPolicy`       | `RequestPolicy`                       | An optional [request policy](/basics/querying-data#request-policy) that should be used specifying the cache strategy. |
+| `url`                 | `string`                              | The GraphQL endpoint                                                                                                  |
+| `pollInterval`        | `?number`                             | Every `pollInterval` milliseconds the query will be refetched.                                                        |
+| `meta`                | `?OperationDebugMeta`                 | Metadata that is only available in development for devtools.                                                          |
+| `suspense`            | `?boolean`                            | Whether suspense is enabled.                                                                                          |
+| `preferGetMethod`     | `?number`                             | Instructs the `fetchExchange` to use HTTP GET for queries.                                                            |
+| `additionalTypenames` | `?number`                             | Allows you to tell the operation that it depends on certain typenames (used in document-cache.)                       |
 
 It also accepts additional, untyped parameters that can be used to send more
 information to custom exchanges.
@@ -221,23 +221,23 @@ information to custom exchanges.
 The result of every GraphQL request, i.e. an `Operation`. It's very similar to what comes back from
 a typical GraphQL API, but slightly enriched and normalized.
 
-| Prop       | Type                   | Description                                                                                                                                       |
-| ---------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| operation  | `Operation`            | The operation that this is a result for                                                                                                           |
-| data       | `?any`                 | Data returned by the specified query                                                                                                              |
-| error      | `?CombinedError`       | A [`CombinedError`](#combinederror) instances that wraps network or `GraphQLError`s (if any)                                                      |
-| extensions | `?Record<string, any>` | Extensions that the GraphQL server may have returned.                                                                                             |
-| stale      | `?boolean`             | A flag that may be set to `true` by exchanges to indicate that the `data` is incomplete or out-of-date, and that the result will be updated soon. |
+| Prop         | Type                   | Description                                                                                                                                       |
+| ------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `operation`  | `Operation`            | The operation that this is a result for                                                                                                           |
+| `data`       | `?any`                 | Data returned by the specified query                                                                                                              |
+| `error`      | `?CombinedError`       | A [`CombinedError`](#combinederror) instances that wraps network or `GraphQLError`s (if any)                                                      |
+| `extensions` | `?Record<string, any>` | Extensions that the GraphQL server may have returned.                                                                                             |
+| `stale`      | `?boolean`             | A flag that may be set to `true` by exchanges to indicate that the `data` is incomplete or out-of-date, and that the result will be updated soon. |
 
 ### ExchangeInput
 
 This is the input that an [`Exchange`](#exchange) receives when it's initialized by the
 [`Client`](#client)
 
-| Input   | Type         | Description                                                                                                             |
-| ------- | ------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| forward | `ExchangeIO` | The unction responsible for receiving an observable operation and returning a result                                    |
-| client  | `Client`     | The urql application-wide client library. Each execute method starts a GraphQL request and returns a stream of results. |
+| Input     | Type         | Description                                                                                                             |
+| --------- | ------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `forward` | `ExchangeIO` | The unction responsible for receiving an observable operation and returning a result                                    |
+| `client`  | `Client`     | The urql application-wide client library. Each execute method starts a GraphQL request and returns a stream of results. |
 
 ### Exchange
 

--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -20,12 +20,12 @@ options and returns an [`Exchange`](./core.md#exchange).
 
 | Input        | Description                                                                                                                                                                                                                   |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| _keys_       | A mapping of key generator functions for types that are used to override the default key generation that _Graphcache_ uses to normalize data for given types.                                                                 |
-| _resolvers_  | A nested mapping of resolvers, which are used to override the record or entity that _Graphcache_ resolves for a given field for a type.                                                                                       |
-| _updates_    | A nested mapping of updater functions for mutation and subscription fields, which may be used to add side-effects that update other parts of the cache when the given subscription or mutation field is written to the cache. |
-| _optimistic_ | A mapping of mutation fields to resolvers that may be used to provide _Graphcache_ with an optimistic result for a given mutation field that should be applied to the cached data temporarily.                                |
-| _schema_     | A serialized GraphQL schema that is used by _Graphcache_ to resolve partial data, interfaces, and enums. The schema also used to provide helpful warnings for [schema awareness](../graphcache/schema-awareness.md).          |
-| _storage_    | A persisted storage interface that may be provided to preserve cache data for [offline support](../graphcache/offline.md).                                                                                                    |
+| `keys`       | A mapping of key generator functions for types that are used to override the default key generation that _Graphcache_ uses to normalize data for given types.                                                                 |
+| `resolvers`  | A nested mapping of resolvers, which are used to override the record or entity that _Graphcache_ resolves for a given field for a type.                                                                                       |
+| `updates`    | A nested mapping of updater functions for mutation and subscription fields, which may be used to add side-effects that update other parts of the cache when the given subscription or mutation field is written to the cache. |
+| `optimistic` | A mapping of mutation fields to resolvers that may be used to provide _Graphcache_ with an optimistic result for a given mutation field that should be applied to the cached data temporarily.                                |
+| `schema`     | A serialized GraphQL schema that is used by _Graphcache_ to resolve partial data, interfaces, and enums. The schema also used to provide helpful warnings for [schema awareness](../graphcache/schema-awareness.md).          |
+| `storage`    | A persisted storage interface that may be provided to preserve cache data for [offline support](../graphcache/offline.md).                                                                                                    |
 
 The `@urql/exchange-graphcache` package also exports the `offlineExchange`; which is identical to
 the `cacheExchange` but activates [offline support](../graphcache/offline.md) when the `storage` option is passed.
@@ -66,10 +66,10 @@ A `Resolver` receives four arguments when it's called: `parent`, `args`, `cache`
 
 | Argument | Type     | Description                                                                                                 |
 | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| parent   | `Data`   | The parent entity that the given field is on.                                                               |
-| args     | `object` | The arguments for the given field the updater is executed on.                                               |
-| cache    | `Cache`  | The cache using which data can be read or written. [See `Cache`.](#cache)                                   |
-| info     | `Info`   | Additional metadata and information about the current operation and the current field. [See `Info`.](#info) |
+| `parent` | `Data`   | The parent entity that the given field is on.                                                               |
+| `args`   | `object` | The arguments for the given field the updater is executed on.                                               |
+| `cache`  | `Cache`  | The cache using which data can be read or written. [See `Cache`.](#cache)                                   |
+| `info`   | `Info`   | Additional metadata and information about the current operation and the current field. [See `Info`.](#info) |
 
 [Read more about how to set up `resolvers` on the "Computed Queries"
 page.](../graphcache/computed-queries.md)
@@ -98,10 +98,10 @@ An `UpdateResolver` receives four arguments when it's called: `result`, `args`, 
 
 | Argument | Type     | Description                                                                                                 |
 | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| result   | `any`    | Always the entire `data` object from the mutation or subscription.                                          |
-| args     | `object` | The arguments for the given field the updater is executed on.                                               |
-| cache    | `Cache`  | The cache using which data can be read or written. [See `Cache`.](#cache)                                   |
-| info     | `Info`   | Additional metadata and information about the current operation and the current field. [See `Info`.](#info) |
+| `result` | `any`    | Always the entire `data` object from the mutation or subscription.                                          |
+| `args`   | `object` | The arguments for the given field the updater is executed on.                                               |
+| `cache`  | `Cache`  | The cache using which data can be read or written. [See `Cache`.](#cache)                                   |
+| `info`   | `Info`   | Additional metadata and information about the current operation and the current field. [See `Info`.](#info) |
 
 [Read more about how to set up `updates` on the "Custom Updates"
 page.](../graphcache/custom-updates.md)
@@ -122,11 +122,11 @@ interface OptimisticMutationConfig {
 A `OptimisticMutationResolver` receives three arguments when it's called: `variables`, `cache`, and
 `info`.
 
-| Argument  | Type     | Description                                                                                                 |
-| --------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| variables | `object` | The variables that the given mutation received.                                                             |
-| cache     | `Cache`  | The cache using which data can be read or written. [See `Cache`.](#cache)                                   |
-| info      | `Info`   | Additional metadata and information about the current operation and the current field. [See `Info`.](#info) |
+| Argument    | Type     | Description                                                                                                 |
+| ----------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `variables` | `object` | The variables that the given mutation received.                                                             |
+| `cache`     | `Cache`  | The cache using which data can be read or written. [See `Cache`.](#cache)                                   |
+| `info`      | `Info`   | Additional metadata and information about the current operation and the current field. [See `Info`.](#info) |
 
 [Read more about how to set up `optimistic` on the "Custom Updates"
 page.](../graphcache/custom-updates.md)
@@ -149,13 +149,13 @@ the cache's data to persisted storage on the user's device. it
 > **NOTE:** Offline Support is currently experimental! It hasn't been extensively tested yet and
 > may not always behave as expected. Please try it out with caution!
 
-| Method        | Type                                          | Description                                                                                                                                                                            |
-| ------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| writeData     | `(delta: SerializedEntries) => Promise<void>` | This provided method must be able to accept an object of key-value entries that will be persisted to the storage. This method is called as a batch of updated entries becomes ready.   |
-| readData      | `() => Promise<SerializedEntries>`            | This provided method must be able to return a single combined object of previous key-value entries that have been previously preserved using `writeData`. It's only called on startup. |
-| writeMetadata | `(json: SerializedRequest[]) => void`         | This provided method must be able to persist metadata for the cache. For backwards compatibility it should be able to accept any JSON data.                                            |
-| readMetadata  | `() => Promise<null \| SerializedRequest[]>`  | This provided method must be able to read the persisted metadata that has previously been written using `writeMetadata`. It's only called on startup.                                  |
-| onOnline      | `(cb: () => void) => void`                    | This method must be able to accept a callback that is called when the user's device comes back online.                                                                                 |
+| Method          | Type                                          | Description                                                                                                                                                                            |
+| --------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `writeData`     | `(delta: SerializedEntries) => Promise<void>` | This provided method must be able to accept an object of key-value entries that will be persisted to the storage. This method is called as a batch of updated entries becomes ready.   |
+| `readData`      | `() => Promise<SerializedEntries>`            | This provided method must be able to return a single combined object of previous key-value entries that have been previously preserved using `writeData`. It's only called on startup. |
+| `writeMetadata` | `(json: SerializedRequest[]) => void`         | This provided method must be able to persist metadata for the cache. For backwards compatibility it should be able to accept any JSON data.                                            |
+| `readMetadata`  | `() => Promise<null \| SerializedRequest[]>`  | This provided method must be able to read the persisted metadata that has previously been written using `writeMetadata`. It's only called on startup.                                  |
+| `onOnline`      | `(cb: () => void) => void`                    | This method must be able to accept a callback that is called when the user's device comes back online.                                                                                 |
 
 These options are split into three parts:
 
@@ -254,11 +254,11 @@ When calling the method this returns an array of `FieldInfo` objects, one per fi
 differing arguments) that is known to the cache. The `FieldInfo` interface has three properties:
 `fieldKey`, `fieldName`, and `arguments`:
 
-| Argument  | Type             | Description                                                                     |
-| --------- | ---------------- | ------------------------------------------------------------------------------- |
-| fieldName | `string`         | The field's name (without any arguments, just the name)                         |
-| arguments | `object \| null` | The field's arguments, or `null` if the field doesn't have any arguments        |
-| fieldKey  | `string`         | The field's cache key, which is similar to what `cache.keyOfField` would return |
+| Argument    | Type             | Description                                                                     |
+| ----------- | ---------------- | ------------------------------------------------------------------------------- |
+| `fieldName` | `string`         | The field's name (without any arguments, just the name)                         |
+| `arguments` | `object \| null` | The field's arguments, or `null` if the field doesn't have any arguments        |
+| `fieldKey`  | `string`         | The field's cache key, which is similar to what `cache.keyOfField` would return |
 
 This works on any given entity. When calling this method the cache works in reverse on its data
 structure, by parsing the entity's individual field keys.
@@ -427,16 +427,16 @@ This is a metadata object that is passed to every resolver and updater function.
 information about the current GraphQL document and query, and also some information on the current
 field that a given resolver or updater is called on.
 
-| Argument       | Type                                         | Description                                                                                                                                    |
-| -------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| parentTypeName | `string`                                     | The field's parent entity's typename                                                                                                           |
-| parentKey      | `string`                                     | The field's parent entity's cache key (if any)                                                                                                 |
-| parentFieldKey | `string`                                     | The current key's cache key, which is the parent entity's key combined with the current field's key (This is mostly obsolete)                  |
-| fieldName      | `string`                                     | The current field's name                                                                                                                       |
-| fragments      | `{ [name: string]: FragmentDefinitionNode }` | A dictionary of fragments from the current GraphQL document                                                                                    |
-| variables      | `object`                                     | The current GraphQL operation's variables (may be an empty object)                                                                             |
-| partial        | `?boolean`                                   | This may be set to `true` at any point in time (by your custom resolver or by _Graphcache_) to indicate that some data is uncached and missing |
-| optimistic     | `?boolean`                                   | This is only `true` when an optimistic mutation update is running                                                                              |
+| Argument         | Type                                         | Description                                                                                                                                    |
+| ---------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `parentTypeName` | `string`                                     | The field's parent entity's typename                                                                                                           |
+| `parentKey`      | `string`                                     | The field's parent entity's cache key (if any)                                                                                                 |
+| `parentFieldKey` | `string`                                     | The current key's cache key, which is the parent entity's key combined with the current field's key (This is mostly obsolete)                  |
+| `fieldName`      | `string`                                     | The current field's name                                                                                                                       |
+| `fragments`      | `{ [name: string]: FragmentDefinitionNode }` | A dictionary of fragments from the current GraphQL document                                                                                    |
+| `variables`      | `object`                                     | The current GraphQL operation's variables (may be an empty object)                                                                             |
+| `partial`        | `?boolean`                                   | This may be set to `true` at any point in time (by your custom resolver or by _Graphcache_) to indicate that some data is uncached and missing |
+| `optimistic`     | `?boolean`                                   | This is only `true` when an optimistic mutation update is running                                                                              |
 
 > **Note:** Using `info` is regarded as a last resort. Please only use information from it if
 > there's no other solution to get to the metadata you need. We don't regard the `Info` API as
@@ -456,10 +456,10 @@ on the "Computed Queries" page.](../graphcache/computed-queries.md#pagination)
 Accepts a single object of optional options and returns a resolver that can be inserted into the
 [`cacheExchange`'s](#cacheexchange) [`resolvers` configuration.](#resolvers-option)
 
-| Argument       | Type      | Description                                                                                                                                                        |
-| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| offsetArgument | `?string` | The field arguments' property, as passed to the resolver, that contains the current offset, i.e. the number of items to be skipped. Defaults to `'skip'`.          |
-| limitArgument  | `?string` | The field arguments' property, as passed to the resolver, that contains the current page size limit, i.e. the number of items on each page. Defaults to `'limit'`. |
+| Argument         | Type      | Description                                                                                                                                                        |
+| ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `offsetArgument` | `?string` | The field arguments' property, as passed to the resolver, that contains the current offset, i.e. the number of items to be skipped. Defaults to `'skip'`.          |
+| `limitArgument`  | `?string` | The field arguments' property, as passed to the resolver, that contains the current page size limit, i.e. the number of items on each page. Defaults to `'limit'`. |
 
 Once set up, the resulting resolver is able to automatically concatenate all pages of a given field
 automatically. Queries to this resolvers will from then on only return the infinite, combined list
@@ -473,9 +473,9 @@ page.](../graphcache/computed-queries.md#simple-pagination)
 Accepts a single object of optional options and returns a resolver that can be inserted into the
 [`cacheExchange`'s](#cacheexchange) [`resolvers` configuration.](#resolvers-option)
 
-| Argument  | Type                      | Description                                                                                                                                                                                                                                                                      |
-| --------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| mergeMode | `'outwards' \| 'inwards'` | With Relay pagination, pages can be queried forwards and backwards using `after` and `before` cursors. This option defines whether pages that have been queried backwards should be concatenated before (outwards) or after (inwards) all pages that have been queried forwards. |
+| Argument    | Type                      | Description                                                                                                                                                                                                                                                                      |
+| ----------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mergeMode` | `'outwards' \| 'inwards'` | With Relay pagination, pages can be queried forwards and backwards using `after` and `before` cursors. This option defines whether pages that have been queried backwards should be concatenated before (outwards) or after (inwards) all pages that have been queried forwards. |
 
 Once set up, the resulting resolver is able to automatically concatenate all pages of a given field
 automatically. Queries to this resolvers will from then on only return the infinite, combined list
@@ -493,7 +493,7 @@ It contains the `makeDefaultStorage` export which is a factory function that acc
 and returns a full [storage interface](#storage-option). This storage by default persists to
 [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API).
 
-| Argument | Type     | Description                                                                                                                                       |
-| -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| idbName  | `string` | The name of the IndexedDB database that is used and created if needed. By default this is set to `"graphcache-v3"`                                |
-| maxAge   | `number` | The maximum age of entries that the storage should use in whole days. By default the storage will discard entries that are older than seven days. |
+| Argument  | Type     | Description                                                                                                                                       |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `idbName` | `string` | The name of the IndexedDB database that is used and created if needed. By default this is set to `"graphcache-v3"`                                |
+| `maxAge`  | `number` | The maximum age of entries that the storage should use in whole days. By default the storage will discard entries that are older than seven days. |

--- a/docs/api/svelte.md
+++ b/docs/api/svelte.md
@@ -9,11 +9,11 @@ order: 3
 
 Accepts three arguments as inputs, where only the first one — `query` — is required.
 
-| Argument  | Type                     | Description                                                                        |
-| --------- | ------------------------ | ---------------------------------------------------------------------------------- |
-| query     | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode. |
-| variables | `?object`                | The variables to be used with the GraphQL request.                                 |
-| context   | `?object`                | Holds the contextual information for the query.                                    |
+| Argument    | Type                     | Description                                                                        |
+| ----------- | ------------------------ | ---------------------------------------------------------------------------------- |
+| `query`     | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode. |
+| `variables` | `?object`                | The variables to be used with the GraphQL request.                                 |
+| `context`   | `?object`                | Holds the contextual information for the query.                                    |
 
 This is a [Svelte Writable Store](https://svelte.dev/docs#writable) that is used by other utilities
 listed in these docs to read [`Operation` inputs](./core.md#operation) from and write
@@ -27,13 +27,13 @@ create an [`Operation`](./core.md#operation) to execute. These are `query`, `var
 Furthermore the store exposes some **readonly properties** which represent the operation's progress
 and [result](./core.md#operationresult).
 
-| Prop       | Type                   | Description                                                                                                                                        |
-| ---------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data       | `?any`                 | Data returned by the specified query                                                                                                               |
-| error      | `?CombinedError`       | A [`CombinedError`](./core.md#combinederror) instances that wraps network or `GraphQLError`s (if any)                                              |
-| extensions | `?Record<string, any>` | Extensions that the GraphQL server may have returned.                                                                                              |
-| stale      | `boolean`              | A flag that may be set to `true` by exchanges to indicate that the `data` is incomplete or out-of-date, and that the result will be updated soon.  |
-| fetching   | `boolean`              | A flag that indicates whether the operation is currently in progress, which means that the `data` and `error` is out-of-date for the given inputs. |
+| Prop         | Type                   | Description                                                                                                                                        |
+| ------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`       | `?any`                 | Data returned by the specified query                                                                                                               |
+| `error`      | `?CombinedError`       | A [`CombinedError`](./core.md#combinederror) instances that wraps network or `GraphQLError`s (if any)                                              |
+| `extensions` | `?Record<string, any>` | Extensions that the GraphQL server may have returned.                                                                                              |
+| `stale`      | `boolean`              | A flag that may be set to `true` by exchanges to indicate that the `data` is incomplete or out-of-date, and that the result will be updated soon.  |
+| `fetching`   | `boolean`              | A flag that indicates whether the operation is currently in progress, which means that the `data` and `error` is out-of-date for the given inputs. |
 
 All of the writable properties are updatable either via the common Svelte Writable's `set` or
 `update` methods or directly. The `operationStore` exposes setters for the writable properties which

--- a/docs/api/urql.md
+++ b/docs/api/urql.md
@@ -9,14 +9,14 @@ order: 1
 
 Accepts a single required options object as an input with the following properties:
 
-| Prop          | Type                     | Description                                                                                              |
-| ------------- | ------------------------ | -------------------------------------------------------------------------------------------------------- |
-| query         | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.                       |
-| variables     | `?object`                | The variables to be used with the GraphQL request.                                                       |
-| requestPolicy | `?RequestPolicy`         | An optional [request policy](./core.md#requestpolicy) that should be used specifying the cache strategy. |
-| pause         | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/queries.md#pausing-usequery).              |
-| pollInterval  | `?number`                | Every `pollInterval` milliseconds the query will be reexecuted.                                          |
-| context       | `?object`                | Holds the contextual information for the query.                                                          |
+| Prop            | Type                     | Description                                                                                              |
+| --------------- | ------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `query`         | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.                       |
+| `variables`     | `?object`                | The variables to be used with the GraphQL request.                                                       |
+| `requestPolicy` | `?RequestPolicy`         | An optional [request policy](./core.md#requestpolicy) that should be used specifying the cache strategy. |
+| `pause`         | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/queries.md#pausing-usequery).              |
+| `pollInterval`  | `?number`                | Every `pollInterval` milliseconds the query will be reexecuted.                                          |
+| `context`       | `?object`                | Holds the contextual information for the query.                                                          |
 
 This hook returns a tuple of the shape `[result, executeQuery]`.
 
@@ -46,12 +46,12 @@ Accepts a single `query` argument of type `string | DocumentNode` and returns a 
 
 Accepts a single required options object as an input with the following properties:
 
-| Prop      | Type                     | Description                                                                                 |
-| --------- | ------------------------ | ------------------------------------------------------------------------------------------- |
-| query     | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.          |
-| variables | `?object`                | The variables to be used with the GraphQL request.                                          |
-| pause     | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/queries.md#pausing-usequery). |
-| context   | `?object`                | Holds the contextual information for the query.                                             |
+| Prop        | Type                     | Description                                                                                 |
+| ----------- | ------------------------ | ------------------------------------------------------------------------------------------- |
+| `query`     | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.          |
+| `variables` | `?object`                | The variables to be used with the GraphQL request.                                          |
+| `pause`     | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/queries.md#pausing-usequery). |
+| `context`   | `?object`                | Holds the contextual information for the query.                                             |
 
 The hook optionally accepts a second argument, which may be a handler function with a type signature
 of:

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -60,7 +60,8 @@ matter which framework you use it with. It's worth mentioning that all three cli
 kind of extensibility API which allows you to change when and how queries are sent to an API. These
 are easy to use primitives particularly in Apollo, with links, and in `urql` with exchanges. The
 major difference in `urql` is that all caching logic is abstracted in exchanges too, which makes
-them slightly more powerful (and hence makes `urql` slightly more customizable.)
+it easy to swap the caching logic or other behavior out (and hence makes `urql` slightly more
+customizable.)
 
 A lot of the added exchanges for persisted queries, file uploads, retrying, and other features are
 implemented by the urql-team, while there are some cases where first-party support isn't provided
@@ -96,7 +97,7 @@ for instance.
 | ------------------------------------------------------- | --------------------------------------------------------------------- | ------------------ | ---------------------------------------------- |
 | Caching Strategy                                        | Document Caching, Normalized Caching with `@urql/exchange-graphcache` | Normalized Caching | Normalized Caching (schema restrictions apply) |
 | Added Bundle Size                                       | +5.9kB (with Graphcache)                                              | +0 (default)       | +0 (default)                                   |
-| Automatic Garbage Collection                            | ✅                                                                    | ✅                 | ✅                                             |
+| Automatic Garbage Collection                            | ✅                                                                    | 🔶                 | ✅                                             |
 | Local State Management                                  | 🛑                                                                    | ✅                 | ✅                                             |
 | Pagination Support                                      | 🔶                                                                    | 🔶                 | ✅                                             |
 | Optimistic Updates                                      | ✅                                                                    | ✅                 | ✅                                             |
@@ -105,7 +106,6 @@ for instance.
 | Local Resolvers and Redirects                           | ✅                                                                    | ✅                 | 🛑                                             |
 | Complex Resolvers (nested non-normalized return values) | ✅                                                                    | 🛑                 | 🛑                                             |
 | Commutativity Guarantees                                | ✅                                                                    | 🛑                 | 🛑                                             |
-| Partial Results                                         | ✅                                                                    | ✅                 | 🛑                                             |
 | Partial Results                                         | ✅                                                                    | ✅                 | 🛑                                             |
 | Safe Partial Results (schema-based)                     | ✅                                                                    | 🛑                 | 🛑                                             |
 | Offline Support                                         | ✅                                                                    | 🛑                 | 🛑                                             |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -105,7 +105,7 @@ for instance.
 |                                                         | urql                                                                  | Apollo             | Relay                                          |
 | ------------------------------------------------------- | --------------------------------------------------------------------- | ------------------ | ---------------------------------------------- |
 | Caching Strategy                                        | Document Caching, Normalized Caching with `@urql/exchange-graphcache` | Normalized Caching | Normalized Caching (schema restrictions apply) |
-| Added Bundle Size                                       | +5.9kB (with Graphcache)                                              | +0 (default)       | +0 (default)                                   |
+| Added Bundle Size                                       | +6.5kB (with Graphcache)                                              | +0 (default)       | +0 (default)                                   |
 | Automatic Garbage Collection                            | ✅                                                                    | 🔶                 | ✅                                             |
 | Local State Management                                  | 🛑                                                                    | ✅                 | ✅                                             |
 | Pagination Support                                      | 🔶                                                                    | 🔶                 | ✅                                             |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -51,6 +51,7 @@ All features are marked to indicate the following:
 | Persisted Queries                          | ✅ `@urql/exchange-persisted-fetch` | ✅ `apollo-link-persisted-queries`            | ✅                             |
 | Batched Queries                            | 🛑                                  | ✅ `apollo-link-batch-http`                   | 🟡 `react-relay-network-layer` |
 | Live Queries                               | 🛑                                  | 🛑                                            | ✅                             |
+| Prefer `GET` method                        | ✅                                  | ✅                                            | 🟡 `react-relay-network-layer` |
 | File Uploads                               | ✅ `@urql/exchange-multipart-fetch` | 🟡 `apollo-upload-client`                     | 🛑                             |
 | Retrying Failed Queries                    | ✅ `@urql/exchange-retry`           | ✅ `apollo-link-retry`                        | ✅ `DefaultNetworkLayer`       |
 | Easy Authentication Flows                  | ✅ `@urql/exchange-auth`            | 🛑 (no docs for refresh-based authentication) | 🟡 `react-relay-network-layer` |
@@ -76,6 +77,7 @@ you'd have to lean on community libraries or maintaining/implementing them yours
 | React Bindings                | ✅                               | ✅                 | ✅                |
 | React Hooks Support           | ✅                               | ✅                 | ✅ (experimental) |
 | React Suspense (Experimental) | ✅ (experimental on client-side) | 🛑                 | ✅                |
+| Next.js Integration           | ✅ `next-urql`                   | 🟡                 | 🔶                |
 | Preact Support                | ✅                               | 🔶                 | 🔶                |
 | Svelte Bindings               | ✅                               | 🟡 `svelte-apollo` | 🛑                |
 | Vue Bindings                  | 🛑 (planned)                     | 🟡 `vue-apollo`    | 🟡 `vue-relay`    |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -35,7 +35,7 @@ All features are marked to indicate the following:
 
 ### Core Features
 
-| ---                                        | urql                                | Apollo                                        | Relay                          |
+|                                            | urql                                | Apollo                                        | Relay                          |
 | ------------------------------------------ | ----------------------------------- | --------------------------------------------- | ------------------------------ |
 | Extensible on a network level              | ✅ Exchanges                        | ✅ Links                                      | ✅ Network Layers              |
 | Extensible on a cache / control flow level | ✅ Exchanges                        | 🛑                                            | 🛑                             |
@@ -72,7 +72,7 @@ you'd have to lean on community libraries or maintaining/implementing them yours
 
 ### Framework Bindings
 
-| ---                           | urql                             | Apollo             | Relay             |
+|                               | urql                             | Apollo             | Relay             |
 | ----------------------------- | -------------------------------- | ------------------ | ----------------- |
 | React Bindings                | ✅                               | ✅                 | ✅                |
 | React Hooks Support           | ✅                               | ✅                 | ✅ (experimental) |
@@ -96,7 +96,7 @@ for instance.
 
 ### Caching and State
 
-| ---                                                     | urql                                                                  | Apollo             | Relay                                          |
+|                                                         | urql                                                                  | Apollo             | Relay                                          |
 | ------------------------------------------------------- | --------------------------------------------------------------------- | ------------------ | ---------------------------------------------- |
 | Caching Strategy                                        | Document Caching, Normalized Caching with `@urql/exchange-graphcache` | Normalized Caching | Normalized Caching (schema restrictions apply) |
 | Added Bundle Size                                       | +5.9kB (with Graphcache)                                              | +0 (default)       | +0 (default)                                   |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,141 @@
+---
+title: Showcase
+order: 8
+---
+
+# Comparison
+
+> This comparison page aims to be accurate, unbiased, and up-to-date. If you see any information that
+> may be inaccurate or could be improved otherwise, please feel free to suggest changes.
+
+The most common question that you may encounter with GraphQL is what client to choose when you are
+getting started. We aim to provide an unbiased and accurate comparison of several options on this
+page, so that you can make an **informed decision**.
+
+All options come with several drawbacks and advantages, and all of these clients have been around
+for a while now. A little known fact is that `urql` in its current form and architecture has already
+existed since February of 2019, and its normalized cache has been around since September 2019.
+
+Overall, we would recommend to make your decision based on whether your required features are
+supported, which patterns you'll use (or restrictions thereof), and you may want to look into
+whether all of the parts and features you're interested in are well maintained.
+
+## Comparison by Features
+
+This section is a list of commonly used features of a GraphQL client and how it's either supported
+or not by our listed alternatives. We're using Relay and Apollo to compare against as the other most
+common choices of GraphQL clients.
+
+All features are marked to indicate the following:
+
+- ✅ Supported 1st-class and documented.
+- 🔶 Supported and documented, but requires custom user-code to implement.
+- 🟡 Supported, but as an unofficial 3rd-party library. (Provided it's commonly used)
+- 🛑 Not officially supported or documented.
+
+### Core Features
+
+| ---                                        | urql                                | Apollo                                        | Relay                          |
+| ------------------------------------------ | ----------------------------------- | --------------------------------------------- | ------------------------------ |
+| Extensible on a network level              | ✅ Exchanges                        | ✅ Links                                      | ✅ Network Layers              |
+| Extensible on a cache / control flow level | ✅ Exchanges                        | 🛑                                            | 🛑                             |
+| Base Bundle Size                           | **5.9kB** (7.1kB with bindings)     | 32.9kB                                        | 27.7kB (34.1kB with bindings)  |
+| Devtools                                   | ✅                                  | ✅                                            | ✅                             |
+| Subscriptions                              | ✅                                  | ✅                                            | ✅                             |
+| Client-side Rehydration                    | ✅                                  | ✅                                            | ✅                             |
+| Polled Queries                             | ✅                                  | ✅                                            | ✅                             |
+| Lazy Queries                               | ✅                                  | ✅                                            | ✅                             |
+| Stale while Revalidate / Cache and Network | ✅                                  | ✅                                            | ✅                             |
+| Focus Refetching                           | ✅ `@urql/exchange-refocus`         | 🛑                                            | 🛑                             |
+| Stale Time Configuration                   | ✅ `@urql/exchange-request-policy`  | ✅                                            | 🛑                             |
+| Persisted Queries                          | ✅ `@urql/exchange-persisted-fetch` | ✅ `apollo-link-persisted-queries`            | 🔶                             |
+| Batched Queries                            | 🛑                                  | ✅ `apollo-link-batch-http`                   | 🟡 `react-relay-network-layer` |
+| File Uploads                               | ✅ `@urql/exchange-multipart-fetch` | 🟡 `apollo-upload-client`                     | 🛑                             |
+| Retrying Failed Queries                    | ✅ `@urql/exchange-retry`           | ✅ `apollo-link-retry`                        | ✅ `DefaultNetworkLayer`       |
+| Easy Authentication Flows                  | ✅ `@urql/exchange-auth`            | 🛑 (no docs for refresh-based authentication) | 🟡 `react-relay-network-layer` |
+| Automatic Refetch after Mutation           | ✅ (with document cache)            | 🛑                                            | ✅                             |
+
+Typically these are all additional addon features that you may expect from a GraphQL client, no
+matter which framework you use it with. It's worth mentioning that all three clients support some
+kind of extensibility API which allows you to change when and how queries are sent to an API. These
+are easy to use primitives particularly in Apollo, with links, and in `urql` with exchanges. The
+major difference in `urql` is that all caching logic is abstracted in exchanges too, which makes
+them slightly more powerful (and hence makes `urql` slightly more customizable.)
+
+A lot of the added exchanges for persisted queries, file uploads, retrying, and other features are
+implemented in the core library, while there are some cases where first-party support isn't provided
+in Relay or Apollo. This doesn't mean that these features can't be used with these clients, but that
+you'd have to lean on community libraries or maintaining/implementing them yourself.
+
+### Framework Bindings
+
+| ---                           | urql                             | Apollo             | Relay             |
+| ----------------------------- | -------------------------------- | ------------------ | ----------------- |
+| React Bindings                | ✅                               | ✅                 | ✅                |
+| React Hooks Support           | ✅                               | ✅                 | ✅ (experimental) |
+| React Suspense (Experimental) | ✅ (experimental on client-side) | 🛑                 | ✅                |
+| Preact Support                | ✅                               | 🔶                 | 🔶                |
+| Svelte Bindings               | ✅                               | 🟡 `svelte-apollo` | 🛑                |
+| Vue Bindings                  | 🛑 (planned)                     | 🟡 `vue-apollo`    | 🟡 `vue-relay`    |
+| Initial Data on mount         | ✅                               | ✅                 | ✅                |
+
+Interestingly all three libraries heavily support React as they were all started from the React
+community outwards, but Apollo and Vue benefit from community bindings for different frameworks a
+lot. `urql`'s community is still growing and while that means it won't see large projects as
+Apollo's `vue-apollo` in the short term, we're aiming for first-party support for these bindings.
+
+This is a common criticism that we hear about `urql`, and it's true that our community isn't as
+extensive, but we attempt to lean on good and well funded maintenance at Formidable, active
+investment, and good documentation. So you may have to evaluate whether you can get any questions
+answered quickly enough on [GitHub Discussions](https://github.com/FormidableLabs/urql/discussions)
+for instance.
+
+### Caching and State
+
+| ---                                                     | urql                                                                  | Apollo             | Relay                                          |
+| ------------------------------------------------------- | --------------------------------------------------------------------- | ------------------ | ---------------------------------------------- |
+| Caching Strategy                                        | Document Caching, Normalized Caching with `@urql/exchange-graphcache` | Normalized Caching | Normalized Caching (schema restrictions apply) |
+| Added Bundle Size                                       | +5.9kB (with Graphcache)                                              | +0 (default)       | +0 (default)                                   |
+| Automatic Garbage Collection                            | ✅                                                                    | ✅                 | ✅                                             |
+| Local State Management                                  | 🛑                                                                    | ✅                 | ✅                                             |
+| Pagination Support                                      | 🔶                                                                    | 🔶                 | ✅                                             |
+| Optimistic Updates                                      | ✅                                                                    | ✅                 | ✅                                             |
+| Local Updates                                           | ✅                                                                    | ✅                 | ✅                                             |
+| Out-of-band Cache Updates                               | 🛑 (stays true to server data)                                        | ✅                 | 🛑                                             |
+| Local Resolvers and Redirects                           | ✅                                                                    | ✅                 | 🛑                                             |
+| Complex Resolvers (nested non-normalized return values) | ✅                                                                    | 🛑                 | 🛑                                             |
+| Commutativity Guarantees                                | ✅                                                                    | 🛑                 | 🛑                                             |
+| Partial Results                                         | ✅                                                                    | ✅                 | 🛑                                             |
+| Partial Results                                         | ✅                                                                    | ✅                 | 🛑                                             |
+| Safe Partial Results (schema-based)                     | ✅                                                                    | 🛑                 | 🛑                                             |
+| Offline Support                                         | ✅                                                                    | 🛑                 | 🛑                                             |
+
+`urql` is the only of the three clients that doesn't pick [normalized
+caching](./graphcache/normalized-caching.md) as its default caching strategy. Typically this is seen
+by users as easier and quicker to get started with.
+
+Once you need the same features that you'll find in Relay and Apollo, it's possible to migrate to
+Graphcache. Graphcache is also slightly different from Apollo's cache and more opinionated as it
+doesn't allow arbitrary cache updates to be made.
+
+`urql` is also the only library that adds [Offline Support](./graphcache/offline.md) and
+[Commutativity Guarantees](./graphcache/under-the-hood.md) to its cache's feature set. So if you
+lean on having these features your options are limited.
+
+## About Bundle Size
+
+`urql` is known and often cited as a "lightweight GraphQL client," which is one of its advantages
+but not its main goal. It manages to be this small by careful size management, just like other
+libraries like Preact.
+
+You may find that adding features like `@urql/exchange-persisted-fetch` and
+`@urql/exchange-graphcache` only slightly increases your bundle size as we're aiming to reduce bloat,
+but often this comparison is hard to make. When you start comparing bundle sizes of these three
+GraphQL clients you should keep in mind that:
+
+- Parts of the `graphql` package tree-shake away and may also be replaced (e.g. `parse`)
+- All packages in `urql` reuse parts of `@urql/core` and `wonka`, which means adding all their total
+  sizes up doesn't give you an accurate result.
+- These sizes may change drastically given the code you write and add yourself, but can be managed
+  via precompilation (e.g. with `babel-plugin-graphql-tag` or GraphQL Code Generator for Apollo and
+  `urql`)

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -48,8 +48,9 @@ All features are marked to indicate the following:
 | Stale while Revalidate / Cache and Network | ✅                                  | ✅                                            | ✅                             |
 | Focus Refetching                           | ✅ `@urql/exchange-refocus`         | 🛑                                            | 🛑                             |
 | Stale Time Configuration                   | ✅ `@urql/exchange-request-policy`  | ✅                                            | 🛑                             |
-| Persisted Queries                          | ✅ `@urql/exchange-persisted-fetch` | ✅ `apollo-link-persisted-queries`            | 🔶                             |
+| Persisted Queries                          | ✅ `@urql/exchange-persisted-fetch` | ✅ `apollo-link-persisted-queries`            | ✅                             |
 | Batched Queries                            | 🛑                                  | ✅ `apollo-link-batch-http`                   | 🟡 `react-relay-network-layer` |
+| Live Queries                               | 🛑                                  | 🛑                                            | ✅                             |
 | File Uploads                               | ✅ `@urql/exchange-multipart-fetch` | 🟡 `apollo-upload-client`                     | 🛑                             |
 | Retrying Failed Queries                    | ✅ `@urql/exchange-retry`           | ✅ `apollo-link-retry`                        | ✅ `DefaultNetworkLayer`       |
 | Easy Authentication Flows                  | ✅ `@urql/exchange-auth`            | 🛑 (no docs for refresh-based authentication) | 🟡 `react-relay-network-layer` |
@@ -102,9 +103,9 @@ for instance.
 | Pagination Support                                      | 🔶                                                                    | 🔶                 | ✅                                             |
 | Optimistic Updates                                      | ✅                                                                    | ✅                 | ✅                                             |
 | Local Updates                                           | ✅                                                                    | ✅                 | ✅                                             |
-| Out-of-band Cache Updates                               | 🛑 (stays true to server data)                                        | ✅                 | 🛑                                             |
-| Local Resolvers and Redirects                           | ✅                                                                    | ✅                 | 🛑                                             |
-| Complex Resolvers (nested non-normalized return values) | ✅                                                                    | 🛑                 | 🛑                                             |
+| Out-of-band Cache Updates                               | 🛑 (stays true to server data)                                        | ✅                 | ✅                                             |
+| Local Resolvers and Redirects                           | ✅                                                                    | ✅                 | 🛑 (not needed)                                |
+| Complex Resolvers (nested non-normalized return values) | ✅                                                                    | 🛑                 | 🛑 (not needed)                                |
 | Commutativity Guarantees                                | ✅                                                                    | 🛑                 | 🛑                                             |
 | Partial Results                                         | ✅                                                                    | ✅                 | 🛑                                             |
 | Safe Partial Results (schema-based)                     | ✅                                                                    | 🛑                 | 🛑                                             |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,5 +1,5 @@
 ---
-title: Showcase
+title: Comparison
 order: 8
 ---
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -63,7 +63,7 @@ major difference in `urql` is that all caching logic is abstracted in exchanges 
 them slightly more powerful (and hence makes `urql` slightly more customizable.)
 
 A lot of the added exchanges for persisted queries, file uploads, retrying, and other features are
-implemented in the core library, while there are some cases where first-party support isn't provided
+implemented by the urql-team, while there are some cases where first-party support isn't provided
 in Relay or Apollo. This doesn't mean that these features can't be used with these clients, but that
 you'd have to lean on community libraries or maintaining/implementing them yourself.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -70,6 +70,12 @@ implemented by the urql-team, while there are some cases where first-party suppo
 in Relay or Apollo. This doesn't mean that these features can't be used with these clients, but that
 you'd have to lean on community libraries or maintaining/implementing them yourself.
 
+One thing of note is our lack of support for batched queries in `urql`. We explicitly decided not to
+support this in our [first-party
+packages](https://github.com/FormidableLabs/urql/issues/800#issuecomment-626342821) as the benefits
+are not present anymore in most cases with HTTP/2 and established patterns by Relay that recommend
+hoisting all necessary data requirements to a page-wide query.
+
 ### Framework Bindings
 
 |                               | urql                             | Apollo             | Relay             |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -127,9 +127,11 @@ Once you need the same features that you'll find in Relay and Apollo, it's possi
 Graphcache. Graphcache is also slightly different from Apollo's cache and more opinionated as it
 doesn't allow arbitrary cache updates to be made.
 
-`urql` is also the only library that adds [Offline Support](./graphcache/offline.md) and
-[Commutativity Guarantees](./graphcache/under-the-hood.md) to its cache's feature set. So if you
-lean on having these features your options are limited.
+`urql` is also the only library that provides [Offline Support](./graphcache/offline.md) and
+[Commutativity Guarantees](./graphcache/under-the-hood.md) out of the box as part of Graphcache's
+feature set. There are a number of options for Apollo and Relay including writing your own logic for
+offline caching, which can be particularly successful in Relay, but for `@urql/exchange-graphcache`
+we chose to include it as a feature since it also strengthened other guarantees that the cache makes.
 
 ## About Bundle Size
 

--- a/packages/site/src/components/mdx.js
+++ b/packages/site/src/components/mdx.js
@@ -151,6 +151,10 @@ const sharedTableCellStyling = css`
   padding: ${p => p.theme.spacing.xs} ${p => p.theme.spacing.sm};
   border-left: 1px solid ${p => p.theme.colors.passiveBg};
   border-bottom: 1px solid ${p => p.theme.colors.passiveBg};
+
+  & > ${InlineCode} {
+    white-space: pre-wrap;
+  }
 `;
 
 const TableHeader = styled.th`
@@ -160,7 +164,6 @@ const TableHeader = styled.th`
 `;
 
 const TableCell = styled.td`
-  width: min-content;
   ${sharedTableCellStyling}
 
   ${p => {
@@ -172,27 +175,23 @@ const TableCell = styled.td`
       css`
         background-color: ${p.theme.colors.codeBg};
 
-        & > ${InlineCode} {
+        && > ${InlineCode} {
           background: none;
           padding: 0;
           margin: 0;
+          white-space: pre;
         }
       `
     );
   }}
 
-  &:last-child {
-    min-width: 20rem;
-    width: max-content;
-  }
-
   &:first-child {
-    white-space: nowrap;
+    width: min-content;
+    min-width: 25rem;
   }
 
-  &:nth-child(2) {
+  &:not(:first-child) {
     overflow-wrap: break-word;
-    min-width: 20rem;
   }
 `;
 

--- a/packages/site/src/components/mdx.js
+++ b/packages/site/src/components/mdx.js
@@ -155,6 +155,7 @@ const sharedTableCellStyling = css`
 
   & > ${InlineCode} {
     white-space: pre-wrap;
+    display: inline;
   }
 `;
 
@@ -181,6 +182,7 @@ const TableCell = styled.td`
           padding: 0;
           margin: 0;
           white-space: pre;
+          display: block;
         }
       `
     );

--- a/packages/site/src/components/mdx.js
+++ b/packages/site/src/components/mdx.js
@@ -198,6 +198,15 @@ const TableCell = styled.td`
   }
 `;
 
+const TableScrollContainer = styled.div`
+  overflow-x: auto;
+
+  @media ${p => p.theme.media.maxmd} {
+    overflow-x: scroll;
+    -webkit-overflow-scrolling: touch;
+  }
+`;
+
 const Table = styled.table`
   border: 1px solid ${p => p.theme.colors.passiveBg};
   border-collapse: collapse;
@@ -211,6 +220,12 @@ const Table = styled.table`
     hyphens: initial;
   }
 `;
+
+const TableScroll = props => (
+  <TableScrollContainer>
+    <Table {...props} />
+  </TableScrollContainer>
+);
 
 const MdLink = ({ href, children }) => {
   const currentPage = useMarkdownPage();
@@ -278,7 +293,7 @@ const components = {
   blockquote: Blockquote,
   inlineCode: InlineCode,
   code: HighlightCode,
-  table: Table,
+  table: TableScroll,
   th: TableHeader,
   td: TableCell,
   a: MdLink,

--- a/packages/site/src/components/mdx.js
+++ b/packages/site/src/components/mdx.js
@@ -38,6 +38,7 @@ const Code = styled.code`
   font-variant-ligatures: none;
   font-feature-settings: normal;
   white-space: pre;
+  hyphens: initial;
 `;
 
 const InlineCode = styled(props => {
@@ -190,28 +191,28 @@ const TableCell = styled.td`
     min-width: 25rem;
   }
 
-  &:not(:first-child) {
-    overflow-wrap: break-word;
+  @media ${p => p.theme.media.md} {
+    &:not(:first-child) {
+      overflow-wrap: break-word;
+    }
   }
-`;
-
-const TableOverflow = styled.div`
-  overflow-x: auto;
 `;
 
 const Table = styled.table`
   border: 1px solid ${p => p.theme.colors.passiveBg};
   border-collapse: collapse;
+  overflow-x: auto;
+
+  @media ${p => p.theme.media.maxmd} {
+    overflow-x: scroll;
+    overflow-wrap: initial;
+    word-wrap: initial;
+    word-break: initial;
+    hyphens: initial;
+  }
 `;
 
-const TableWithOverflow = props => (
-  <TableOverflow>
-    <Table {...props} />
-  </TableOverflow>
-);
-
 const MdLink = ({ href, children }) => {
-  const location = useLocation();
   const currentPage = useMarkdownPage();
 
   if (!/^\w+:/.test(href) && !href.startsWith('#')) {
@@ -277,7 +278,7 @@ const components = {
   blockquote: Blockquote,
   inlineCode: InlineCode,
   code: HighlightCode,
-  table: TableWithOverflow,
+  table: Table,
   th: TableHeader,
   td: TableCell,
   a: MdLink,

--- a/packages/site/src/styles/theme.js
+++ b/packages/site/src/styles/theme.js
@@ -75,6 +75,7 @@ export const mediaSizes = {
 };
 
 export const media = {
+  maxmd: `(max-width: ${mediaSizes.md - 1}px)`,
   sm: `(min-width: ${mediaSizes.sm}px)`,
   md: `(min-width: ${mediaSizes.md}px)`,
   lg: `(min-width: ${mediaSizes.lg}px)`,


### PR DESCRIPTION
This aims to add an unbiased and comprehensive comparison page that can be expanded in the future as we see fit. I'm trying to keep it accurate but I expect that it'll change as more questions arise or other libraries change. For now we only compare `urql` with Apollo and Relay and not other libraries like React Query or SWR as we only want to have direct comparisons with GraphQL clients... well, for just GraphQL. Otherwise the feature sets wouldn't make much sense.