### PR TITLE
(docs) - Update Comparison page with relay-tools related projects

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -81,7 +81,7 @@ hoisting all necessary data requirements to a page-wide query.
 |                               | urql                             | Apollo             | Relay             |
 | ----------------------------- | -------------------------------- | ------------------ | ----------------- |
 | React Bindings                | ✅                               | ✅                 | ✅                |
-| React Concurrent Hooks Support| 🛑                               | ✅                 | ✅ (experimental) |
+| React Concurrent Hooks Support| ✅                               | 🛑                 | ✅ (experimental) |
 | React Legacy Hooks Support    | ✅                               | ✅                 | 🟡 `relay-hooks`  |
 | React Suspense (Experimental) | ✅ (experimental on client-side) | 🛑                 | ✅                |
 | Next.js Integration           | ✅ `next-urql`                   | 🟡                 | 🔶                |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -81,12 +81,13 @@ hoisting all necessary data requirements to a page-wide query.
 |                               | urql                             | Apollo             | Relay             |
 | ----------------------------- | -------------------------------- | ------------------ | ----------------- |
 | React Bindings                | ✅                               | ✅                 | ✅                |
-| React Hooks Support           | ✅                               | ✅                 | ✅ (experimental) |
+| React Hooks Support           | ✅                               | ✅                 | ✅ (experimental), 🟡 `relay-hooks` |
 | React Suspense (Experimental) | ✅ (experimental on client-side) | 🛑                 | ✅                |
 | Next.js Integration           | ✅ `next-urql`                   | 🟡                 | 🔶                |
 | Preact Support                | ✅                               | 🔶                 | 🔶                |
-| Svelte Bindings               | ✅                               | 🟡 `svelte-apollo` | 🛑                |
+| Svelte Bindings               | ✅                               | 🟡 `svelte-apollo` | 🟡 `svelte-relay` |
 | Vue Bindings                  | 🛑 (planned)                     | 🟡 `vue-apollo`    | 🟡 `vue-relay`    |
+| Angular Bindings              | 🛑                               | 🟡 `apollo-angular`| 🟡 `relay-angular`|
 | Initial Data on mount         | ✅                               | ✅                 | ✅                |
 
 Interestingly all three libraries heavily support React as they were all started from the React
@@ -117,7 +118,7 @@ for instance.
 | Commutativity Guarantees                                | ✅                                                                    | 🛑                 | 🛑                                             |
 | Partial Results                                         | ✅                                                                    | ✅                 | 🛑                                             |
 | Safe Partial Results (schema-based)                     | ✅                                                                    | 🛑                 | 🛑                                             |
-| Offline Support                                         | ✅                                                                    | 🛑                 | 🛑                                             |
+| Offline Support                                         | ✅                                                                    | 🟡 `@wora/apollo-offline`| 🟡 `react-relay-offline` `relay-angular`|
 
 `urql` is the only of the three clients that doesn't pick [normalized
 caching](./graphcache/normalized-caching.md) as its default caching strategy. Typically this is seen

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -81,7 +81,8 @@ hoisting all necessary data requirements to a page-wide query.
 |                               | urql                             | Apollo             | Relay             |
 | ----------------------------- | -------------------------------- | ------------------ | ----------------- |
 | React Bindings                | ✅                               | ✅                 | ✅                |
-| React Hooks Support           | ✅                               | ✅                 | ✅ (experimental), 🟡 `relay-hooks` |
+| React Concurrent Hooks Support| 🛑                               | ✅                 | ✅ (experimental) |
+| React Legacy Hooks Support    | ✅                               | ✅                 | 🟡 `relay-hooks`  |
 | React Suspense (Experimental) | ✅ (experimental on client-side) | 🛑                 | ✅                |
 | Next.js Integration           | ✅ `next-urql`                   | 🟡                 | 🔶                |
 | Preact Support                | ✅                               | 🔶                 | 🔶                |
@@ -118,7 +119,7 @@ for instance.
 | Commutativity Guarantees                                | ✅                                                                    | 🛑                 | 🛑                                             |
 | Partial Results                                         | ✅                                                                    | ✅                 | 🛑                                             |
 | Safe Partial Results (schema-based)                     | ✅                                                                    | 🛑                 | 🛑                                             |
-| Offline Support                                         | ✅                                                                    | 🟡 `@wora/apollo-offline`| 🟡 `react-relay-offline` `relay-angular`|
+| Offline Support                                         | ✅                                                                    | 🛑                 | 🟡 `react-relay-offline`|
 
 `urql` is the only of the three clients that doesn't pick [normalized
 caching](./graphcache/normalized-caching.md) as its default caching strategy. Typically this is seen


### PR DESCRIPTION
In this PR I have added some of the libraries that I have implemented and currently supported:
 * [relay-hooks](https://github.com/relay-tools/relay-hooks): hooks for Relay for both concurrent and legacy modes
 * [react-relay-offline](https://github.com/morrys/react-relay-offline): it's a Relay extension for offline capabilities
 * [relay-angular](https://github.com/morrys/react-relay-offline): Angular Bindings including offline capabilities
 * [wora/apollo-offline](https://morrys.github.io/wora/docs/apollo-offline) is an Apollo extension for offline functionality
