### PR TITLE
(core) - Refactor useSource and improve hooks edge case behaviour

### DIFF
--- a/.changeset/gorgeous-radios-dream.md
+++ b/.changeset/gorgeous-radios-dream.md
@@ -1,0 +1,7 @@
+---
+'@urql/core': patch
+'@urql/preact': patch
+'urql': patch
+---
+
+Refactor `useSource` hooks which powers `useQuery` and `useSubscription` to improve various edge case behaviour. This will not change the behaviour of these hooks dramatically but avoid unnecessary state updates when any updates are obviously equivalent and the hook will furthermore improve continuation from mount to effects, which will fix cases where the state between the mounting and effect phase may slightly change.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -201,8 +201,12 @@ export class Client {
     const prevActive = this.activeOperations[key] || 0;
     const newActive = (this.activeOperations[key] =
       prevActive <= 0 ? 0 : prevActive - 1);
-
+    // Check whether this operation has now become inactive
     if (newActive <= 0) {
+      // Delete all related queued up operations for the inactive one
+      for (let i = this.queue.length - 1; i >= 0; i--)
+        if (this.queue[i].key === operation.key) this.queue.splice(i, 1);
+      // Issue the cancellation teardown operation
       this.dispatchOperation(
         makeOperation('teardown', operation, operation.context)
       );

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -1,6 +1,7 @@
 import { DocumentNode } from 'graphql';
 import { useCallback, useMemo } from 'preact/hooks';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
+
 import {
   CombinedError,
   OperationContext,
@@ -9,7 +10,7 @@ import {
 } from '@urql/core';
 
 import { useClient } from '../context';
-import { useSource, useBehaviourSubject } from './useSource';
+import { useSource } from './useSource';
 import { useRequest } from './useRequest';
 import { initialState } from './constants';
 
@@ -58,12 +59,9 @@ export function useQuery<T = any, V = object>(
     [client, request, args.requestPolicy, args.pollInterval, args.context]
   );
 
-  const [query$$, update] = useBehaviourSubject(
-    useMemo(() => (args.pause ? null : makeQuery$()), [args.pause, makeQuery$])
-  );
-
-  const state = useSource(
-    useMemo(() => {
+  const [state, update] = useSource(
+    useMemo(() => (args.pause ? null : makeQuery$()), [args.pause, makeQuery$]),
+    useCallback((query$$, prevState: UseQueryState<T> | undefined) => {
       return pipe(
         query$$,
         switchMap(query$ => {
@@ -93,11 +91,10 @@ export function useQuery<T = any, V = object>(
             ...result,
             ...partial,
           }),
-          initialState
+          prevState || initialState
         )
       );
-    }, [query$$]),
-    initialState
+    }, [])
   );
 
   // This is the imperative execute function passed to the user

--- a/packages/preact-urql/src/hooks/useSource.ts
+++ b/packages/preact-urql/src/hooks/useSource.ts
@@ -1,88 +1,75 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { useMemo, useEffect, useState } from 'preact/hooks';
+import { useMemo, useEffect, useState, useRef } from 'preact/hooks';
 
-import {
-  Source,
-  fromValue,
-  makeSubject,
-  pipe,
-  map,
-  concat,
-  onPush,
-  publish,
-  subscribe,
-} from 'wonka';
+import { Source, fromValue, makeSubject, pipe, concat, subscribe } from 'wonka';
 
 import { useClient } from '../context';
 
+type Updater<T> = (input: T) => void;
+
 let currentInit = false;
 
-export function useSource<T>(source: Source<T>, init: T): T {
-  const [state, setState] = useState(() => {
+const isShallowDifferent = (a: any, b: any) => {
+  if (typeof a != 'object' || typeof b != 'object') return a !== b;
+  for (const x in a) if (!(x in b)) return true;
+  for (const x in b) if (a[x] !== b[x]) return true;
+  return false;
+};
+
+export function useSource<T, R>(
+  input: T,
+  transform: (input$: Source<T>, initial: R | undefined) => Source<R>
+): [R, Updater<T>] {
+  const client = useClient();
+  const prev = useRef<R>();
+
+  const [input$, updateInput] = useMemo((): [Source<T>, (value: T) => void] => {
+    const subject = makeSubject<T>();
+    const source = concat([fromValue(input), subject.source]);
+
+    let prevInput = input;
+    const updateInput = (input: T) => {
+      if (input !== prevInput) subject.next((prevInput = input));
+    };
+
+    return [source, updateInput];
+  }, []);
+
+  const [state, setState] = useState<R>(() => {
     currentInit = true;
-    let initialValue = init;
 
     pipe(
-      source,
-      onPush(value => {
-        initialValue = value;
-      }),
-      publish
+      transform(fromValue(input), prev.current),
+      subscribe(value => {
+        prev.current = value;
+      })
     ).unsubscribe();
 
     currentInit = false;
-    return initialValue;
+    return prev.current!;
   });
 
   useEffect(() => {
     return pipe(
-      source,
+      transform(input$, prev.current),
       subscribe(value => {
         if (!currentInit) {
-          setState(value);
+          setState(prevValue => {
+            return (prev.current = isShallowDifferent(prevValue, value)
+              ? value
+              : prevValue);
+          });
         }
       })
-    ).unsubscribe as () => void;
-  }, [source]);
+    ).unsubscribe;
+  }, [input$]);
 
-  return state;
-}
-
-export function useBehaviourSubject<T>(value: T) {
-  const client = useClient();
-
-  const state = useMemo((): [Source<T>, (value: T) => void] => {
-    let prevValue = value;
-
-    const subject = makeSubject<T>();
-    const prevValue$ = pipe(
-      fromValue(value),
-      map(() => prevValue)
-    );
-
-    // This turns the subject into a behaviour subject that returns
-    // the last known value (or the initial value) synchronously
-    const source = concat([prevValue$, subject.source]);
-
-    const next = (value: T) => {
-      // We can use the latest known value to also deduplicate next calls.
-      if (value !== prevValue) {
-        subject.next((prevValue = value));
-      }
-    };
-
-    return [source, next];
-  }, []);
-
-  // NOTE: This is a special case for client-side suspense.
-  // We can't trigger suspense inside an effect but only in the render function.
-  // So we "deopt" to not using an effect if the client is in suspense-mode.
   useEffect(() => {
-    if (!client.suspense) state[1](value);
-  }, [state, value]);
+    if (!client.suspense) updateInput(input);
+  }, [updateInput, input]);
 
-  if (client.suspense) state[1](value);
+  if (client.suspense) updateInput(input);
 
-  return state;
+  return [state, updateInput];
 }

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -9,7 +9,7 @@ import {
 } from '@urql/core';
 
 import { useClient } from '../context';
-import { useSource, useBehaviourSubject } from './useSource';
+import { useSource } from './useSource';
 import { useRequest } from './useRequest';
 import { initialState } from './constants';
 
@@ -58,12 +58,9 @@ export function useQuery<T = any, V = object>(
     [client, request, args.requestPolicy, args.pollInterval, args.context]
   );
 
-  const [query$$, update] = useBehaviourSubject(
-    useMemo(() => (args.pause ? null : makeQuery$()), [args.pause, makeQuery$])
-  );
-
-  const state = useSource(
-    useMemo(() => {
+  const [state, update] = useSource(
+    useMemo(() => (args.pause ? null : makeQuery$()), [args.pause, makeQuery$]),
+    useCallback(query$$ => {
       return pipe(
         query$$,
         switchMap(query$ => {
@@ -96,8 +93,7 @@ export function useQuery<T = any, V = object>(
           initialState
         )
       );
-    }, [query$$]),
-    initialState
+    }, [])
   );
 
   // This is the imperative execute function passed to the user

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -1,6 +1,7 @@
 import { DocumentNode } from 'graphql';
 import { useCallback, useMemo } from 'react';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
+
 import {
   CombinedError,
   OperationContext,
@@ -60,7 +61,7 @@ export function useQuery<T = any, V = object>(
 
   const [state, update] = useSource(
     useMemo(() => (args.pause ? null : makeQuery$()), [args.pause, makeQuery$]),
-    useCallback(query$$ => {
+    useCallback((query$$, prevState: UseQueryState<T> | undefined) => {
       return pipe(
         query$$,
         switchMap(query$ => {
@@ -90,7 +91,7 @@ export function useQuery<T = any, V = object>(
             ...result,
             ...partial,
           }),
-          initialState
+          prevState || initialState
         )
       );
     }, [])

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -51,7 +51,7 @@ export function useSource<T, R>(
   });
 
   useEffect(() => {
-    pipe(
+    return pipe(
       transform(input$, prev.current),
       subscribe(value => {
         if (!currentInit) {
@@ -62,7 +62,7 @@ export function useSource<T, R>(
           });
         }
       })
-    );
+    ).unsubscribe;
   }, [input$]);
 
   useEffect(() => {

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -11,7 +11,7 @@ type Updater<T> = (input: T) => void;
 let currentInit = false;
 
 const isShallowDifferent = (a: any, b: any) => {
-  if (typeof a != typeof b || typeof b != 'object') return true;
+  if (typeof a != 'object' || typeof b != 'object') return a !== b;
   for (const x in a) if (!(x in b)) return true;
   for (const x in b) if (a[x] !== b[x]) return true;
   return false;

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -2,87 +2,65 @@
 
 import { useMemo, useEffect, useState } from 'react';
 
-import {
-  Source,
-  fromValue,
-  makeSubject,
-  pipe,
-  map,
-  concat,
-  onPush,
-  publish,
-  subscribe,
-} from 'wonka';
+import { Source, fromValue, makeSubject, pipe, concat, subscribe } from 'wonka';
 
 import { useClient } from '../context';
 
+type Updater<T> = (input: T) => void;
+
 let currentInit = false;
 
-export function useSource<T>(source: Source<T>, init: T): T {
-  const [state, setState] = useState(() => {
+export function useSource<T, R>(
+  input: T,
+  transform: (input$: Source<T>) => Source<R>
+): [R, Updater<T>] {
+  const client = useClient();
+
+  const [input$, updateInput] = useMemo((): [Source<T>, (value: T) => void] => {
+    const subject = makeSubject<T>();
+    const source = concat([fromValue(input), subject.source]);
+
+    let prevInput = input;
+    const updateInput = (input: T) => {
+      if (input !== prevInput) {
+        subject.next((prevInput = input));
+      }
+    };
+
+    return [source, updateInput];
+  }, []);
+
+  const [state, setState] = useState<R>(() => {
+    let currentValue: R;
     currentInit = true;
-    let initialValue = init;
 
     pipe(
-      source,
-      onPush(value => {
-        initialValue = value;
-      }),
-      publish
+      transform(fromValue(input)),
+      subscribe(value => {
+        currentValue = value;
+      })
     ).unsubscribe();
 
     currentInit = false;
-    return initialValue;
+    return currentValue!;
   });
 
   useEffect(() => {
-    return pipe(
-      source,
+    pipe(
+      transform(input$),
       subscribe(value => {
         if (!currentInit) {
           setState(value);
         }
       })
-    ).unsubscribe as () => void;
-  }, [source]);
-
-  return state;
-}
-
-export function useBehaviourSubject<T>(value: T) {
-  const client = useClient();
-
-  const state = useMemo((): [Source<T>, (value: T) => void] => {
-    let prevValue = value;
-
-    const subject = makeSubject<T>();
-    const prevValue$ = pipe(
-      fromValue(value),
-      map(() => prevValue)
     );
+  }, [input$]);
 
-    // This turns the subject into a behaviour subject that returns
-    // the last known value (or the initial value) synchronously
-    const source = concat([prevValue$, subject.source]);
-
-    const next = (value: T) => {
-      // We can use the latest known value to also deduplicate next calls.
-      if (value !== prevValue) {
-        subject.next((prevValue = value));
-      }
-    };
-
-    return [source, next];
-  }, []);
-
-  // NOTE: This is a special case for client-side suspense.
-  // We can't trigger suspense inside an effect but only in the render function.
-  // So we "deopt" to not using an effect if the client is in suspense-mode.
   useEffect(() => {
-    if (!client.suspense) state[1](value);
-  }, [state, value]);
+    if (!client.suspense) updateInput(input);
+  }, [updateInput, input]);
 
-  if (client.suspense) state[1](value);
+  if (client.suspense) updateInput(input);
 
-  return state;
+  return [state, updateInput];
 }

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -4,7 +4,7 @@ import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
 import { CombinedError, OperationContext, Operation } from '@urql/core';
 
 import { useClient } from '../context';
-import { useSource, useBehaviourSubject } from './useSource';
+import { useSource } from './useSource';
 import { useRequest } from './useRequest';
 import { initialState } from './constants';
 
@@ -54,15 +54,12 @@ export function useSubscription<T = any, R = T, V = object>(
     [client, request, args.context]
   );
 
-  const [subscription$$, update] = useBehaviourSubject(
+  const [state, update] = useSource(
     useMemo(() => (args.pause ? null : makeSubscription$()), [
       args.pause,
       makeSubscription$,
-    ])
-  );
-
-  const state = useSource(
-    useMemo(() => {
+    ]),
+    useCallback(subscription$$ => {
       return pipe(
         subscription$$,
         switchMap(subscription$ => {
@@ -99,8 +96,7 @@ export function useSubscription<T = any, R = T, V = object>(
           return { ...result, ...partial, data };
         }, initialState)
       );
-    }, [subscription$$]),
-    initialState
+    }, [])
   );
 
   // This is the imperative execute function passed to the user


### PR DESCRIPTION
## Summary

The motivation of this change is to simplify the `useSource` and `useBehaviourSubject` implementations and to remove various additional edge cases from the implementation, like shallow equal updates. In theory it'd be best to also figure out a way to carry over the subscription from the mount phase to the effect phase, which we attempted before but which very deliberately is impossible in React.

This will not change the behaviour of these hooks dramatically but avoid unnecessary state updates when any updates are obviously equivalent and the hook will furthermore improve continuation from mount to effects, which will fix cases where the state between the mounting and effect phase may slightly change.

## Changes

- Combine `useSource` and `useBehaviourSubject` into just `useSource`
- Prevent shallow-equal updates from being triggered by `useSource` when the state is an object
- Improve continuation from mount to effect phase by re-using previous state values
- Fix `Client.onOperationEnd` to remove cancelled operations from its queue
