### PR TITLE
(vue-urql) - Add Tests

### DIFF
--- a/packages/vue-urql/src/useQuery.test.ts
+++ b/packages/vue-urql/src/useQuery.test.ts
@@ -1,0 +1,132 @@
+jest.mock('vue', () => {
+  const vue = jest.requireActual('vue');
+
+  return {
+    __esModule: true,
+    ...vue,
+    inject: () => client,
+  };
+});
+import { makeSubject } from 'wonka';
+import { createClient } from '@urql/core';
+import { useQuery } from './useQuery';
+import { nextTick, reactive } from 'vue';
+
+const client = createClient({ url: '/graphql', exchanges: [] });
+
+describe('useQuery', () => {
+  it('runs a query and updates data', async () => {
+    const subject = makeSubject<any>();
+    const executeQuery = jest
+      .spyOn(client, 'executeQuery')
+      .mockImplementation(() => subject.source);
+
+    const _query = useQuery({
+      query: `{ test }`,
+    });
+    const query = reactive(_query);
+
+    expect(executeQuery).toHaveBeenCalledWith(
+      {
+        key: expect.any(Number),
+        query: expect.any(Object),
+        variables: {},
+        context: undefined,
+      },
+      {
+        pollInterval: undefined,
+        requestPolicy: undefined,
+      }
+    );
+
+    expect(query.fetching).toBe(true);
+
+    subject.next({ data: { test: true } });
+
+    expect(query.fetching).toBe(false);
+    expect(query.data).toEqual({ test: true });
+  });
+
+  it('runs Query and awaits results', async () => {
+    const subject = makeSubject<any>();
+    const executeQuery = jest
+      .spyOn(client, 'executeQuery')
+      .mockImplementation(() => subject.source);
+
+    const query = useQuery({
+      query: `{ test }`,
+      pause: true,
+    });
+
+    const promise = query.then(result => {
+      expect(executeQuery).toHaveBeenCalled();
+      expect(query.fetching.value).toBe(false);
+      expect(result.data.value).toEqual({ test: true });
+    });
+    expect(query.fetching.value).toBe(true);
+    subject.next({ data: { test: true } });
+
+    return promise;
+  });
+
+  it('pauses query when asked to do so', async () => {
+    const subject = makeSubject<any>();
+    const executeQuery = jest
+      .spyOn(client, 'executeQuery')
+      .mockImplementation(() => subject.source);
+
+    const _query = useQuery({
+      query: `{ test }`,
+      pause: true,
+    });
+    const query = reactive(_query);
+
+    expect(executeQuery).not.toHaveBeenCalled();
+
+    query.resume();
+    await nextTick();
+    expect(query.fetching).toBe(true);
+
+    subject.next({ data: { test: true } });
+
+    expect(query.fetching).toBe(false);
+    expect(query.data).toEqual({ test: true });
+  });
+
+  it('updates when polling', async () => {
+    const subject = makeSubject<any>();
+    const executeQuery = jest
+      .spyOn(client, 'executeQuery')
+      .mockImplementation(() => subject.source);
+
+    const _query = useQuery({
+      query: `{ test }`,
+      pollInterval: 500,
+      requestPolicy: 'cache-first',
+    });
+    const query = reactive(_query);
+
+    expect(executeQuery).toHaveBeenCalledWith(
+      {
+        key: expect.any(Number),
+        query: expect.any(Object),
+        variables: {},
+        context: undefined,
+      },
+      {
+        pollInterval: 500,
+        requestPolicy: 'cache-first',
+      }
+    );
+
+    expect(query.fetching).toBe(true);
+
+    subject.next({ data: { test: true } });
+
+    expect(query.fetching).toBe(false);
+    expect(query.data).toEqual({ test: true });
+
+    subject.next({ data: { test: false } });
+    expect(query.data).toEqual({ test: false });
+  });
+});

