### PR TITLE
(core) - Add support for TypedDocumentNode

### DIFF
--- a/.changeset/fifty-fans-dream.md
+++ b/.changeset/fifty-fans-dream.md
@@ -1,0 +1,9 @@
+---
+'@urql/exchange-graphcache': patch
+'@urql/core': patch
+'@urql/preact': patch
+'urql': patch
+'@urql/svelte': patch
+---
+
+Add support for `TypedDocumentNode` to infer the type of the `OperationResult` and `Operation` for all methods, functions, and hooks that either directly or indirectly accept a `DocumentNode`. See [`graphql-typed-document-node` and the corresponding blog post for more information.](https://github.com/dotansimha/graphql-typed-document-node)

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -1,3 +1,4 @@
+import { TypedDocumentNode } from '@urql/core';
 import { DocumentNode, FragmentDefinitionNode } from 'graphql';
 
 // Helper types
@@ -52,8 +53,8 @@ export interface KeyInfo {
 
 // This is an input operation
 export interface OperationRequest {
-  query: DocumentNode;
-  variables?: object;
+  query: DocumentNode | TypedDocumentNode<any, any>;
+  variables?: any;
 }
 
 export interface ResolveInfo {
@@ -67,9 +68,9 @@ export interface ResolveInfo {
   optimistic?: boolean;
 }
 
-export interface QueryInput {
-  query: string | DocumentNode;
-  variables?: Variables;
+export interface QueryInput<T = Data, V = Variables> {
+  query: string | DocumentNode | TypedDocumentNode<T, V>;
+  variables?: V;
 }
 
 export interface Cache {
@@ -99,26 +100,26 @@ export interface Cache {
   invalidate(entity: Data | string, fieldName?: string, args?: Variables): void;
 
   /** updateQuery() can be used to update the data of a given query using an updater function */
-  updateQuery(
-    input: QueryInput,
-    updater: (data: Data | null) => Data | null
+  updateQuery<T = Data, V = Variables>(
+    input: QueryInput<T, V>,
+    updater: (data: T | null) => T | null
   ): void;
 
   /** readQuery() retrieves the data for a given query */
-  readQuery(input: QueryInput): Data | null;
+  readQuery<T = Data, V = Variables>(input: QueryInput<T, V>): T | null;
 
   /** readFragment() retrieves the data for a given fragment, given a partial/keyable entity or an entity key */
-  readFragment(
-    fragment: DocumentNode,
-    entity: string | Data,
-    variables?: Variables
-  ): Data | null;
+  readFragment<T = Data, V = Variables>(
+    fragment: DocumentNode | TypedDocumentNode<T, V>,
+    entity: string | Data | T,
+    variables?: V
+  ): T | null;
 
   /** writeFragment() can be used to update the data of a given fragment, given an entity that is supposed to be written using the fragment */
-  writeFragment(
-    fragment: DocumentNode,
-    data: Data,
-    variables?: Variables
+  writeFragment<T = Data, V = Variables>(
+    fragment: DocumentNode | TypedDocumentNode<T, V>,
+    data: T,
+    variables?: V
   ): void;
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "dependencies": {
+    "@graphql-typed-document-node/core": "^3.1.0",
     "wonka": "^4.0.14"
   },
   "publishConfig": {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -187,7 +187,11 @@ export class Client {
     request: GraphQLRequest<Data, Variables>,
     opts?: Partial<OperationContext>
   ): Operation<Data, Variables> =>
-    makeOperation(kind, request, this.createOperationContext(opts));
+    makeOperation<Data, Variables>(
+      kind,
+      request,
+      this.createOperationContext(opts)
+    );
 
   /** Counts up the active operation key and dispatches the operation */
   private onOperationStart(operation: Operation) {
@@ -222,7 +226,7 @@ export class Client {
     let operationResults$ = pipe(
       this.results$,
       filter((res: OperationResult) => res.operation.key === key)
-    );
+    ) as Source<OperationResult<Data, Variables>>;
 
     if (this.maskTypename) {
       operationResults$ = pipe(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
+export { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
 export * from './client';
 export * from './exchanges';
 export * from './types';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,4 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { Source } from 'wonka';
 import { Client } from './client';
@@ -23,10 +24,10 @@ export type RequestPolicy =
 export type CacheOutcome = 'miss' | 'partial' | 'hit';
 
 /** A Graphql query, mutation, or subscription. */
-export interface GraphQLRequest {
+export interface GraphQLRequest<Data = any, Variables = object> {
   /** Unique identifier of the request. */
   key: number;
-  query: DocumentNode;
+  query: DocumentNode | TypedDocumentNode<Data, Variables>;
   variables?: object;
 }
 
@@ -53,7 +54,8 @@ export interface OperationContext {
 }
 
 /** A [query]{@link Query} or [mutation]{@link Mutation} with additional metadata for use during transmission. */
-export interface Operation extends GraphQLRequest {
+export interface Operation<Data = any, Variables = object>
+  extends GraphQLRequest<Data, Variables> {
   readonly kind: OperationType;
   context: OperationContext;
 
@@ -62,9 +64,9 @@ export interface Operation extends GraphQLRequest {
 }
 
 /** Resulting data from an [operation]{@link Operation}. */
-export interface OperationResult<Data = any> {
+export interface OperationResult<Data = any, Variables = object> {
   /** The [operation]{@link Operation} which has been executed. */
-  operation: Operation;
+  operation: Operation<Data, Variables>;
   /** The data returned from the Graphql server. */
   data?: Data;
   /** Any errors resulting from the operation. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -28,7 +28,7 @@ export interface GraphQLRequest<Data = any, Variables = object> {
   /** Unique identifier of the request. */
   key: number;
   query: DocumentNode | TypedDocumentNode<Data, Variables>;
-  variables?: object;
+  variables?: Variables;
 }
 
 /** Metadata that is only available in development for devtools. */
@@ -54,7 +54,7 @@ export interface OperationContext {
 }
 
 /** A [query]{@link Query} or [mutation]{@link Mutation} with additional metadata for use during transmission. */
-export interface Operation<Data = any, Variables = object>
+export interface Operation<Data = any, Variables = any>
   extends GraphQLRequest<Data, Variables> {
   readonly kind: OperationType;
   context: OperationContext;
@@ -64,7 +64,7 @@ export interface Operation<Data = any, Variables = object>
 }
 
 /** Resulting data from an [operation]{@link Operation}. */
-export interface OperationResult<Data = any, Variables = object> {
+export interface OperationResult<Data = any, Variables = any> {
   /** The [operation]{@link Operation} which has been executed. */
   operation: Operation<Data, Variables>;
   /** The data returned from the Graphql server. */

--- a/packages/core/src/utils/operation.ts
+++ b/packages/core/src/utils/operation.ts
@@ -15,16 +15,17 @@ const DEPRECATED: Record<string, Warning> = {
   },
 };
 
-function makeOperation(
+function makeOperation<Data = any, Variables = object>(
   kind: OperationType,
-  request: GraphQLRequest,
+  request: GraphQLRequest<Data, Variables>,
   context: OperationContext
-): Operation;
-function makeOperation(
+): Operation<Data, Variables>;
+
+function makeOperation<Data = any, Variables = object>(
   kind: OperationType,
-  request: Operation,
+  request: Operation<Data, Variables>,
   context?: OperationContext
-): Operation;
+): Operation<Data, Variables>;
 
 function makeOperation(kind, request, context) {
   if (!context) context = request.context;

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -1,3 +1,4 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode, Kind, parse, print } from 'graphql';
 import { hash, phash } from './hash';
 import { stringifyVariables } from './stringifyVariables';
@@ -12,10 +13,10 @@ const hashQuery = (q: string): number =>
 
 const docs: Documents = Object.create(null);
 
-export const createRequest = (
-  q: string | DocumentNode,
-  vars?: object
-): GraphQLRequest => {
+export const createRequest = <Data = any, Variables = object>(
+  q: string | DocumentNode | TypedDocumentNode<Data, Variables>,
+  vars?: Variables
+): GraphQLRequest<Data, Variables> => {
   let key: number;
   let query: DocumentNode;
   if (typeof q === 'string') {

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -37,7 +37,7 @@ export const createRequest = <Data = any, Variables = object>(
   return {
     key: vars ? phash(key, stringifyVariables(vars)) >>> 0 : key,
     query,
-    variables: vars || {},
+    variables: vars || ({} as Variables),
   };
 };
 

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -59,7 +59,7 @@ const formatNode = (node: FieldNode | InlineFragmentNode) => {
   }
 };
 
-export const formatDocument = (node: DocumentNode): DocumentNode => {
+export const formatDocument = <T extends DocumentNode>(node: T): T => {
   const result = visit(node, {
     Field: formatNode,
     InlineFragment: formatNode,

--- a/packages/preact-urql/src/components/Mutation.ts
+++ b/packages/preact-urql/src/components/Mutation.ts
@@ -1,7 +1,10 @@
 import { VNode } from 'preact';
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
-import { OperationResult, OperationContext } from '@urql/core';
+import {
+  TypedDocumentNode,
+  OperationResult,
+  OperationContext,
+} from '@urql/core';
 import { useMutation, UseMutationState } from '../hooks';
 
 export interface MutationProps<Data = any, Variables = object> {

--- a/packages/preact-urql/src/components/Mutation.ts
+++ b/packages/preact-urql/src/components/Mutation.ts
@@ -1,26 +1,25 @@
 import { VNode } from 'preact';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { OperationResult, OperationContext } from '@urql/core';
 import { useMutation, UseMutationState } from '../hooks';
 
-export interface MutationProps<T, V> {
-  query: DocumentNode | string;
-  children: (arg: MutationState<T, V>) => VNode<any>;
+export interface MutationProps<Data = any, Variables = object> {
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string;
+  children: (arg: MutationState<Data, Variables>) => VNode<any>;
 }
 
-export interface MutationState<T, V> extends UseMutationState<T> {
+export interface MutationState<Data = any, Variables = object>
+  extends UseMutationState<Data, Variables> {
   executeMutation: (
-    variables?: V,
+    variables?: Variables,
     context?: Partial<OperationContext>
-  ) => Promise<OperationResult<T>>;
+  ) => Promise<OperationResult<Data, Variables>>;
 }
 
-export function Mutation<T = any, V = any>(
-  props: MutationProps<T, V>
+export function Mutation<Data = any, Variables = any>(
+  props: MutationProps<Data, Variables>
 ): VNode<any> {
-  const mutationState = useMutation<T, V>(props.query);
-  return props.children({
-    ...mutationState[0],
-    executeMutation: mutationState[1],
-  });
+  const mutation = useMutation<Data, Variables>(props.query);
+  return props.children({ ...mutation[0], executeMutation: mutation[1] });
 }

--- a/packages/preact-urql/src/components/Query.ts
+++ b/packages/preact-urql/src/components/Query.ts
@@ -2,15 +2,19 @@ import { VNode } from 'preact';
 import { OperationContext } from '@urql/core';
 import { useQuery, UseQueryArgs, UseQueryState } from '../hooks';
 
-export interface QueryProps<T, V> extends UseQueryArgs<V> {
-  children: (arg: QueryState<T>) => VNode<any>;
+export interface QueryProps<Data = any, Variables = object>
+  extends UseQueryArgs<Variables, Data> {
+  children: (arg: QueryState<Data, Variables>) => VNode<any>;
 }
 
-export interface QueryState<T> extends UseQueryState<T> {
+export interface QueryState<Data = any, Variables = object>
+  extends UseQueryState<Data, Variables> {
   executeQuery: (opts?: Partial<OperationContext>) => void;
 }
 
-export function Query<T = any, V = any>(props: QueryProps<T, V>): VNode<any> {
-  const queryState = useQuery<T, V>(props);
-  return props.children({ ...queryState[0], executeQuery: queryState[1] });
+export function Query<Data = any, Variables = any>(
+  props: QueryProps<Data, Variables>
+): VNode<any> {
+  const query = useQuery<Data, Variables>(props);
+  return props.children({ ...query[0], executeQuery: query[1] });
 }

--- a/packages/preact-urql/src/components/Subscription.ts
+++ b/packages/preact-urql/src/components/Subscription.ts
@@ -1,5 +1,6 @@
 import { VNode } from 'preact';
 import { OperationContext } from '@urql/core';
+
 import {
   useSubscription,
   UseSubscriptionArgs,
@@ -7,21 +8,30 @@ import {
   SubscriptionHandler,
 } from '../hooks';
 
-export interface SubscriptionProps<T, R, V> extends UseSubscriptionArgs<V> {
-  handler?: SubscriptionHandler<T, R>;
-  children: (arg: SubscriptionState<R>) => VNode<any>;
+export interface SubscriptionProps<
+  Data = any,
+  Result = Data,
+  Variables = object
+> extends UseSubscriptionArgs<Variables, Data> {
+  handler?: SubscriptionHandler<Data, Result>;
+  children: (arg: SubscriptionState<Result, Variables>) => VNode<any>;
 }
 
-export interface SubscriptionState<T> extends UseSubscriptionState<T> {
+export interface SubscriptionState<Data = any, Variables = object>
+  extends UseSubscriptionState<Data, Variables> {
   executeSubscription: (opts?: Partial<OperationContext>) => void;
 }
 
-export function Subscription<T = any, R = T, V = any>(
-  props: SubscriptionProps<T, R, V>
+export function Subscription<Data = any, Result = Data, Variables = object>(
+  props: SubscriptionProps<Data, Result, Variables>
 ): VNode<any> {
-  const subscriptionState = useSubscription<T, R, V>(props, props.handler);
+  const subscription = useSubscription<Data, Result, Variables>(
+    props,
+    props.handler
+  );
+
   return props.children({
-    ...subscriptionState[0],
-    executeSubscription: subscriptionState[1],
+    ...subscription[0],
+    executeSubscription: subscription[1],
   });
 }

--- a/packages/preact-urql/src/hooks/useMutation.ts
+++ b/packages/preact-urql/src/hooks/useMutation.ts
@@ -42,12 +42,12 @@ export function useMutation<Data = any, Variables = object>(
   );
 
   const executeMutation = useCallback(
-    (variables: Variables, context?: Partial<OperationContext>) => {
+    (variables?: Variables, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
 
       return pipe(
         client.executeMutation<Data, Variables>(
-          createRequest(query, variables),
+          createRequest<Data, Variables>(query, variables),
           context || {}
         ),
         toPromise

--- a/packages/preact-urql/src/hooks/useMutation.ts
+++ b/packages/preact-urql/src/hooks/useMutation.ts
@@ -1,9 +1,9 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useState, useCallback, useRef, useEffect } from 'preact/hooks';
 import { pipe, toPromise } from 'wonka';
 
 import {
+  TypedDocumentNode,
   OperationResult,
   OperationContext,
   CombinedError,

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -1,9 +1,9 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useCallback, useMemo } from 'preact/hooks';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
 
 import {
+  TypedDocumentNode,
   CombinedError,
   OperationContext,
   RequestPolicy,

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -1,3 +1,4 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useCallback, useMemo } from 'preact/hooks';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
@@ -14,42 +15,42 @@ import { useSource } from './useSource';
 import { useRequest } from './useRequest';
 import { initialState } from './constants';
 
-export interface UseQueryArgs<V> {
-  query: string | DocumentNode;
-  variables?: V;
+export interface UseQueryArgs<Variables = object, Data = any> {
+  query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
+  variables?: Variables;
   requestPolicy?: RequestPolicy;
   pollInterval?: number;
   context?: Partial<OperationContext>;
   pause?: boolean;
 }
 
-export interface UseQueryState<T> {
+export interface UseQueryState<Data = any, Variables = object> {
   fetching: boolean;
   stale: boolean;
-  data?: T;
+  data?: Data;
   error?: CombinedError;
   extensions?: Record<string, any>;
-  operation?: Operation;
+  operation?: Operation<Data, Variables>;
 }
 
-export type UseQueryResponse<T> = [
-  UseQueryState<T>,
+export type UseQueryResponse<Data = any, Variables = object> = [
+  UseQueryState<Data, Variables>,
   (opts?: Partial<OperationContext>) => void
 ];
 
-export function useQuery<T = any, V = object>(
-  args: UseQueryArgs<V>
-): UseQueryResponse<T> {
+export function useQuery<Data = any, Variables = object>(
+  args: UseQueryArgs<Variables, Data>
+): UseQueryResponse<Data, Variables> {
   const client = useClient();
 
   // This creates a request which will keep a stable reference
   // if request.key doesn't change
-  const request = useRequest(args.query, args.variables);
+  const request = useRequest<Data, Variables>(args.query, args.variables);
 
   // Create a new query-source from client.executeQuery
   const makeQuery$ = useCallback(
     (opts?: Partial<OperationContext>) => {
-      return client.executeQuery(request, {
+      return client.executeQuery<Data, Variables>(request, {
         requestPolicy: args.requestPolicy,
         pollInterval: args.pollInterval,
         ...args.context,
@@ -87,7 +88,7 @@ export function useQuery<T = any, V = object>(
         }),
         // The individual partial results are merged into each previous result
         scan(
-          (result, partial) => ({
+          (result: UseQueryState<Data, Variables>, partial) => ({
             ...result,
             ...partial,
           }),

--- a/packages/preact-urql/src/hooks/useRequest.ts
+++ b/packages/preact-urql/src/hooks/useRequest.ts
@@ -1,7 +1,6 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useRef, useMemo } from 'preact/hooks';
-import { GraphQLRequest, createRequest } from '@urql/core';
+import { TypedDocumentNode, GraphQLRequest, createRequest } from '@urql/core';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
 export function useRequest<Data = any, Variables = object>(

--- a/packages/preact-urql/src/hooks/useRequest.ts
+++ b/packages/preact-urql/src/hooks/useRequest.ts
@@ -1,21 +1,23 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useRef, useMemo } from 'preact/hooks';
 import { GraphQLRequest, createRequest } from '@urql/core';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
-export const useRequest = (
-  query: string | DocumentNode,
-  variables?: any
-): GraphQLRequest => {
-  const prev = useRef<undefined | GraphQLRequest>(undefined);
+export function useRequest<Data = any, Variables = object>(
+  query: string | DocumentNode | TypedDocumentNode<Data, Variables>,
+  variables?: Variables
+): GraphQLRequest<Data, Variables> {
+  const prev = useRef<undefined | GraphQLRequest<Data, Variables>>(undefined);
 
   return useMemo(() => {
-    const request = createRequest(query, variables);
+    const request = createRequest<Data, Variables>(query, variables);
     // We manually ensure reference equality if the key hasn't changed
-    if (prev.current != null && prev.current.key === request.key) {
+    if (prev.current !== undefined && prev.current.key === request.key) {
       return prev.current;
     } else {
-      return (prev.current = request);
+      prev.current = request;
+      return request;
     }
   }, [query, variables]);
-};
+}

--- a/packages/preact-urql/src/hooks/useSubscription.ts
+++ b/packages/preact-urql/src/hooks/useSubscription.ts
@@ -1,8 +1,12 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useCallback, useRef, useMemo } from 'preact/hooks';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
-import { CombinedError, OperationContext, Operation } from '@urql/core';
+import {
+  TypedDocumentNode,
+  CombinedError,
+  OperationContext,
+  Operation,
+} from '@urql/core';
 
 import { useClient } from '../context';
 import { useSource } from './useSource';

--- a/packages/preact-urql/src/hooks/useSubscription.ts
+++ b/packages/preact-urql/src/hooks/useSubscription.ts
@@ -68,43 +68,48 @@ export function useSubscription<Data = any, Result = Data, Variables = object>(
       makeSubscription$,
     ]),
     useCallback(
-      (subscription$$, prevState: UseSubscriptionState<Result> | undefined) => {
+      (
+        subscription$$,
+        prevState: UseSubscriptionState<Result, Variables> | undefined
+      ) => {
         return pipe(
           subscription$$,
           switchMap(subscription$ => {
             if (!subscription$) return fromValue({ fetching: false });
 
-          return concat([
-            // Initially set fetching to true
-            fromValue({ fetching: true, stale: false }),
-            pipe(
-              subscription$,
-              map(({ stale, data, error, extensions, operation }) => ({
-                fetching: true,
-                stale: !!stale,
-                data,
-                error,
-                extensions,
-                operation,
-              }))
-            ),
-            // When the source proactively closes, fetching is set to false
-            fromValue({ fetching: false, stale: false }),
-          ]);
-        }),
-        // The individual partial results are merged into each previous result
-        scan(
-          (result: UseSubscriptionState<Result, Variables>, partial: any) => {
-            const { current: handler } = handlerRef;
-            // If a handler has been passed, it's used to merge new data in
-            const data =
-              partial.data !== undefined
-                ? typeof handler === 'function'
-                  ? handler(result.data, partial.data)
-                  : partial.data
-                : result.data;
-            return { ...result, ...partial, data };
-          }, prevState || initialState)
+            return concat([
+              // Initially set fetching to true
+              fromValue({ fetching: true, stale: false }),
+              pipe(
+                subscription$,
+                map(({ stale, data, error, extensions, operation }) => ({
+                  fetching: true,
+                  stale: !!stale,
+                  data,
+                  error,
+                  extensions,
+                  operation,
+                }))
+              ),
+              // When the source proactively closes, fetching is set to false
+              fromValue({ fetching: false, stale: false }),
+            ]);
+          }),
+          // The individual partial results are merged into each previous result
+          scan(
+            (result: UseSubscriptionState<Result, Variables>, partial: any) => {
+              const { current: handler } = handlerRef;
+              // If a handler has been passed, it's used to merge new data in
+              const data =
+                partial.data !== undefined
+                  ? typeof handler === 'function'
+                    ? handler(result.data, partial.data)
+                    : partial.data
+                  : result.data;
+              return { ...result, ...partial, data };
+            },
+            prevState || initialState
+          )
         );
       },
       []

--- a/packages/preact-urql/src/hooks/useSubscription.ts
+++ b/packages/preact-urql/src/hooks/useSubscription.ts
@@ -1,3 +1,4 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useCallback, useRef, useMemo } from 'preact/hooks';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
@@ -8,33 +9,33 @@ import { useSource } from './useSource';
 import { useRequest } from './useRequest';
 import { initialState } from './constants';
 
-export interface UseSubscriptionArgs<V> {
-  query: DocumentNode | string;
-  variables?: V;
+export interface UseSubscriptionArgs<Variables = object, Data = any> {
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string;
+  variables?: Variables;
   pause?: boolean;
   context?: Partial<OperationContext>;
 }
 
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 
-export interface UseSubscriptionState<T> {
+export interface UseSubscriptionState<Data = any, Variables = object> {
   fetching: boolean;
   stale: boolean;
-  data?: T;
+  data?: Data;
   error?: CombinedError;
   extensions?: Record<string, any>;
-  operation?: Operation;
+  operation?: Operation<Data, Variables>;
 }
 
-export type UseSubscriptionResponse<T> = [
-  UseSubscriptionState<T>,
+export type UseSubscriptionResponse<Data = any, Variables = object> = [
+  UseSubscriptionState<Data, Variables>,
   (opts?: Partial<OperationContext>) => void
 ];
 
-export function useSubscription<T = any, R = T, V = object>(
-  args: UseSubscriptionArgs<V>,
-  handler?: SubscriptionHandler<T, R>
-): UseSubscriptionResponse<R> {
+export function useSubscription<Data = any, Result = Data, Variables = object>(
+  args: UseSubscriptionArgs<Variables, Data>,
+  handler?: SubscriptionHandler<Data, Result>
+): UseSubscriptionResponse<Result, Variables> {
   const client = useClient();
 
   // Update handler on constant ref, since handler changes shouldn't
@@ -44,12 +45,15 @@ export function useSubscription<T = any, R = T, V = object>(
 
   // This creates a request which will keep a stable reference
   // if request.key doesn't change
-  const request = useRequest(args.query, args.variables);
+  const request = useRequest<Data, Variables>(args.query, args.variables);
 
   // Create a new subscription-source from client.executeSubscription
   const makeSubscription$ = useCallback(
     (opts?: Partial<OperationContext>) => {
-      return client.executeSubscription(request, { ...args.context, ...opts });
+      return client.executeSubscription<Data, Variables>(request, {
+        ...args.context,
+        ...opts,
+      });
     },
     [client, request, args.context]
   );
@@ -60,32 +64,33 @@ export function useSubscription<T = any, R = T, V = object>(
       makeSubscription$,
     ]),
     useCallback(
-      (subscription$$, prevState: UseSubscriptionState<R> | undefined) => {
+      (subscription$$, prevState: UseSubscriptionState<Result> | undefined) => {
         return pipe(
           subscription$$,
           switchMap(subscription$ => {
             if (!subscription$) return fromValue({ fetching: false });
 
-            return concat([
-              // Initially set fetching to true
-              fromValue({ fetching: true, stale: false }),
-              pipe(
-                subscription$,
-                map(({ stale, data, error, extensions, operation }) => ({
-                  fetching: true,
-                  stale: !!stale,
-                  data,
-                  error,
-                  extensions,
-                  operation,
-                }))
-              ),
-              // When the source proactively closes, fetching is set to false
-              fromValue({ fetching: false, stale: false }),
-            ]);
-          }),
-          // The individual partial results are merged into each previous result
-          scan((result, partial: any) => {
+          return concat([
+            // Initially set fetching to true
+            fromValue({ fetching: true, stale: false }),
+            pipe(
+              subscription$,
+              map(({ stale, data, error, extensions, operation }) => ({
+                fetching: true,
+                stale: !!stale,
+                data,
+                error,
+                extensions,
+                operation,
+              }))
+            ),
+            // When the source proactively closes, fetching is set to false
+            fromValue({ fetching: false, stale: false }),
+          ]);
+        }),
+        // The individual partial results are merged into each previous result
+        scan(
+          (result: UseSubscriptionState<Result, Variables>, partial: any) => {
             const { current: handler } = handlerRef;
             // If a handler has been passed, it's used to merge new data in
             const data =

--- a/packages/react-urql/src/components/Mutation.ts
+++ b/packages/react-urql/src/components/Mutation.ts
@@ -1,7 +1,10 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { ReactElement } from 'react';
-import { OperationResult, OperationContext } from '@urql/core';
+import {
+  TypedDocumentNode,
+  OperationResult,
+  OperationContext,
+} from '@urql/core';
 import { useMutation, UseMutationState } from '../hooks';
 
 export interface MutationProps<Data = any, Variables = object> {

--- a/packages/react-urql/src/components/Mutation.ts
+++ b/packages/react-urql/src/components/Mutation.ts
@@ -1,23 +1,25 @@
-import { ReactElement } from 'react';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
+import { ReactElement } from 'react';
 import { OperationResult, OperationContext } from '@urql/core';
 import { useMutation, UseMutationState } from '../hooks';
 
-export interface MutationProps<T, V> {
-  query: DocumentNode | string;
-  children: (arg: MutationState<T, V>) => ReactElement<any>;
+export interface MutationProps<Data = any, Variables = object> {
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string;
+  children: (arg: MutationState<Data, Variables>) => ReactElement<any>;
 }
 
-export interface MutationState<T, V> extends UseMutationState<T> {
+export interface MutationState<Data = any, Variables = object>
+  extends UseMutationState<Data, Variables> {
   executeMutation: (
-    variables?: V,
+    variables?: Variables,
     context?: Partial<OperationContext>
-  ) => Promise<OperationResult<T>>;
+  ) => Promise<OperationResult<Data, Variables>>;
 }
 
-export function Mutation<T = any, V = any>(
-  props: MutationProps<T, V>
+export function Mutation<Data = any, Variables = any>(
+  props: MutationProps<Data, Variables>
 ): ReactElement<any> {
-  const [state, executeMutation] = useMutation<T, V>(props.query);
-  return props.children({ ...state, executeMutation });
+  const mutation = useMutation<Data, Variables>(props.query);
+  return props.children({ ...mutation[0], executeMutation: mutation[1] });
 }

--- a/packages/react-urql/src/components/Query.ts
+++ b/packages/react-urql/src/components/Query.ts
@@ -2,17 +2,19 @@ import { ReactElement } from 'react';
 import { OperationContext } from '@urql/core';
 import { useQuery, UseQueryArgs, UseQueryState } from '../hooks';
 
-export interface QueryProps<T, V> extends UseQueryArgs<V> {
-  children: (arg: QueryState<T>) => ReactElement<any>;
+export interface QueryProps<Data = any, Variables = object>
+  extends UseQueryArgs<Variables, Data> {
+  children: (arg: QueryState<Data, Variables>) => ReactElement<any>;
 }
 
-export interface QueryState<T> extends UseQueryState<T> {
+export interface QueryState<Data = any, Variables = object>
+  extends UseQueryState<Data, Variables> {
   executeQuery: (opts?: Partial<OperationContext>) => void;
 }
 
-export function Query<T = any, V = any>(
-  props: QueryProps<T, V>
+export function Query<Data = any, Variables = any>(
+  props: QueryProps<Data, Variables>
 ): ReactElement<any> {
-  const [state, executeQuery] = useQuery<T, V>(props);
-  return props.children({ ...state, executeQuery });
+  const query = useQuery<Data, Variables>(props);
+  return props.children({ ...query[0], executeQuery: query[1] });
 }

--- a/packages/react-urql/src/components/Subscription.ts
+++ b/packages/react-urql/src/components/Subscription.ts
@@ -8,21 +8,30 @@ import {
   SubscriptionHandler,
 } from '../hooks';
 
-export interface SubscriptionProps<T, R, V> extends UseSubscriptionArgs<V> {
-  handler?: SubscriptionHandler<T, R>;
-  children: (arg: SubscriptionState<R>) => ReactElement<any>;
+export interface SubscriptionProps<
+  Data = any,
+  Result = Data,
+  Variables = object
+> extends UseSubscriptionArgs<Variables, Data> {
+  handler?: SubscriptionHandler<Data, Result>;
+  children: (arg: SubscriptionState<Result, Variables>) => ReactElement<any>;
 }
 
-export interface SubscriptionState<T> extends UseSubscriptionState<T> {
+export interface SubscriptionState<Data = any, Variables = object>
+  extends UseSubscriptionState<Data, Variables> {
   executeSubscription: (opts?: Partial<OperationContext>) => void;
 }
 
-export function Subscription<T = any, R = T, V = any>(
-  props: SubscriptionProps<T, R, V>
+export function Subscription<Data = any, Result = Data, Variables = object>(
+  props: SubscriptionProps<Data, Result, Variables>
 ): ReactElement<any> {
-  const [state, executeSubscription] = useSubscription<T, R, V>(
+  const subscription = useSubscription<Data, Result, Variables>(
     props,
     props.handler
   );
-  return props.children({ ...state, executeSubscription });
+
+  return props.children({
+    ...subscription[0],
+    executeSubscription: subscription[1],
+  });
 }

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -42,12 +42,12 @@ export function useMutation<Data = any, Variables = object>(
   );
 
   const executeMutation = useCallback(
-    (variables: Variables, context?: Partial<OperationContext>) => {
+    (variables?: Variables, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
 
       return pipe(
         client.executeMutation<Data, Variables>(
-          createRequest(query, variables),
+          createRequest<Data, Variables>(query, variables),
           context || {}
         ),
         toPromise

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -1,9 +1,9 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { pipe, toPromise } from 'wonka';
 
 import {
+  TypedDocumentNode,
   OperationResult,
   OperationContext,
   CombinedError,

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -1,3 +1,4 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { pipe, toPromise } from 'wonka';
@@ -13,38 +14,40 @@ import {
 import { useClient } from '../context';
 import { initialState } from './constants';
 
-export interface UseMutationState<T> {
+export interface UseMutationState<Data = any, Variables = object> {
   fetching: boolean;
   stale: boolean;
-  data?: T;
+  data?: Data;
   error?: CombinedError;
   extensions?: Record<string, any>;
-  operation?: Operation;
+  operation?: Operation<Data, Variables>;
 }
 
-export type UseMutationResponse<T, V> = [
-  UseMutationState<T>,
+export type UseMutationResponse<Data = any, Variables = object> = [
+  UseMutationState<Data, Variables>,
   (
-    variables?: V,
+    variables?: Variables,
     context?: Partial<OperationContext>
-  ) => Promise<OperationResult<T>>
+  ) => Promise<OperationResult<Data, Variables>>
 ];
 
-export function useMutation<T = any, V = object>(
-  query: DocumentNode | string
-): UseMutationResponse<T, V> {
+export function useMutation<Data = any, Variables = object>(
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string
+): UseMutationResponse<Data, Variables> {
   const isMounted = useRef(true);
   const client = useClient();
 
-  const [state, setState] = useState<UseMutationState<T>>(initialState);
+  const [state, setState] = useState<UseMutationState<Data, Variables>>(
+    initialState
+  );
 
   const executeMutation = useCallback(
-    (variables?: V, context?: Partial<OperationContext>) => {
+    (variables: Variables, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
 
       return pipe(
-        client.executeMutation(
-          createRequest(query, variables as any),
+        client.executeMutation<Data, Variables>(
+          createRequest(query, variables),
           context || {}
         ),
         toPromise

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -1,9 +1,9 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useCallback, useMemo } from 'react';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
 
 import {
+  TypedDocumentNode,
   CombinedError,
   OperationContext,
   RequestPolicy,

--- a/packages/react-urql/src/hooks/useRequest.ts
+++ b/packages/react-urql/src/hooks/useRequest.ts
@@ -1,16 +1,17 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useRef, useMemo } from 'react';
 import { GraphQLRequest, createRequest } from '@urql/core';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
-export function useRequest(
-  query: string | DocumentNode,
-  variables?: any
-): GraphQLRequest {
-  const prev = useRef<undefined | GraphQLRequest>(undefined);
+export function useRequest<Data = any, Variables = object>(
+  query: string | DocumentNode | TypedDocumentNode<Data, Variables>,
+  variables?: Variables
+): GraphQLRequest<Data, Variables> {
+  const prev = useRef<undefined | GraphQLRequest<Data, Variables>>(undefined);
 
   return useMemo(() => {
-    const request = createRequest(query, variables);
+    const request = createRequest<Data, Variables>(query, variables);
     // We manually ensure reference equality if the key hasn't changed
     if (prev.current !== undefined && prev.current.key === request.key) {
       return prev.current;

--- a/packages/react-urql/src/hooks/useRequest.ts
+++ b/packages/react-urql/src/hooks/useRequest.ts
@@ -1,7 +1,6 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useRef, useMemo } from 'react';
-import { GraphQLRequest, createRequest } from '@urql/core';
+import { TypedDocumentNode, GraphQLRequest, createRequest } from '@urql/core';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
 export function useRequest<Data = any, Variables = object>(

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -1,8 +1,13 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 import { useCallback, useRef, useMemo } from 'react';
 import { pipe, concat, fromValue, switchMap, map, scan } from 'wonka';
-import { CombinedError, OperationContext, Operation } from '@urql/core';
+
+import {
+  TypedDocumentNode,
+  CombinedError,
+  OperationContext,
+  Operation,
+} from '@urql/core';
 
 import { useClient } from '../context';
 import { useSource } from './useSource';

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -1,5 +1,6 @@
 import { Readable, writable } from 'svelte/store';
 import { DocumentNode } from 'graphql';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { OperationContext, CombinedError } from '@urql/core';
 
 import { _storeUpdate } from './internal';
@@ -15,8 +16,8 @@ type Updater<T> = (value: T) => T;
 export interface OperationStore<Data = any, Vars = any>
   extends Readable<OperationStore<Data, Vars>> {
   // Input properties
-  query: DocumentNode | string;
-  variables: Vars | undefined | null;
+  query: DocumentNode | TypedDocumentNode<Data, Vars> | string;
+  variables: Vars | null;
   context: Partial<OperationContext> | undefined;
   // Output properties
   readonly stale: boolean;
@@ -30,13 +31,13 @@ export interface OperationStore<Data = any, Vars = any>
 }
 
 export function operationStore<Data = any, Vars = object>(
-  query: string | DocumentNode,
+  query: string | DocumentNode | TypedDocumentNode<Data, Vars>,
   variables?: Vars | null,
   context?: Partial<OperationContext & { pause: boolean }>
 ): OperationStore<Data, Vars> {
   const internal = {
     query,
-    variables,
+    variables: variables || null,
     context,
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,6 +1454,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@graphql-typed-document-node/core@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
+  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"


### PR DESCRIPTION
Resolve https://github.com/dotansimha/graphql-typed-document-node/issues/36

## Summary

This comprehensively adds `Data` and `Variables` generics with untyped fallbacks to all of our results and operations, containing either `DocumentNode` or variables.

It uses the `TypedDocumentNode` type from `@graphql-typed-document-node/core` which is just a stand-in for generated types for a given GraphQL document. So other tooling can step in and fill this out. The advantage of using it throughout is that all of our APIs will be able to accept a `TypedDocumentNode` which then subsequently makes their results typed as well, similar to `graphql_ppx` and `reason-urql`.

## Set of changes

- Reexport `TypedDocumentNode` from `@urql/core` (It's technically a core type and that limits where the dependency is installed)
- Add `TypedDocumentNode` to all related types in `@urql/core`, so `GraphQLRequest`, `Operation`, `OperationResult`, several client methods, `makeOperation`, and `createRequest` now accept generics with fallbacks
- Add support for `TypedDocumentNode` to `urql`
- Add support for `TypedDocumentNode` to `@urql/preact`
- Add support for `TypedDocumentNode` to `@urql/svelte`
- Add `TypedDocumentNode` to appropriate store methods on `@urql/exchange-graphcache`

> **Note:** These changes have been marked as patches as we usually do for changes that only affect TypeScript typings.