### PR TITLE
(graphcache) - Refactor SelectionIterator and clean up exports

### DIFF
--- a/.changeset/kind-radios-clean.md
+++ b/.changeset/kind-radios-clean.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Changes some internals of how selections are iterated over and remove some private exports. This will have no effect or fixes on how Graphcache functions, but may improve some minor performance characteristics of large queries.

--- a/exchanges/graphcache/src/ast/traversal.ts
+++ b/exchanges/graphcache/src/ast/traversal.ts
@@ -1,8 +1,6 @@
 import {
   SelectionNode,
-  DefinitionNode,
   DocumentNode,
-  FragmentDefinitionNode,
   OperationDefinitionNode,
   valueFromASTUntyped,
   Kind,
@@ -12,9 +10,6 @@ import { getName } from './node';
 
 import { invariant } from '../helpers/help';
 import { Fragments, Variables } from '../types';
-
-const isFragmentNode = (node: DefinitionNode): node is FragmentDefinitionNode =>
-  node.kind === Kind.FRAGMENT_DEFINITION;
 
 /** Returns the main operation's definition */
 export const getMainOperation = (
@@ -35,11 +30,17 @@ export const getMainOperation = (
 };
 
 /** Returns a mapping from fragment names to their selections */
-export const getFragments = (doc: DocumentNode): Fragments =>
-  doc.definitions.filter(isFragmentNode).reduce((map: Fragments, node) => {
-    map[getName(node)] = node;
-    return map;
-  }, {});
+export const getFragments = (doc: DocumentNode): Fragments => {
+  const fragments: Fragments = {};
+  for (let i = 0; i < doc.definitions.length; i++) {
+    const node = doc.definitions[i];
+    if (node.kind === Kind.FRAGMENT_DEFINITION) {
+      fragments[getName(node)] = node;
+    }
+  }
+
+  return fragments;
+};
 
 export const shouldInclude = (
   node: SelectionNode,

--- a/exchanges/graphcache/src/index.ts
+++ b/exchanges/graphcache/src/index.ts
@@ -1,3 +1,5 @@
 export * from './types';
+export { query, write } from './operations';
+export { Store } from './store';
 export { cacheExchange } from './cacheExchange';
 export { offlineExchange } from './offlineExchange';

--- a/exchanges/graphcache/src/index.ts
+++ b/exchanges/graphcache/src/index.ts
@@ -1,5 +1,3 @@
 export * from './types';
-export { query, write, writeOptimistic } from './operations';
-export { Store, noopDataState, reserveLayer } from './store';
 export { cacheExchange } from './cacheExchange';
 export { offlineExchange } from './offlineExchange';

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -117,12 +117,12 @@ const readRoot = (
     return originalData;
   }
 
-  const iter = makeSelectionIterator(entityKey, entityKey, select, ctx);
+  const iterate = makeSelectionIterator(entityKey, entityKey, select, ctx);
   const data = {} as Data;
   data.__typename = originalData.__typename;
 
   let node: FieldNode | void;
-  while ((node = iter.next()) !== undefined) {
+  while ((node = iterate()) !== undefined) {
     const fieldAlias = getFieldAlias(node);
     const fieldValue = originalData[fieldAlias];
     if (node.selectionSet !== undefined && fieldValue !== null) {
@@ -274,12 +274,12 @@ const readSelection = (
   // The following closely mirrors readSelection, but differs only slightly for the
   // sake of resolving from an existing resolver result
   data.__typename = typename;
-  const iter = makeSelectionIterator(typename, entityKey, select, ctx);
+  const iterate = makeSelectionIterator(typename, entityKey, select, ctx);
 
   let node: FieldNode | void;
   let hasFields = false;
   let hasPartials = false;
-  while ((node = iter.next()) !== undefined) {
+  while ((node = iterate()) !== undefined) {
     // Derive the needed data from our node.
     const fieldName = getName(node);
     const fieldArgs = getFieldArguments(node, ctx.variables);

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -1,4 +1,4 @@
-import { InlineFragmentNode, FragmentDefinitionNode } from 'graphql';
+import { FieldNode, InlineFragmentNode, FragmentDefinitionNode } from 'graphql';
 
 import {
   isInlineFragment,
@@ -90,68 +90,69 @@ const isFragmentHeuristicallyMatching = (
   });
 };
 
+interface SelectionIterator {
+  (): FieldNode | undefined;
+}
+
 export const makeSelectionIterator = (
   typename: void | string,
   entityKey: string,
   select: SelectionSet,
   ctx: Context
-) => {
-  const indexStack: number[] = [0];
-  const selectionStack: SelectionSet[] = [select];
+): SelectionIterator => {
+  let childIterator: SelectionIterator | void;
+  let index = 0;
 
-  return {
-    next() {
-      while (indexStack.length !== 0) {
-        const index = indexStack[indexStack.length - 1]++;
-        const select = selectionStack[selectionStack.length - 1];
-        if (index >= select.length) {
-          indexStack.pop();
-          selectionStack.pop();
-          if (process.env.NODE_ENV !== 'production') {
-            popDebugNode();
-          }
-          continue;
-        } else {
-          const node = select[index];
-          if (!shouldInclude(node, ctx.variables)) {
-            continue;
-          } else if (!isFieldNode(node)) {
-            // A fragment is either referred to by FragmentSpread or inline
-            const fragmentNode = !isInlineFragment(node)
-              ? ctx.fragments[getName(node)]
-              : node;
-
-            if (fragmentNode !== undefined) {
-              if (process.env.NODE_ENV !== 'production') {
-                pushDebugNode(typename, fragmentNode);
-              }
-
-              const isMatching = ctx.store.schema
-                ? isInterfaceOfType(ctx.store.schema, fragmentNode, typename)
-                : isFragmentHeuristicallyMatching(
-                    fragmentNode,
-                    typename,
-                    entityKey,
-                    ctx.variables
-                  );
-
-              if (isMatching) {
-                indexStack.push(0);
-                selectionStack.push(getSelectionSet(fragmentNode));
-              }
-            }
-
-            continue;
-          } else if (getName(node) === '__typename') {
-            continue;
-          } else {
-            return node;
-          }
-        }
+  return function next() {
+    if (childIterator !== undefined) {
+      const node = childIterator();
+      if (node !== undefined) {
+        return node;
       }
 
-      return undefined;
-    },
+      childIterator = undefined;
+      if (process.env.NODE_ENV !== 'production') {
+        popDebugNode();
+      }
+    }
+
+    while (index < select.length) {
+      const node = select[index++];
+      if (!shouldInclude(node, ctx.variables)) {
+        continue;
+      } else if (!isFieldNode(node)) {
+        // A fragment is either referred to by FragmentSpread or inline
+        const fragmentNode = !isInlineFragment(node)
+          ? ctx.fragments[getName(node)]
+          : node;
+
+        if (fragmentNode !== undefined) {
+          const isMatching = ctx.store.schema
+            ? isInterfaceOfType(ctx.store.schema, fragmentNode, typename)
+            : isFragmentHeuristicallyMatching(
+                fragmentNode,
+                typename,
+                entityKey,
+                ctx.variables
+              );
+
+          if (isMatching) {
+            if (process.env.NODE_ENV !== 'production') {
+              pushDebugNode(typename, fragmentNode);
+            }
+
+            return (childIterator = makeSelectionIterator(
+              typename,
+              entityKey,
+              getSelectionSet(fragmentNode),
+              ctx
+            ))();
+          }
+        }
+      } else if (getName(node) !== '__typename') {
+        return node;
+      }
+    }
   };
 };
 

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -199,7 +199,7 @@ const writeSelection = (
     InMemoryData.writeRecord(entityKey, '__typename', typename);
   }
 
-  const iter = makeSelectionIterator(
+  const iterate = makeSelectionIterator(
     typename,
     entityKey || typename,
     select,
@@ -207,7 +207,7 @@ const writeSelection = (
   );
 
   let node: FieldNode | void;
-  while ((node = iter.next())) {
+  while ((node = iterate())) {
     const fieldName = getName(node);
     const fieldArgs = getFieldArguments(node, ctx.variables);
     const fieldKey = keyOfField(fieldName, fieldArgs);


### PR DESCRIPTION
##  Summary

These changes were initially started to remove obsolete exports from Graphcache. Previously we would expose some `data.ts` internals so they could be used externally, but since we forgot to expose `initDataState` those exports wouldn't be of much use anyway. So instead we can reduce our exports to a minimum just to satisfy our `benchmark`'s needs.

Also this made me search for some more bundlesize opportunities, and I found that a small `traversal` helper could be rewritten and the shared `SelectionIterator` could be optimised a little. This also gave us a small micro-benchmark performance bump, since it's a hotpath.

## Set of changes

- Remove `noopDataState`, `writeOptimistic`, and `reserveLayer` from exports
- Rewrite `getFragments` utility in `ast/traversal.ts`
- Rewrite `makeSelectionIterator` to become nested if needed and remove intermediary iterator object
