### PR TITLE
(chore) - Fix development build being overwritten by production build

### DIFF
--- a/.changeset/wet-onions-burn.md
+++ b/.changeset/wet-onions-burn.md
@@ -1,5 +1,8 @@
 ---
 '@urql/exchange-graphcache': patch
+'@urql/exchange-persisted-fetch': patch
+'@urql/exchange-multipart-fetch': patch
+'@urql/exchange-retry': patch
 '@urql/core': patch
 '@urql/preact': patch
 'urql': patch

--- a/.changeset/wet-onions-burn.md
+++ b/.changeset/wet-onions-burn.md
@@ -1,0 +1,8 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/core': patch
+'@urql/preact': patch
+'urql': patch
+---
+
+Fix the production build overwriting the development build. Specifically in the previous release we mistakenly replaced all development bundles with production bundles. This doesn't have any direct influence on how these packages work, but prevented development warnings from being logged or full errors from being thrown.

--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -15,7 +15,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@urql/core": ">=1.13.1",
+    "@urql/core": ">=1.14.0",
     "wonka": "^4.0.14"
   }
 }

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -40,9 +40,12 @@ const output = ({ format, isProduction }) => {
   if (format !== 'cjs' && format !== 'esm')
     throw new Error('Invalid option `format` at output({ ... })');
 
-  const extension = format === 'esm'
+  let extension = format === 'esm'
     ? (settings.hasReact ? '.es.js' : '.mjs')
     : '.js';
+  if (isProduction) {
+    extension = '.min' + extension;
+  }
 
   return {
     chunkFileNames: '[hash]' + extension,


### PR DESCRIPTION
Fix the production build overwriting the development build. Specifically in the previous release we mistakenly replaced all development bundles with production bundles. This doesn't have any direct influence on how these packages work, but prevented development warnings from being logged or full errors from being thrown.
