### PR TITLE
(populate) - skip visits inside of a FragmentDefinition

### DIFF
--- a/.changeset/lazy-suns-end.md
+++ b/.changeset/lazy-suns-end.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-populate': patch
+---
+
+Fix the scenario where we traverse a query but end up in a nested fragment, this maks it so that we can't derive the type for the sub-entity

--- a/exchanges/populate/src/populateExchange.ts
+++ b/exchanges/populate/src/populateExchange.ts
@@ -176,13 +176,19 @@ export const extractSelectionsFromQuery = (
   };
 
   const visits: string[] = [];
+  let insideFragment = false;
 
   traverse(
     query,
     node => {
       if (node.kind === Kind.FRAGMENT_DEFINITION) {
+        insideFragment = true;
         extractedFragments.push(node);
-      } else if (node.kind === Kind.FIELD && node.selectionSet) {
+      } else if (
+        node.kind === Kind.FIELD &&
+        node.selectionSet &&
+        !insideFragment
+      ) {
         const type = unwrapType(
           resolveFields(schema, visits)[node.name.value].type
         );
@@ -219,7 +225,13 @@ export const extractSelectionsFromQuery = (
       }
     },
     node => {
-      if (node.kind === Kind.FIELD && node.selectionSet) visits.pop();
+      if (node.kind === Kind.FIELD && node.selectionSet && !insideFragment) {
+        visits.pop();
+      }
+
+      if (node.kind === Kind.FRAGMENT_DEFINITION) {
+        insideFragment = false;
+      }
     }
   );
 


### PR DESCRIPTION
## Summary

Fixes: https://github.com/FormidableLabs/urql/issues/1149

When we are inside of a Fragment we shouldn't resolve types, we copy them over either way to the mutation.

## Set of changes

- Add flag to skip Fragment traversal
