### PR TITLE
(chore) - Create GH Action for automated releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+/.github/ @kitten @jovidecroock
 /.changeset/config.json @kitten @jovidecroock
 /scripts/prepare/* @kitten @jovidecroock
 /scripts/rollup/* @kitten @jovidecroock

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+/.changeset/config.json @kitten @jovidecroock
+/scripts/prepare/* @kitten @jovidecroock
+/scripts/rollup/* @kitten @jovidecroock
+/scripts/changesets/* @kitten @jovidecroock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js 12.x
+        uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+      - name: Install Dependencies
+        run: yarn --frozen-lockfile
+      - name: Create PR or Publish to npm
+        id: changesets
+        uses: changesets/action@master
+        with:
+          publish: yarn changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,28 @@
 name: Release
-
 on:
   push:
     branches:
       - main
-
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Setup Node.js 12.x
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: '12'
       - name: Install Dependencies
-        run: yarn --frozen-lockfile
-      - name: Create PR or Publish to npm
+        run: yarn --frozen-lockfile --non-interactive
+      - name: PR or Publish
         id: changesets
-        uses: changesets/action@master
+        uses: changesets/action@bfeb9e0
         with:
-          publish: yarn changeset publish
+          publish: ./node_modules/.bin/changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
       - name: PR or Publish
         id: changesets
         uses: changesets/action@bfeb9e0
-        with:
-          publish: ./node_modules/.bin/changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This automates our release process, we're already using changesets but what changed?

- Every merged PR will make a PR from changesets that increments all versions (`yarn changeset version`) and updates changelogs
- When we merge it it will release all the packages to the NPM-registry

TODO: add npm-token to this repo's secrets