### PR TITLE
(react, preact) Add default context to useMutation

### DIFF
--- a/.changeset/friendly-eyes-sip.md
+++ b/.changeset/friendly-eyes-sip.md
@@ -1,0 +1,6 @@
+---
+'@urql/preact': minor
+'urql': minor
+---
+
+Add optional parameter for `useMutation` to supply a default `OperationContext`

--- a/packages/preact-urql/src/hooks/useMutation.ts
+++ b/packages/preact-urql/src/hooks/useMutation.ts
@@ -32,7 +32,8 @@ export type UseMutationResponse<Data = any, Variables = object> = [
 ];
 
 export function useMutation<Data = any, Variables = object>(
-  query: DocumentNode | TypedDocumentNode<Data, Variables> | string
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+  defaultContext: Partial<OperationContext> = {}
 ): UseMutationResponse<Data, Variables> {
   const isMounted = useRef(true);
   const client = useClient();
@@ -42,13 +43,13 @@ export function useMutation<Data = any, Variables = object>(
   );
 
   const executeMutation = useCallback(
-    (variables?: Variables, context?: Partial<OperationContext>) => {
+    (variables?: Variables, context: Partial<OperationContext> = {}) => {
       setState({ ...initialState, fetching: true });
 
       return pipe(
         client.executeMutation<Data, Variables>(
           createRequest<Data, Variables>(query, variables),
-          context || {}
+          { ...defaultContext, ...context }
         ),
         toPromise
       ).then(result => {

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -32,7 +32,8 @@ export type UseMutationResponse<Data = any, Variables = object> = [
 ];
 
 export function useMutation<Data = any, Variables = object>(
-  query: DocumentNode | TypedDocumentNode<Data, Variables> | string
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+  defaultContext: Partial<OperationContext> = {}
 ): UseMutationResponse<Data, Variables> {
   const isMounted = useRef(true);
   const client = useClient();
@@ -42,13 +43,13 @@ export function useMutation<Data = any, Variables = object>(
   );
 
   const executeMutation = useCallback(
-    (variables?: Variables, context?: Partial<OperationContext>) => {
+    (variables?: Variables, context: Partial<OperationContext> = {}) => {
       setState({ ...initialState, fetching: true });
 
       return pipe(
         client.executeMutation<Data, Variables>(
           createRequest<Data, Variables>(query, variables),
-          context || {}
+          { ...defaultContext, ...context }
         ),
         toPromise
       ).then(result => {


### PR DESCRIPTION
## Summary

When writing a `Login` mutation, I could add `additionalTypenames` without much extra code.

## Set of changes

Additional parameter for `useMutation`, that is a `Partial<OperationContext>`, that get's merged (and overwritten) by mutation-time context.