### PR TITLE
remove explicit undefined

### DIFF
--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -36,8 +36,7 @@ const serializeResult = ({
   error,
 }: OperationResult): SerializedResult => {
   const result: SerializedResult = {
-    data: JSON.stringify(data),
-    error: undefined,
+    data: JSON.stringify(data)
   };
 
   if (error) {


### PR DESCRIPTION
## Summary

Using an explicit undefined crashes the next.js stringify function.

## Set of changes

- remove explicit `undefined` on the ssr-exchange
