### PR TITLE
(svelte) - Add pause support and fix update edge case

### DIFF
--- a/.changeset/lovely-gorillas-change.md
+++ b/.changeset/lovely-gorillas-change.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': patch
+---
+
+Fix an issue where updated `context` options wouldn't cause a new query to be executed, or updates to the store would erroneously throw a debug error.

--- a/.changeset/yellow-toes-decide.md
+++ b/.changeset/yellow-toes-decide.md
@@ -2,4 +2,4 @@
 '@urql/svelte': minor
 ---
 
-Support pausing a query-operation
+Support passing `pause` to stop executing queries or subscriptions.

--- a/.changeset/yellow-toes-decide.md
+++ b/.changeset/yellow-toes-decide.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': minor
+---
+
+Support pausing a query-operation

--- a/docs/basics/queries.md
+++ b/docs/basics/queries.md
@@ -210,7 +210,7 @@ the query's eventual result, which we can then observe.
 For the following examples, we'll imagine that we're querying data from a GraphQL API that contains
 todo items. Let's dive right into it!
 
-```html
+```jsx
 <script>
   import { operationStore, query } from '@urql/svelte';
 
@@ -257,7 +257,7 @@ Typically we'll also need to pass variables to our queries, for instance, if we 
 pagination. For this purpose the `operationStore` also accepts a `variables` argument, which we can
 use to supply variables to our query.
 
-```html
+```jsx
 <script>
   import { operationStore, query } from '@urql/svelte';
 
@@ -283,7 +283,7 @@ As when we're sending GraphQL queries manually using `fetch`, the variables will
 The `operationStore` also supports being actively changed. This will hook into Svelte's reactivity
 model as well and cause the `query` utility to start a new operation.
 
-```html
+```jsx
 <script>
   import { operationStore, query } from '@urql/svelte';
 
@@ -304,13 +304,48 @@ model as well and cause the `query` utility to start a new operation.
   }
 </script>
 
-<button on:click="{nextPage}">Next page<button></button></button>
+<button on:click={nextPage}>Next page<button></button></button>
 ```
 
 The `operationStore` provides getters too so it's also possible for us to pass `todos` around and
 update `todos.variables` or `todos.query` directly. Both, updating `todos.variables` and
 `$todos.variables` in a component for instance, will cause `query` to pick up the update and execute
 our changes.
+
+### Pausing Queries
+
+In some cases we may want our queries to not execute until a pre-condition has been met. Since the
+`query` operation exists for the entire component lifecycle however, it can't just be stopped and
+started at will. Instead, the `query`'s third argument, the `context`, may have an added `pause`
+option that can be set to `true` to temporarily _freeze_ all changes and stop requests.
+
+For instance we may start out with a paused store and then unpause it once a callback is invoked:
+
+```html
+<script>
+  import { operationStore, query } from '@urql/svelte';
+
+  const todo = operationStore(
+    `
+    query {
+      todo {
+        id
+        title
+      }
+    }`,
+    undefined,
+    { pause: true }
+  );
+
+  query(todo);
+
+  function nextPage() {
+    $todo.context.pause = false;
+  }
+</script>
+
+<button on:click="{unpause}">Unpause</button>
+```
 
 ### Request Policies
 
@@ -339,7 +374,7 @@ the background.
 For this reason there's another field on results, `result.stale`, which indicates that the cached
 result is either outdated or that another request is being sent in the background.
 
-```html
+```jsx
 <script>
   import { operationStore, query } from '@urql/svelte';
 
@@ -376,7 +411,7 @@ couple of cases. It can for instance be used to refresh data that is currently b
 
 We can trigger a new query update by changing out the `context` of our `operationStore`.
 
-```html
+```jsx
 <script>
   import { operationStore, query } from '@urql/svelte';
 

--- a/packages/svelte-urql/example/src/App.svelte
+++ b/packages/svelte-urql/example/src/App.svelte
@@ -3,6 +3,8 @@
 
   initClient({ url: "https://0ufyz.sse.codesandbox.io" });
 
+  let pause = false;
+
   const todos = operationStore(`
     query {
       todos {
@@ -11,21 +13,28 @@
         complete
       }
     }
