### PR TITLE
(svelte) - Remove use of void type unions which prevent optional chaining

### DIFF
--- a/.changeset/fuzzy-flowers-accept.md
+++ b/.changeset/fuzzy-flowers-accept.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': patch
+---
+
+Replace `void` union types with `undefined` in `OperationStore` to allow nullish property access in TypeScript.

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -21,9 +21,9 @@ export interface OperationStore<Data = any, Vars = any>
   // Output properties
   readonly stale: boolean;
   readonly fetching: boolean;
-  readonly data: Data | void;
-  readonly error?: CombinedError | void;
-  readonly extensions?: Record<string, any> | void;
+  readonly data: Data | undefined;
+  readonly error: CombinedError | undefined;
+  readonly extensions: Record<string, any> | undefined;
   // Writable properties
   set(value: Partial<OperationStore<Data, Vars>>): void;
   update(updater: Updater<Partial<OperationStore<Data, Vars>>>): void;


### PR DESCRIPTION
Fix #1051 