### PR TITLE
(storybook) - Add missing dependency on @urql/devtools

### DIFF
--- a/.changeset/thin-years-scream.md
+++ b/.changeset/thin-years-scream.md
@@ -1,0 +1,5 @@
+---
+'@urql/storybook-addon': patch
+---
+
+Add missing optional dependency (@urql/devtools)

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -50,7 +50,8 @@
     "wonka": "^4.0.14"
   },
   "optionalDependencies": {
-    "@storybook/addons": ">=6.0.28"
+    "@storybook/addons": ">=6.0.28",
+    "@urql/devtools": ">=2.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## About

Given the choice to statically import devtools, we need to ensure it exists.