### PR TITLE
(react) - Fix client-side Suspense update edge-case

### DIFF
--- a/.changeset/nasty-kids-bake.md
+++ b/.changeset/nasty-kids-bake.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Fix in edge-case in client-side React Suspense, where after suspending due to an update a new state value is given to `useSource` in a render update. This was previously then causing us to subscribe to an outdated source in `useEffect` since the updated source would be ignored by the time we reach `useEffect` in `useSource`.

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -37,7 +37,16 @@ export function useSource<T, R>(
     ]);
 
     const updateInput = (nextInput: T) => {
-      if (nextInput !== input) subject.next((input = nextInput));
+      const prevInput = input;
+      try {
+        if (nextInput !== prevInput) subject.next((input = nextInput));
+      } catch (error) {
+        // If we suspend then React will preserve the component's state
+        // which means we'll need to prepare that the next update must be
+        // able to retrigger an update of the input.
+        input = prevInput;
+        throw error;
+      }
     };
 
     return [source, updateInput];

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -47,7 +47,7 @@ export function useSource<T, R>(
     currentInit = true;
     let state: R;
     pipe(
-      transform(fromValue(input)),
+      transform(input$),
       subscribe(value => {
         state = value;
       })

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -1,8 +1,15 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import { useMemo, useEffect, useState } from 'react';
-
-import { Source, fromValue, makeSubject, pipe, concat, subscribe } from 'wonka';
+import {
+  Source,
+  fromValue,
+  makeSubject,
+  pipe,
+  map,
+  concat,
+  subscribe,
+} from 'wonka';
 
 type Updater<T> = (input: T) => void;
 
@@ -21,7 +28,13 @@ export function useSource<T, R>(
 ): [R, Updater<T>] {
   const [input$, updateInput] = useMemo((): [Source<T>, (value: T) => void] => {
     const subject = makeSubject<T>();
-    const source = concat([fromValue(input), subject.source]);
+    const source = concat([
+      pipe(
+        fromValue(input),
+        map(() => input)
+      ),
+      subject.source,
+    ]);
 
     const updateInput = (nextInput: T) => {
       if (nextInput !== input) subject.next((input = nextInput));


### PR DESCRIPTION
Fix #1150 

## Summary

We encountered another edge-case in client-side React Suspense, which is caused by React handling suspense-on-updates differently than suspense-on-mount. We basically have to be more sensible with state on suspense-on-update because React doesn't clear any state when we suspend during an update.

This can be tested against this reproduction sandbox: https://codesandbox.io/s/ecstatic-ritchie-lzxvl (See CodeSandbox CI output)

## Set of changes

- Use the latest known `input` in `useSource` when subscribing