### PR TITLE
(retry) - Add operation argument to retryIf predicate

### DIFF
--- a/.changeset/gentle-grapes-love.md
+++ b/.changeset/gentle-grapes-love.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-retry': minor
+---
+
+Add a second `Operation` input argument to the `retryIf` predicate, so that retrying can be actively avoided for specific types of operations, e.g. mutations or subscriptions, in certain user-defined cases.

--- a/exchanges/retry/src/retryExchange.test.ts
+++ b/exchanges/retry/src/retryExchange.test.ts
@@ -116,7 +116,7 @@ it(`retries if it hits an error and works for multiple concurrent operations`, (
   next(op);
 
   expect(mockRetryIf).toHaveBeenCalledTimes(1);
-  expect(mockRetryIf).toHaveBeenCalledWith(queryOneError);
+  expect(mockRetryIf).toHaveBeenCalledWith(queryOneError, op);
 
   jest.runAllTimers();
 
@@ -131,7 +131,7 @@ it(`retries if it hits an error and works for multiple concurrent operations`, (
 
   jest.runAllTimers();
 
-  expect(mockRetryIf).toHaveBeenCalledWith(queryTwoError);
+  expect(mockRetryIf).toHaveBeenCalledWith(queryTwoError, opTwo);
 
   // max number of retries for each op
   expect(response).toHaveBeenCalledTimes(mockOptions.maxNumberAttempts * 2);
@@ -176,7 +176,7 @@ it('should retry x number of times and then return the successful result', () =>
   jest.runAllTimers();
 
   expect(mockRetryIf).toHaveBeenCalledTimes(numberRetriesBeforeSuccess);
-  expect(mockRetryIf).toHaveBeenCalledWith(queryOneError);
+  expect(mockRetryIf).toHaveBeenCalledWith(queryOneError, op);
 
   // one for original source, one for retry
   expect(response).toHaveBeenCalledTimes(1 + numberRetriesBeforeSuccess);

--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -24,7 +24,7 @@ interface RetryExchangeOptions {
   randomDelay?: boolean;
   maxNumberAttempts?: number;
   /** Conditionally determine whether an error should be retried */
-  retryIf?: (e: CombinedError) => boolean;
+  retryIf?: (error: CombinedError, operation: Operation) => boolean;
 }
 
 export const retryExchange = ({
@@ -106,7 +106,7 @@ export const retryExchange = ({
       filter(res => {
         // Only retry if the error passes the conditional retryIf function (if passed)
         // or if the error contains a networkError
-        if (!res.error || !retryIf(res.error)) {
+        if (!res.error || !retryIf(res.error, res.operation)) {
           return true;
         }
 


### PR DESCRIPTION
Resolve #1116 

## Summary

Suppose there's a `error.graphqlErrors` error and that triggers a retry. This type of error won't have broken the operation pipe for subscriptions, so retrying will start an identical operation in that case for subscriptions, depending on the transport protocol and method that's used.

We could also consider adding a small dedup predicate to `subscriptionExchange` but for now we should allow the `retryExchange` to be configured to ignore certain cases per operation kind.

## Set of changes

- Add `operation: Operation` argument to `retryIf` predicate
