### PR TITLE
Update Relay supported features

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -49,10 +49,10 @@ All features are marked to indicate the following:
 | Focus Refetching                           | ✅ `@urql/exchange-refocus`         | 🛑                                            | 🛑                             |
 | Stale Time Configuration                   | ✅ `@urql/exchange-request-policy`  | ✅                                            | 🛑                             |
 | Persisted Queries                          | ✅ `@urql/exchange-persisted-fetch` | ✅ `apollo-link-persisted-queries`            | ✅                             |
-| Batched Queries                            | 🛑                                  | ✅ `apollo-link-batch-http`                   | 🟡 `react-relay-network-layer` |
+| Batched Queries                            | 🛑                                  | ✅ `apollo-link-batch-http`                   | ✅ `react-relay-network-layer` |
 | Live Queries                               | 🛑                                  | 🛑                                            | ✅                             |
-| Switching to `GET` method                  | ✅                                  | ✅                                            | 🟡 `react-relay-network-layer` |
-| File Uploads                               | ✅ `@urql/exchange-multipart-fetch` | 🟡 `apollo-upload-client`                     | 🛑                             |
+| Switching to `GET` method                  | ✅                                  | ✅                                            | ✅ `react-relay-network-layer` |
+| File Uploads                               | ✅ `@urql/exchange-multipart-fetch` | 🟡 `apollo-upload-client`                     | ✅ `react-relay-network-layer` |
 | Retrying Failed Queries                    | ✅ `@urql/exchange-retry`           | ✅ `apollo-link-retry`                        | ✅ `DefaultNetworkLayer`       |
 | Easy Authentication Flows                  | ✅ `@urql/exchange-auth`            | 🛑 (no docs for refresh-based authentication) | 🟡 `react-relay-network-layer` |
 | Automatic Refetch after Mutation           | ✅ (with document cache)            | 🛑                                            | ✅                             |


### PR DESCRIPTION
## Summary

This updates a few Relay features to give them green checkmarks, which I believe is a more accurate representation of the Relay client. My justification for this is that Relay Networking layer is entirely user-provided. Because of this, I'd consider anything to touch networking (file uploads, switching to GET, and batched queries) to be technically supported. File uploads are also supported by `react-relay-network-layer`, so I added it there.

## Set of changes

Changing the emojis used in the comparison. 