### PR TITLE
(build) - Fix graphql imports for Webpack 5

### DIFF
--- a/.changeset/thin-rings-tell.md
+++ b/.changeset/thin-rings-tell.md
@@ -1,4 +1,5 @@
 ---
+'@urql/preact': patch
 '@urql/exchange-execute': patch
 '@urql/exchange-graphcache': patch
 '@urql/exchange-populate': patch

--- a/.changeset/thin-rings-tell.md
+++ b/.changeset/thin-rings-tell.md
@@ -1,0 +1,9 @@
+---
+'@urql/exchange-execute': patch
+'@urql/exchange-graphcache': patch
+'@urql/exchange-populate': patch
+'@urql/core': patch
+'@urql/introspection': patch
+---
+
+Add missing `.mjs` extension to all imports from `graphql` to fix Webpack 5 builds, which require extension-specific import paths for ESM bundles and packages.

--- a/.changeset/thin-rings-tell.md
+++ b/.changeset/thin-rings-tell.md
@@ -7,4 +7,4 @@
 '@urql/introspection': patch
 ---
 
-Add missing `.mjs` extension to all imports from `graphql` to fix Webpack 5 builds, which require extension-specific import paths for ESM bundles and packages.
+Add missing `.mjs` extension to all imports from `graphql` to fix Webpack 5 builds, which require extension-specific import paths for ESM bundles and packages. **This change allows you to safely upgrade to Webpack 5.**

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/eslint-plugin": "^4.1.0",
     "@typescript-eslint/parser": "^4.1.0",
     "babel-plugin-closure-elimination": "^1.3.2",
-    "babel-plugin-modular-graphql": "0.1.3",
+    "babel-plugin-modular-graphql": "1.0.0",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "dotenv": "^8.2.0",
     "eslint": "^7.8.1",

--- a/packages/preact-urql/src/hooks/index.ts
+++ b/packages/preact-urql/src/hooks/index.ts
@@ -1,8 +1,3 @@
-export {
-  useQuery,
-  UseQueryArgs,
-  UseQueryResponse,
-  UseQueryState,
-} from './useQuery';
+export * from './useQuery';
 export * from './useMutation';
 export * from './useSubscription';

--- a/scripts/rollup/cleanup-plugin.js
+++ b/scripts/rollup/cleanup-plugin.js
@@ -1,5 +1,6 @@
 import { transformSync as transform } from '@babel/core';
 import { createFilter } from '@rollup/pluginutils';
+import babelPluginModularGraphQL from 'babel-plugin-modular-graphql';
 
 function removeEmptyImports({ types: t }) {
   return {
@@ -36,7 +37,10 @@ function cleanup(opts = {}) {
       }
 
       return transform(code, {
-        plugins: [removeEmptyImports],
+        plugins: [
+          [babelPluginModularGraphQL, { extension: opts.extension }],
+          removeEmptyImports
+        ],
         babelrc: false
       });
     }

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -58,7 +58,7 @@ const output = ({ format, isProduction }) => {
     format,
     plugins: makeOutputPlugins({
       isProduction,
-      extension,
+      extension: format === 'esm' ? '.mjs' : '.js',
     })
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3976,10 +3976,10 @@ babel-plugin-minify-type-constructors@^0.4.3:
   dependencies:
     babel-helper-is-void-0 "^0.4.3"
 
-babel-plugin-modular-graphql@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-modular-graphql/-/babel-plugin-modular-graphql-0.1.3.tgz#23d474daab2278229bfc9a9f2491f3e1d9f555f1"
-  integrity sha512-13QBZm1sqPTHVBlG79p0jswR+FdNIIaxRrg1tNjpfGYU4U9M8bEDVQ51QK9+cZ6zUBQ0k2mh0iRvCjZt+856pg==
+babel-plugin-modular-graphql@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-modular-graphql/-/babel-plugin-modular-graphql-1.0.0.tgz#f8575e746895cf9652ec1ad804661791f520d56c"
+  integrity sha512-yyj8KcO1YU4LfaUGOyP1DY9y3CdqRhc5WhTWYD2XNx8jX4OBLVED+QBY1QmCNLsVqyXyfsv86C2BnwaMnFfDKQ==
 
 babel-plugin-named-asset-import@^0.3.1:
   version "0.3.6"


### PR DESCRIPTION
Resolve #1086 

## Summary

Another week another small ESM issue in Webpack 5. In the upgrade Webpack now supports `package.json:exports` maps. However, a small problem with this support is how it handles sub-packages without a `package.json:exports`. There's a small quirk in Webpack that will require all import paths to be exact (including extensions) even when the sub-package doesn't have a `package.json:exports` map.

We're affected by this because we use our `babel-plugin-modular-graphql` plugin to convert some `graphql` imports into more specific ones. But instead of specifying files like `graphql/language/visitor` we need to add the full path like `graphql/language/visitor.mjs`. While I'm not convinced that this is the correct behaviour, it's an easy fix.

## Set of changes

- Upgrade to `babel-plugin-modular-graphql@1.0.0` which adds an `extension` option
- Refactor Rollup build pipeline to move production/non-production plugins to `output.plugins`. This allows us to merge the two build runs into a single one.
- Move `babel-plugin-modular-graphql` to `cleanup()` plugin.
