### PR TITLE
(react/preact) - Fix client-side Suspense loop regression

### DIFF
--- a/.changeset/eighty-rivers-sniff.md
+++ b/.changeset/eighty-rivers-sniff.md
@@ -1,0 +1,6 @@
+---
+'@urql/preact': patch
+'urql': patch
+---
+
+Fix regression in client-side Suspense behaviour. This has been fixed in `urql@1.11.0` and `@urql/preact@1.4.0` but regressed in the patches afterwards that were aimed at fixing server-side Suspense.

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -181,13 +181,10 @@ export function useQuery<Data = any, Variables = object>(
 
   useEffect(() => {
     sources.delete(request.key); // Delete any cached suspense source
-    if (!isSuspense(client, args.context)) {
-      update(query$);
-    }
+    if (!isSuspense(client, args.context)) update(query$);
   }, [update, client, query$, request, args.context]);
 
   if (isSuspense(client, args.context)) {
-    sources.delete(request.key); // Delete any cached suspense source
     update(query$);
   }
 

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -181,13 +181,10 @@ export function useQuery<Data = any, Variables = object>(
 
   useEffect(() => {
     sources.delete(request.key); // Delete any cached suspense source
-    if (!isSuspense(client, args.context)) {
-      update(query$);
-    }
+    if (!isSuspense(client, args.context)) update(query$);
   }, [update, client, query$, request, args.context]);
 
   if (isSuspense(client, args.context)) {
-    sources.delete(request.key); // Delete any cached suspense source
     update(query$);
   }
 


### PR DESCRIPTION
## Summary

This regressed in the last patch, the version before that explicitly fixing it. This patch was aimed at server-side rendering but cleared the local suspense cache too early.

## Set of changes

- Ensure that caching is still disabled on the server-side
- Clear suspense cache in effect rather than render loop
