### PR TITLE
(graphcache) - Clear optimistic updates before retrying in offlineExchange

### DIFF
--- a/.changeset/gorgeous-queens-fetch.md
+++ b/.changeset/gorgeous-queens-fetch.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Enforce atomic optimistic updates so that optimistic layers are cleared before they're reapplied. This is important for instance when an optimistic update is performed while offline and then reapplied while online, which would previously repeat the optimistic update on top of its past data changes.

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -83,16 +83,15 @@ export const initDataState = (
   if (!layerKey) {
     currentOptimisticKey = null;
   } else if (isOptimistic || data.optimisticOrder.length > 0) {
+    // If this operation isn't optimistic and we see it for the first time,
+    // then it must've been optimistic in the past, so we can proactively
+    // clear the optimistic data before writing
     if (!isOptimistic && !data.commutativeKeys.has(layerKey)) {
-      // If this operation isn't optimistic and we see it for the first time,
-      // then it must've been optimistic in the past, so we can proactively
-      // clear the optimistic data before writing
       reserveLayer(data, layerKey);
     } else if (isOptimistic) {
-      // If an optimistic layer is written again, make sure that it's not
-      // a permanent non-optimistic layer and clear all previous data
+      // NOTE: This optimally shouldn't happen as it implies that an optimistic
+      // write is being performed after a concrete write.
       data.commutativeKeys.delete(layerKey);
-      clearLayer(data, layerKey);
     }
 
     // An optimistic update of a mutation may force an optimistic layer,

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -83,15 +83,16 @@ export const initDataState = (
   if (!layerKey) {
     currentOptimisticKey = null;
   } else if (isOptimistic || data.optimisticOrder.length > 0) {
-    // If this operation isn't optimistic and we see it for the first time,
-    // then it must've been optimistic in the past, so we can proactively
-    // clear the optimistic data before writing
     if (!isOptimistic && !data.commutativeKeys.has(layerKey)) {
+      // If this operation isn't optimistic and we see it for the first time,
+      // then it must've been optimistic in the past, so we can proactively
+      // clear the optimistic data before writing
       reserveLayer(data, layerKey);
     } else if (isOptimistic) {
-      // NOTE: This optimally shouldn't happen as it implies that an optimistic
-      // write is being performed after a concrete write.
+      // If an optimistic layer is written again, make sure that it's not
+      // a permanent non-optimistic layer and clear all previous data
       data.commutativeKeys.delete(layerKey);
+      clearLayer(data, layerKey);
     }
 
     // An optimistic update of a mutation may force an optimistic layer,

--- a/exchanges/graphcache/src/test-utils/examples-1.test.ts
+++ b/exchanges/graphcache/src/test-utils/examples-1.test.ts
@@ -552,3 +552,65 @@ it('allows cumulative optimistic updates', () => {
     ],
   });
 });
+
+it('enforces atomic optimistic updates', () => {
+  let counter = 1;
+
+  const store = new Store({
+    updates: {
+      Mutation: {
+        addTodo: (result, _, cache) => {
+          cache.updateQuery({ query: Todos }, data => {
+            (data as any).todos.push(result.addTodo);
+            return data as Data;
+          });
+        },
+      },
+    },
+    optimistic: {
+      addTodo: () => ({
+        __typename: 'Todo',
+        id: 'optimistic_' + ++counter,
+        text: '',
+        complete: false,
+      }),
+    },
+  });
+
+  const todosData = {
+    __typename: 'Query',
+    todos: [
+      { id: '0', complete: true, text: '0', __typename: 'Todo' },
+      { id: '1', complete: true, text: '1', __typename: 'Todo' },
+    ],
+  };
+
+  write(store, { query: Todos }, todosData);
+
+  const AddTodo = gql`
+    mutation {
+      __typename
+      addTodo {
+        __typename
+        complete
+        text
+        id
+      }
+    }
+  `;
+
+  writeOptimistic(store, { query: AddTodo }, 1);
+  writeOptimistic(store, { query: AddTodo }, 1);
+
+  const queryRes = query(store, { query: Todos });
+
+  expect(queryRes.partial).toBe(false);
+  expect(queryRes.data).toEqual({
+    ...todosData,
+    todos: [
+      todosData.todos[0],
+      todosData.todos[1],
+      { __typename: 'Todo', text: '', complete: false, id: 'optimistic_3' },
+    ],
+  });
+});

--- a/exchanges/graphcache/src/test-utils/examples-1.test.ts
+++ b/exchanges/graphcache/src/test-utils/examples-1.test.ts
@@ -553,7 +553,7 @@ it('allows cumulative optimistic updates', () => {
   });
 });
 
-it('enforces atomic optimistic updates', () => {
+it('supports clearing a layer then reapplying optimistic updates', () => {
   let counter = 1;
 
   const store = new Store({
@@ -602,6 +602,11 @@ it('enforces atomic optimistic updates', () => {
   writeOptimistic(store, { query: AddTodo }, 1);
   writeOptimistic(store, { query: AddTodo }, 1);
 
+  InMemoryData.noopDataState(store.data, 1);
+
+  writeOptimistic(store, { query: AddTodo }, 1);
+  writeOptimistic(store, { query: AddTodo }, 1);
+
   const queryRes = query(store, { query: Todos });
 
   expect(queryRes.partial).toBe(false);
@@ -610,7 +615,8 @@ it('enforces atomic optimistic updates', () => {
     todos: [
       todosData.todos[0],
       todosData.todos[1],
-      { __typename: 'Todo', text: '', complete: false, id: 'optimistic_3' },
+      { __typename: 'Todo', text: '', complete: false, id: 'optimistic_4' },
+      { __typename: 'Todo', text: '', complete: false, id: 'optimistic_5' },
     ],
   });
 });


### PR DESCRIPTION
Fix #1079

## Summary

> ~**NOTE:** This changes an earlier (but rare) case's behaviour!~
> ~We expect that this changes how a "toggling mutation" may look in the UI. Specifically it will never be able now to actually toggle if we trigger it repeatedly in optimistic updates. That's probably a good thing however as between a bad network connection and going offline/online we can't tell whether all toggling mutations will be delivered and applied in-order and atomically. So it's invalid to prioritise this case over the following fix.~

This fix clears all optimistic updates as a single batch by sending `'teardown'` operations in the `offlineExchange` when the mutations are ready to be retried. This uses the existing functionality that clears layers using `noopDataState` when a `teardown` operation comes in.

This causes all optimistic layers to be erased before optimistic updates are reapplied.

## Set of changes

- Clear all optimistic updates when they're retried by the `offlineExchange` in a whole batch, by sending a `teardown` operaton for each failed mutation.
- Add test case for `noopDataState` in combination with a past and future optimistic update.