-  `);
+  `, undefined, { pause: false });
 
   query(todos);
+
+  function clickPause() {
+    $todos.context = { pause: !todos.context.pause }
+  }
 </script>
 
-{#if $todos.fetching}
-  Loading...
-{:else if $todos.error}
-  Oh no! {$todos.error.message}
-{:else if !$todos.data}
-  No data
-{:else}
-  <ul>
-    {#each $todos.data.todos as todo}
-      <li>{todo.text}</li>
-    {/each}
-  </ul>
-{/if}
+<div>
+  {#if $todos.fetching}
+    Loading...
+  {:else if $todos.error}
+    Oh no! {$todos.error.message}
+  {:else if !$todos.data}
+    No data
+  {:else}
+    <ul>
+      {#each $todos.data.todos as todo}
+        <li>{todo.text}</li>
+      {/each}
+    </ul>
+  {/if}
+  <button on:click={clickPause}>Pause</button>
+</div>

--- a/packages/svelte-urql/src/operationStore.test.ts
+++ b/packages/svelte-urql/src/operationStore.test.ts
@@ -10,7 +10,11 @@ it('instantiates an operation container acting as a store', () => {
   expect(store.variables).toBe(variables);
   expect(store.context).toBe(context);
 
-  const subscriber = jest.fn();
+  let state: any;
+  const subscriber = jest.fn($state => {
+    state = $state;
+  });
+
   store.subscribe(subscriber);
 
   expect(subscriber).toHaveBeenCalledWith(store);
@@ -19,8 +23,11 @@ it('instantiates an operation container acting as a store', () => {
   store.set({ query: '{ test2 }' });
   expect(subscriber).toHaveBeenCalledWith(store);
   expect(subscriber).toHaveBeenCalledTimes(2);
-
   expect(store.query).toBe('{ test2 }');
+
+  // Svelte's reactive updates will call set with an identity state value
+  store.set(state);
+  expect(subscriber).toHaveBeenCalledTimes(3);
 });
 
 it('adds getters and setters for known values', () => {

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -32,7 +32,7 @@ export interface OperationStore<Data = any, Vars = any>
 export function operationStore<Data = any, Vars = object>(
   query: string | DocumentNode,
   variables?: Vars | null,
-  context?: Partial<OperationContext>
+  context?: Partial<OperationContext & { pause: boolean }>
 ): OperationStore<Data, Vars> {
   const internal = {
     query,

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -52,7 +52,7 @@ export function operationStore<Data = any, Vars = object>(
   let _internalUpdate = false;
 
   state.set = function set(value?: Partial<typeof state>) {
-    if (!value) value = emptyUpdate;
+    if (!value || value === state) value = emptyUpdate;
 
     _internalUpdate = true;
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -71,7 +71,7 @@ export function query<T = any, V = object>(
     toSource(store),
     switchMap(
       (request): Source<Partial<OperationStore>> => {
-        if (store.context && store.context.pause) {
+        if (request.context && request.context.pause) {
           return fromValue({ fetching: false, stale: false });
         }
 
@@ -113,7 +113,7 @@ export function subscription<T = any, R = T, V = object>(
     toSource(store),
     switchMap(
       (request): Source<Partial<OperationStore>> => {
-        if (store.context && store.context.pause) {
+        if (request.context && request.context.pause) {
           return fromValue({ fetching: false, stale: false });
         }
 

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -31,9 +31,10 @@ const toSource = (store: OperationStore) => {
     return store.subscribe(state => {
       const request = createRequest(state.query, state.variables as any);
       if (
-        $context !== state.context ||
-        !$request ||
-        request.key !== $request.key
+        (!state.context || (state.context && !state.context.pause)) &&
+        ($context !== state.context ||
+          !$request ||
+          request.key !== $request.key)
       ) {
         $context = state.context;
         observer.next(($request = request));


### PR DESCRIPTION
- Add support for `context.pause` to restore functionality like other bindings' to pause executing
- Fix an edge case where Svelte wouldn't correctly update the store, which lead to a faulty error (Fix #1036)
- Update `context` comparison code to deeply compare context changes (because Svelte lacks primitives for easy memoisation)