--- a/packages/vue-urql/src/useSubscription.test.ts
+++ b/packages/vue-urql/src/useSubscription.test.ts
@@ -10,7 +10,7 @@ jest.mock('vue', () => {
 import { makeSubject } from 'wonka';
 import { createClient } from '@urql/core';
 import { useSubscription } from './useSubscription';
-import { nextTick, reactive, ref, useCssModule } from 'vue';
+import { nextTick, reactive, ref } from 'vue';
 
 const client = createClient({ url: '/graphql', exchanges: [] });
 

--- a/packages/vue-urql/src/useSubscription.test.ts
+++ b/packages/vue-urql/src/useSubscription.test.ts
@@ -1,0 +1,134 @@
+jest.mock('vue', () => {
+  const vue = jest.requireActual('vue');
+
+  return {
+    __esModule: true,
+    ...vue,
+    inject: () => client,
+  };
+});
+import { makeSubject } from 'wonka';
+import { createClient } from '@urql/core';
+import { useSubscription } from './useSubscription';
+import { nextTick, reactive, ref, useCssModule } from 'vue';
+
+const client = createClient({ url: '/graphql', exchanges: [] });
+
+describe('useSubscription', () => {
+  it('subscribes to a subscription and updates data', async () => {
+    const subject = makeSubject<any>();
+    const executeQuery = jest
+      .spyOn(client, 'executeSubscription')
+      .mockImplementation(() => subject.source);
+
+    const sub = reactive(
+      useSubscription({
+        query: `{ test }`,
+      })
+    );
+
+    expect(sub).toMatchObject({
+      data: undefined,
+      stale: false,
+      fetching: true,
+      error: undefined,
+      extensions: undefined,
+      operation: undefined,
+      isPaused: false,
+      pause: expect.any(Function),
+      resume: expect.any(Function),
+      executeSubscription: expect.any(Function),
+    });
+
+    expect(executeQuery).toHaveBeenCalledWith(
+      {
+        key: expect.any(Number),
+        query: expect.any(Object),
+        variables: {},
+      },
+      expect.any(Object)
+    );
+
+    expect(sub.fetching).toBe(true);
+
+    subject.next({ data: { test: true } });
+    expect(sub.data).toEqual({ test: true });
+    subject.complete();
+    expect(sub.fetching).toBe(false);
+  });
+
+  it('updates the executed subscription when inputs change', async () => {
+    const subject = makeSubject<any>();
+    const executeSubscription = jest
+      .spyOn(client, 'executeSubscription')
+      .mockImplementation(() => subject.source);
+
+    const variables = ref({});
+    const sub = reactive(
+      useSubscription({
+        query: `{ test }`,
+        variables,
+      })
+    );
+
+    expect(executeSubscription).toHaveBeenCalledWith(
+      {
+        key: expect.any(Number),
+        query: expect.any(Object),
+        variables: {},
+      },
+      expect.any(Object)
+    );
+
+    subject.next({ data: { test: true } });
+    expect(sub.data).toEqual({ test: true });
+
+    variables.value = { test: true };
+    await nextTick();
+    expect(executeSubscription).toHaveBeenCalledTimes(2);
+    expect(executeSubscription).toHaveBeenCalledWith(
+      {
+        key: expect.any(Number),
+        query: expect.any(Object),
+        variables: { test: true },
+      },
+      expect.any(Object)
+    );
+
+    expect(sub.fetching).toBe(true);
+    expect(sub.data).toEqual({ test: true });
+  });
+  it('supports a custom scanning handler', async () => {
+    const subject = makeSubject<any>();
+    const executeSubscription = jest
+      .spyOn(client, 'executeSubscription')
+      .mockImplementation(() => subject.source);
+
+    const scanHandler = (currentState: any, nextState: any) => ({
+      counter: (currentState ? currentState.counter : 0) + nextState.counter,
+    });
+    const sub = reactive(
+      useSubscription(
+        {
+          query: `subscription { counter }`,
+        },
+        scanHandler
+      )
+    );
+
+    expect(executeSubscription).toHaveBeenCalledWith(
+      {
+        key: expect.any(Number),
+        query: expect.any(Object),
+        variables: {},
+      },
+      expect.any(Object)
+    );
+
+    subject.next({ data: { counter: 1 } });
+    expect(sub.data).toEqual({ counter: 1 });
+
+    subject.next({ data: { counter: 2 } });
+    expect(sub.data).toEqual({ counter: 3 });
+  });
+});

--- a/packages/vue-urql/tsconfig.json
+++ b/packages/vue-urql/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["src"],
   "compilerOptions": {
     "baseUrl": "./",
-    "types": ["node", "vue"],
+    "types": ["node", "vue", "jest"],
     "paths": {
       "urql": ["../../node_modules/urql/src"],
       "*-urql": ["../../node_modules/*-urql/src"],


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

This PR adds tests for:
- `useMutation`
- `useQuery`
- `useSubscription`

## Set of changes

- The added tests cover the same cases as the svelte implementation.
- I had to add `jest` to the package's tsconfig type option in order to stop TS from complaining, this should not have any impact outside of the vue-urql package.
- This is a draft PR for now as I came across some problems to test `useQuery().then()` behavior, and I'm not certain what the desired behavior here should be. Please see the code comments 

This only adds tests, so I didn't create a changeset. I can provide one if that's still required for this kind of PR. 