### PR TITLE
(vue-urql) - Fix pausing behavior

### DIFF
--- a/.changeset/flat-rats-fetch.md
+++ b/.changeset/flat-rats-fetch.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+fix pausing feature of useQuery by turning "isPaused" into a ref again.

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -1,4 +1,4 @@
-import { Ref, ref, watchEffect, reactive } from 'vue';
+import { Ref, ref, watchEffect, reactive, isRef } from 'vue';
 import { DocumentNode } from 'graphql';
 import { pipe, take, publish, share, onPush, toPromise, onEnd } from 'wonka';
 
@@ -61,7 +61,9 @@ export function useQuery<T = any, V = object>(
     /* noop */
   });
 
-  const isPaused: Ref<boolean> = ref(!!args.pause);
+  const isPaused: Ref<boolean> = isRef(_args.pause)
+    ? _args.pause
+    : ref(!!_args.pause);
 
   const request: Ref<GraphQLRequest<T, V>> = ref(
     createRequest<T, V>(args.query, args.variables as V) as any

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -1,4 +1,4 @@
-import { Ref, ref, watchEffect, reactive, computed } from 'vue';
+import { Ref, ref, watchEffect, reactive } from 'vue';
 import { DocumentNode } from 'graphql';
 import { pipe, take, publish, share, onPush, toPromise, onEnd } from 'wonka';
 
@@ -61,7 +61,7 @@ export function useQuery<T = any, V = object>(
     /* noop */
   });
 
-  const isPaused: Ref<boolean> = computed(() => !!args.pause);
+  const isPaused: Ref<boolean> = ref(!!args.pause);
 
   const request: Ref<GraphQLRequest<T, V>> = ref(
     createRequest<T, V>(args.query, args.variables as V) as any

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -1,4 +1,4 @@
-import { Ref, ref, watchEffect, reactive, computed, isRef } from 'vue';
+import { Ref, ref, watchEffect, reactive, isRef } from 'vue';
 import { DocumentNode } from 'graphql';
 import { pipe, subscribe, onEnd } from 'wonka';
 

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -1,4 +1,4 @@
-import { Ref, ref, watchEffect, reactive, computed } from 'vue';
+import { Ref, ref, watchEffect, reactive, computed, isRef } from 'vue';
 import { DocumentNode } from 'graphql';
 import { pipe, subscribe, onEnd } from 'wonka';
 
@@ -64,7 +64,9 @@ export function useSubscription<T = any, R = T, V = object>(
 
   const scanHandler: Ref<SubscriptionHandler<T, R> | undefined> = ref(handler);
 
-  const isPaused: Ref<boolean> = computed(() => !!args.pause);
+  const isPaused: Ref<boolean> = isRef(_args.pause)
+    ? _args.pause
+    : ref(!!_args.pause);
 
   const request: Ref<GraphQLRequest<T, V>> = ref(
     createRequest<T, V>(args.query, args.variables as V) as any


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Fixes a bug introduced in #1151, which broke `pause()`/resume()` functionality of `useQuery()`

## Set of changes

I'm sorry about this - in #1151 I turned `isPaused` into a computed ref, which makes it read-only as it's a derived value.

This PR turns it into a writeable `ref()` again.

It doesn't contain any breaking changes, just a fix for a patch release.