### PR TITLE
(fix) - use Record over object type for subscription operation variables

### DIFF
--- a/.changeset/breezy-ghosts-sin.md
+++ b/.changeset/breezy-ghosts-sin.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Use `Record` over `object` type for subscription operation variables. The `object` type is currently hard to use ([see this issue](https://github.com/microsoft/TypeScript/issues/21732)).

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -38,7 +38,7 @@ export interface ObservableLike<T> {
 
 export interface SubscriptionOperation {
   query: string;
-  variables?: object;
+  variables?: Record<string, unknown>;
   key: string;
   context: OperationContext;
 }


### PR DESCRIPTION
As suggested by TS and recommended ESLint rules - don't use `object` as a type. The `object` type is currently hard to use ([see this issue](https://github.com/microsoft/TypeScript/issues/21732)).

This also solves the type compatibility for `graphql-ws` where you can use the lib in TS as you would in plain ol' JS like in #1118.

Previously, because of this `object` type, you have to do this:
```ts
...
subscriptionExchange({
  forwardSubscription({ query, variables }) {
    return {
      subscribe: (sink) => {
        const dispose = wsClient.subscribe(
          {
            query,
            variables: variables as Record<string, unknown>, // 😞
          },
          sink,
        );

        return {
          unsubscribe: dispose,
        };
      },
    };
  },
}),
...
```