### PR TITLE
(vue) - Refactor lazy promise and watch effects

### DIFF
--- a/.changeset/six-wolves-eat.md
+++ b/.changeset/six-wolves-eat.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': minor
+---
+
+Refactor `useQuery` to resolve the lazy promise for Vue Suspense to the latest result that has been requested as per the input to `useQuery`.

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -4,16 +4,19 @@ import { DocumentNode } from 'graphql';
 import {
   Source,
   concat,
+  switchAll,
+  share,
   fromValue,
+  makeSubject,
+  filter,
   map,
   pipe,
   take,
   publish,
-  share,
+  onEnd,
   onStart,
   onPush,
   toPromise,
-  onEnd,
 } from 'wonka';
 
 import {
@@ -40,6 +43,10 @@ export interface UseQueryArgs<T = any, V = object> {
   pause?: MaybeRef<boolean>;
 }
 
+export type QueryPartialState<T = any, V = object> = Partial<
+  OperationResult<T, V>
+> & { fetching?: boolean };
+
 export interface UseQueryState<T = any, V = object> {
   fetching: Ref<boolean>;
   stale: Ref<boolean>;
@@ -50,7 +57,6 @@ export interface UseQueryState<T = any, V = object> {
   isPaused: Ref<boolean>;
   resume(): void;
   pause(): void;
-
   executeQuery(opts?: Partial<OperationContext>): UseQueryResponse<T, V>;
 }
 
@@ -58,8 +64,28 @@ export type UseQueryResponse<T, V> = UseQueryState<T, V> &
   PromiseLike<UseQueryState<T, V>>;
 
 const watchOptions = {
-  flush: 'pre' as const,
+  flush: 'sync' as const,
 };
+
+/** Wonka Operator to replay the most recent value to sinks */
+function replayOne<T>(source: Source<T>): Source<T> {
+  let cached: undefined | T;
+
+  return concat([
+    pipe(
+      fromValue(cached!),
+      map(() => cached!),
+      filter(x => x !== undefined)
+    ),
+    pipe(
+      source,
+      onPush(value => {
+        cached = value;
+      }),
+      share
+    ),
+  ]);
+}
 
 export function useQuery<T = any, V = object>(
   _args: UseQueryArgs<T, V>
@@ -82,56 +108,15 @@ export function useQuery<T = any, V = object>(
     createRequest<T, V>(args.query, args.variables as V) as any
   );
 
-  const source: Ref<Source<OperationResult<T, V>> | undefined> = ref();
+  const source: Ref<Source<Source<any>>> = ref(null as any);
+  const next: Ref<(
+    query$: undefined | Source<OperationResult<T, V>>
+  ) => void> = ref(null as any);
 
   watchEffect(() => {
     const newRequest = createRequest<T, V>(args.query, args.variables as any);
     if (request.value.key !== newRequest.key) {
       request.value = newRequest;
-    }
-  }, watchOptions);
-
-  watchEffect(() => {
-    if (!isPaused.value) {
-      source.value = pipe(
-        client.executeQuery<T, V>(request.value, {
-          requestPolicy: args.requestPolicy,
-          pollInterval: args.pollInterval,
-          ...args.context,
-        }),
-        share
-      );
-    } else {
-      source.value = undefined;
-    }
-  }, watchOptions);
-
-  watchEffect(onInvalidate => {
-    if (source.value) {
-      let cached: OperationResult<T, V> | undefined;
-
-      onInvalidate(
-        pipe(
-          cached ? concat([fromValue(cached), source.value]) : source.value,
-          onStart(() => {
-            fetching.value = true;
-          }),
-          onEnd(() => {
-            cached = undefined;
-            fetching.value = false;
-          }),
-          onPush(res => {
-            cached = res;
-            data.value = res.data;
-            stale.value = !!res.stale;
-            fetching.value = false;
-            error.value = res.error;
-            operation.value = res.operation;
-            extensions.value = res.extensions;
-          }),
-          publish
-        ).unsubscribe
-      );
     }
   }, watchOptions);
 
@@ -144,14 +129,13 @@ export function useQuery<T = any, V = object>(
     fetching,
     isPaused,
     executeQuery(opts?: Partial<OperationContext>): UseQueryResponse<T, V> {
-      source.value = pipe(
+      next.value(
         client.executeQuery<T, V>(request.value, {
           requestPolicy: args.requestPolicy,
           pollInterval: args.pollInterval,
           ...args.context,
           ...opts,
-        }),
-        share
+        })
       );
 
       return response;
@@ -164,22 +148,73 @@ export function useQuery<T = any, V = object>(
     },
   };
 
+  const getState = () => state;
+
+  watchEffect(onInvalidate => {
+    const subject = makeSubject<Source<any>>();
+    source.value = pipe(subject.source, replayOne);
+    next.value = (value: undefined | Source<any>) => {
+      const query$ = pipe(
+        value
+          ? pipe(
+              value,
+              onStart(() => {
+                fetching.value = true;
+                stale.value = false;
+              }),
+              onPush(res => {
+                data.value = res.data;
+                stale.value = !!res.stale;
+                fetching.value = false;
+                error.value = res.error;
+                operation.value = res.operation;
+                extensions.value = res.extensions;
+              }),
+              share
+            )
+          : fromValue(undefined),
+        onEnd(() => {
+          fetching.value = false;
+          stale.value = false;
+        })
+      );
+
+      subject.next(query$);
+    };
+
+    onInvalidate(
+      pipe(source.value, switchAll, map(getState), publish).unsubscribe
+    );
+  }, watchOptions);
+
+  watchEffect(
+    () => {
+      next.value(
+        !isPaused.value
+          ? client.executeQuery<T, V>(request.value, {
+              requestPolicy: args.requestPolicy,
+              pollInterval: args.pollInterval,
+              ...args.context,
+            })
+          : undefined
+      );
+    },
+    {
+      // NOTE: Allows multiple reactive changes to take place before triggering the new query
+      flush: 'pre',
+    }
+  );
+
   const response: UseQueryResponse<T, V> = {
     ...state,
     then(onFulfilled, onRejected) {
-      let result$: Promise<UseQueryState<T, V>>;
-      if (fetching.value && source.value) {
-        result$ = pipe(
-          source.value,
-          take(1),
-          map(() => state),
-          toPromise
-        );
-      } else {
-        result$ = Promise.resolve(state);
-      }
-
-      return result$.then(onFulfilled, onRejected);
+      return pipe(
+        source.value,
+        switchAll,
+        map(getState),
+        take(1),
+        toPromise
+      ).then(onFulfilled, onRejected);
     },
   };
 


### PR DESCRIPTION
## Summary

This refactors `useQuery` to use `watchEffect` again (see earlier commits). It then goes further to ensure that the lazy promise will always look at the latest query that has been issued. It also ensures that this latest query is shared if it's ongoing and not if it's completed. A paused query will always immediately resolve the latest result.

This implementation is made a lot easier by the fact that we're resolving to the same `state` object every time. Since there's only one truth for the state, we don't need to ensure that the streams are transformed to usable `scan` state like in `react-urql`.

## Set of changes

- Use a continuous subject to track the latest query stream
- Make all ref updates side-effects of these query streams as they're issued
- Write a `replayOne` operator to wrap the subject stream with
- Derive current state as one continuous `switchAll` on the `replayOne` subject stream
- Derive lazy promise from a `switchAll` then `take(1)` on the `replayOne` subject stream
- Refactor used effects back to `watchEffect`

cc @LinusBorg: This should tick all the boxes for you 🙌 