### PR TITLE
(execute) - Fix imports and reuse getOperationName from core

### DIFF
--- a/.changeset/popular-bananas-camp.md
+++ b/.changeset/popular-bananas-camp.md
@@ -3,4 +3,4 @@
 "@urql/exchange-execute": patch
 ---
 
-add the getOperationName export to @urql/core and use the newly exported getOperationName in @urql/exchange-execute.
+Export `getOperationName` from `@urql/core` and use it in `@urql/exchange-execute`, fixing several imports.

--- a/.changeset/popular-bananas-camp.md
+++ b/.changeset/popular-bananas-camp.md
@@ -1,0 +1,6 @@
+---
+"@urql/core": patch
+"@urql/exchange-execute": patch
+---
+
+add the getOperationName export to @urql/core and use the newly exported getOperationName in @urql/exchange-execute.

--- a/exchanges/execute/src/execute.test.ts
+++ b/exchanges/execute/src/execute.test.ts
@@ -14,7 +14,13 @@ import {
 } from 'wonka';
 import { mocked } from 'ts-jest/utils';
 import { queryOperation } from '@urql/core/test-utils';
-import { makeErrorResult, makeOperation, Client, getOperationName, OperationResult } from '@urql/core';
+import {
+  makeErrorResult,
+  makeOperation,
+  Client,
+  getOperationName,
+  OperationResult,
+} from '@urql/core';
 
 const schema = 'STUB_SCHEMA' as any;
 const exchangeArgs = {

--- a/exchanges/execute/src/execute.test.ts
+++ b/exchanges/execute/src/execute.test.ts
@@ -13,11 +13,8 @@ import {
   Source,
 } from 'wonka';
 import { mocked } from 'ts-jest/utils';
-import { getOperationName } from '@urql/core/utils';
 import { queryOperation } from '@urql/core/test-utils';
-import { makeErrorResult, makeOperation } from '@urql/core';
-import { Client } from '@urql/core/client';
-import { OperationResult } from '@urql/core/types';
+import { makeErrorResult, makeOperation, Client, getOperationName, OperationResult } from '@urql/core';
 
 const schema = 'STUB_SCHEMA' as any;
 const exchangeArgs = {

--- a/exchanges/execute/src/execute.ts
+++ b/exchanges/execute/src/execute.ts
@@ -16,7 +16,13 @@ import {
   execute,
 } from 'graphql';
 
-import { Exchange, makeResult, makeErrorResult, Operation, getOperationName } from '@urql/core';
+import {
+  Exchange,
+  makeResult,
+  makeErrorResult,
+  Operation,
+  getOperationName,
+} from '@urql/core';
 
 interface ExecuteExchangeArgs {
   schema: GraphQLSchema;

--- a/exchanges/execute/src/execute.ts
+++ b/exchanges/execute/src/execute.ts
@@ -16,8 +16,7 @@ import {
   execute,
 } from 'graphql';
 
-import { Exchange, makeResult, makeErrorResult, Operation } from '@urql/core';
-import { getOperationName } from '@urql/core/utils';
+import { Exchange, makeResult, makeErrorResult, Operation, getOperationName } from '@urql/core';
 
 interface ExecuteExchangeArgs {
   schema: GraphQLSchema;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,5 +13,5 @@ export {
   formatDocument,
   maskTypename,
   makeOperation,
-  getOperationName
+  getOperationName,
 } from './utils';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,4 +13,5 @@ export {
   formatDocument,
   maskTypename,
   makeOperation,
+  getOperationName
 } from './utils';


### PR DESCRIPTION
## Summary

Fixes: https://github.com/FormidableLabs/urql/issues/1134

## Set of changes

- Add getOperationName export to core
- Import getOperationName from core in the execute-exchange
