### PR TITLE
(vue-urql) - Add plugin install function

### DIFF
--- a/.changeset/odd-starfishes-punch.md
+++ b/.changeset/odd-starfishes-punch.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+expose Vue plugin function as default export

--- a/.changeset/odd-starfishes-punch.md
+++ b/.changeset/odd-starfishes-punch.md
@@ -1,5 +1,5 @@
 ---
-'@urql/vue': patch
+'@urql/vue': minor
 ---
 
 expose Vue plugin function as default export

--- a/packages/vue-urql/src/index.ts
+++ b/packages/vue-urql/src/index.ts
@@ -1,5 +1,10 @@
+import { App } from 'vue';
+
 export * from '@urql/core';
 export * from './useClient';
 export * from './useQuery';
 export * from './useMutation';
 export * from './useSubscription';
+import { install } from './useClient';
+
+export default install;

--- a/packages/vue-urql/src/index.ts
+++ b/packages/vue-urql/src/index.ts
@@ -1,5 +1,3 @@
-import { App } from 'vue';
-
 export * from '@urql/core';
 export * from './useClient';
 export * from './useQuery';

--- a/packages/vue-urql/src/useClient.ts
+++ b/packages/vue-urql/src/useClient.ts
@@ -1,4 +1,4 @@
-import { inject, provide } from 'vue';
+import { App, inject, provide } from 'vue';
 import { Client, ClientOptions } from '@urql/core';
 
 export function provideClient(opts: ClientOptions | Client) {
@@ -7,11 +7,16 @@ export function provideClient(opts: ClientOptions | Client) {
   return client;
 }
 
+export function install(app: App, opts: ClientOptions | Client) {
+  const client = opts instanceof Client ? opts : new Client(opts);
+  app.provide('$urql', client);
+}
+
 export function useClient(): Client {
   const client = inject('$urql') as Client;
   if (process.env.NODE_ENV !== 'production' && !client) {
     throw new Error(
-      'No urql Client was provided. Did you forget to call `provideClient` in a parent?'
+      'No urql Client was provided. Did you forget to install the plugin or call `provideClient` in a parent?'
     );
   }
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

In the Vue ecosystem, library bindings like this one commonly provide an install function to add global configuration -  such as providing the client - through the global `app.use()`plugin API. This install function is usually the default export of the package.

This PR adds such an install function

## Set of changes

- Adds an `install` function which allows the user to install and urql client as a plugin.
- exports this function as the default export.

This should be a minor change and doesn't break existing behavior or APIs, so a matching changeset is included.