### PR TITLE
(auth) - Fix duplicate operation on willAuthError

### DIFF
--- a/.changeset/heavy-peaches-brush.md
+++ b/.changeset/heavy-peaches-brush.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-auth': patch
+---
+
+Fix an operation that triggers `willAuthError` with a truthy return value being sent off twice.

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -8,6 +8,7 @@
     "exchanges/graphcache",
     "exchanges/multipart-fetch",
     "exchanges/persisted-fetch",
+    "exchanges/auth",
     "exchanges/retry",
     "exchanges/suspense",
     "exchanges/execute"

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -6,6 +6,7 @@ import {
   fromValue,
   filter,
   onStart,
+  empty,
   take,
   makeSubject,
   toPromise,
@@ -153,6 +154,7 @@ export function authExchange<T>({
                 willAuthError({ operation, authState })
               ) {
                 pendingPromise = refreshAuth(operation);
+                return empty;
               } else if (!pendingPromise) {
                 return fromValue(addAuthAttemptToOperation(operation, false));
               }


### PR DESCRIPTION
See: https://github.com/FormidableLabs/urql/discussions/1070

## Summary

Previously the `willAuthError` method would trigger the operation that triggered it twice. First for the active operation `mergeMap` function, and second for the `retryQueue` which is caused by `refreshAuth(operation)`.
