### PR TITLE
(react/preact) - Force suspense to be disabled for executeQuery calls

### DIFF
--- a/.changeset/hungry-penguins-teach.md
+++ b/.changeset/hungry-penguins-teach.md
@@ -1,0 +1,6 @@
+---
+'@urql/preact': patch
+'urql': patch
+---
+
+Add `suspense: false` to options when `executeQuery` is called explicitly.

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -175,7 +175,9 @@ export function useQuery<Data = any, Variables = object>(
 
   // This is the imperative execute function passed to the user
   const executeQuery = useCallback(
-    (opts?: Partial<OperationContext>) => update(makeQuery$(opts)),
+    (opts?: Partial<OperationContext>) => {
+      update(makeQuery$({ suspense: false, ...opts }));
+    },
     [update, makeQuery$]
   );
 

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -175,7 +175,9 @@ export function useQuery<Data = any, Variables = object>(
 
   // This is the imperative execute function passed to the user
   const executeQuery = useCallback(
-    (opts?: Partial<OperationContext>) => update(makeQuery$(opts)),
+    (opts?: Partial<OperationContext>) => {
+      update(makeQuery$({ suspense: false, ...opts }));
+    },
     [update, makeQuery$]
   );
 


### PR DESCRIPTION
Fix #1180
