### PR TITLE
(refocus) - Switch to visibilitychange api

### DIFF
--- a/.changeset/dirty-dragons-try.md
+++ b/.changeset/dirty-dragons-try.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-refocus': minor
+---
+
+Switch from focus to visibilitychange api

--- a/.changeset/dirty-dragons-try.md
+++ b/.changeset/dirty-dragons-try.md
@@ -2,4 +2,4 @@
 '@urql/exchange-refocus': minor
 ---
 
-Switch from focus to visibilitychange api
+Switch from a `focus-event` triggering the refetch to a change in [`page-visbility`](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API). This means that interacting with an `iframe` and then going back to the page won't trigger a refetch, interacting with Devtools won't cause refetches and a bubbled `focusEvent` won't trigger a refetch.

--- a/exchanges/refocus/src/refocusExchange.test.ts
+++ b/exchanges/refocus/src/refocusExchange.test.ts
@@ -77,7 +77,7 @@ it(`attaches a listener and redispatches queries on call`, () => {
   );
 
   expect(spy).toBeCalledTimes(1);
-  expect(spy).toBeCalledWith('focus', expect.anything());
+  expect(spy).toBeCalledWith('visibilitychange', expect.anything());
 
   next(op);
 

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -1,12 +1,36 @@
 import { pipe, tap } from 'wonka';
 import { Exchange, Operation } from '@urql/core';
 
+// Source: https://github.com/vercel/swr/blob/4d6be3df441f925d235a4b26914efcc85ae335a3/src/libs/is-document-visible.ts
+const isDocumentVisible = (): boolean => {
+  if (
+    typeof document !== 'undefined' &&
+    typeof document.visibilityState !== 'undefined'
+  ) {
+    return document.visibilityState !== 'hidden';
+  }
+  // always assume it's visible
+  return true;
+};
+
+// Source: https://github.com/vercel/swr/blob/4d6be3df441f925d235a4b26914efcc85ae335a3/src/libs/is-online.ts
+const isOnline = (): boolean => {
+  if (typeof navigator.onLine !== 'undefined') {
+    return navigator.onLine;
+  }
+  // always assume it's online
+  return true;
+};
+
 export const refocusExchange = (): Exchange => {
   return ({ client, forward }) => ops$ => {
     const watchedOperations = new Map<number, Operation>();
     const observedOperations = new Map<number, number>();
 
-    window.addEventListener('focus', () => {
+    window.addEventListener('visibilitychange', () => {
+      if (!isDocumentVisible() || !isOnline()) {
+        return;
+      }
       watchedOperations.forEach(op => {
         client.reexecuteOperation(
           client.createRequestOperation('query', op, {

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -1,43 +1,24 @@
 import { pipe, tap } from 'wonka';
 import { Exchange, Operation } from '@urql/core';
 
-// Source: https://github.com/vercel/swr/blob/4d6be3df441f925d235a4b26914efcc85ae335a3/src/libs/is-document-visible.ts
-const isDocumentVisible = (): boolean => {
-  if (
-    typeof document !== 'undefined' &&
-    typeof document.visibilityState !== 'undefined'
-  ) {
-    return document.visibilityState !== 'hidden';
-  }
-  // always assume it's visible
-  return true;
-};
-
-// Source: https://github.com/vercel/swr/blob/4d6be3df441f925d235a4b26914efcc85ae335a3/src/libs/is-online.ts
-const isOnline = (): boolean => {
-  if (typeof navigator.onLine !== 'undefined') {
-    return navigator.onLine;
-  }
-  // always assume it's online
-  return true;
-};
-
 export const refocusExchange = (): Exchange => {
   return ({ client, forward }) => ops$ => {
     const watchedOperations = new Map<number, Operation>();
     const observedOperations = new Map<number, number>();
 
     window.addEventListener('visibilitychange', () => {
-      if (!isDocumentVisible() || !isOnline()) {
-        return;
+      if (
+        typeof document !== 'object' ||
+        document.visibilityState === 'visible'
+      ) {
+        watchedOperations.forEach(op => {
+          client.reexecuteOperation(
+            client.createRequestOperation('query', op, {
+              requestPolicy: 'cache-and-network',
+            })
+          );
+        });
       }
-      watchedOperations.forEach(op => {
-        client.reexecuteOperation(
-          client.createRequestOperation('query', op, {
-            requestPolicy: 'cache-and-network',
-          })
-        );
-      });
     });
 
     const processIncomingOperation = (op: Operation) => {


### PR DESCRIPTION
Resolves #1063 


## Summary

Use the `visibilitychange` api.

## Set of changes

* Switch from `focus` to `visibilitychange` api


I looked at [SWR](https://github.com/vercel/swr/blob/4d6be3df441f925d235a4b26914efcc85ae335a3/src/use-swr.ts#L61) and [react-query](https://github.com/tannerlinsley/react-query/blob/master/src/core/setFocusHandler.ts#L14) code and noticed that they refetch on both `focus` and `visibilitychange` events. As you can see in the video below, `visibilitychange` does not fire when we switch from one window to another (while `focus` does). It actually makes sense since the visibility of the document does not change. According to #1063, `focus` has some issues so I guess it's fine to only refetch on `visibilitychange`?

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/5595092/96684965-bf392d80-137c-11eb-8c3b-4b3b8e91834c.gif)







