### PR TITLE
(react/preact) - Fix suspense-ssr runs

### DIFF
--- a/.changeset/cool-news-buy.md
+++ b/.changeset/cool-news-buy.md
@@ -3,4 +3,4 @@
 'urql': patch
 ---
 
-Clear suspense cache outside of effect for ssr-prepasses and disable caching for concurrent ssr-prepasses.
+Fix server-side rendering by disabling the new Suspense cache on the server-side and clear it for prepasses.

--- a/.changeset/cool-news-buy.md
+++ b/.changeset/cool-news-buy.md
@@ -1,0 +1,6 @@
+---
+'@urql/preact': patch
+'urql': patch
+---
+
+Clear suspense cache outside of effect for ssr-prepasses and disable caching for concurrent ssr-prepasses.

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -108,6 +108,7 @@ export function useQuery<Data = any, Variables = object>(
       let source: Source<OperationResult> | void = suspense
         ? sources.get(request.key)
         : undefined;
+
       if (!source) {
         source = client.executeQuery(request, {
           requestPolicy: args.requestPolicy,
@@ -117,8 +118,12 @@ export function useQuery<Data = any, Variables = object>(
         });
 
         // Create a suspense source and cache it for the given request
-        if (suspense)
-          sources.set(request.key, (source = toSuspenseSource(source)));
+        if (suspense) {
+          source = toSuspenseSource(source);
+          if (typeof window !== 'undefined') {
+            sources.set(request.key, source);
+          }
+        }
       }
 
       return source;
@@ -182,6 +187,7 @@ export function useQuery<Data = any, Variables = object>(
   }, [update, client, query$, request, args.context]);
 
   if (isSuspense(client, args.context)) {
+    sources.delete(request.key); // Delete any cached suspense source
     update(query$);
   }
 

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -108,6 +108,7 @@ export function useQuery<Data = any, Variables = object>(
       let source: Source<OperationResult> | void = suspense
         ? sources.get(request.key)
         : undefined;
+
       if (!source) {
         source = client.executeQuery(request, {
           requestPolicy: args.requestPolicy,
@@ -117,8 +118,12 @@ export function useQuery<Data = any, Variables = object>(
         });
 
         // Create a suspense source and cache it for the given request
-        if (suspense)
-          sources.set(request.key, (source = toSuspenseSource(source)));
+        if (suspense) {
+          source = toSuspenseSource(source);
+          if (typeof window !== 'undefined') {
+            sources.set(request.key, source);
+          }
+        }
       }
 
       return source;
@@ -182,6 +187,7 @@ export function useQuery<Data = any, Variables = object>(
   }, [update, client, query$, request, args.context]);
 
   if (isSuspense(client, args.context)) {
+    sources.delete(request.key); // Delete any cached suspense source
     update(query$);
   }
 


### PR DESCRIPTION
## Summary

When using `Suspense` on ssr-runs/interrupted runs effects won't be run, also when subsequent prepasses happen we can't be caching

Fixes https://github.com/FormidableLabs/urql/discussions/1136

## Set of changes

- Don't cache suspenseful operations during ssr on Preact and React
