### PR TITLE
feat: Expose reponse headers inside OperationResult

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -69,6 +69,8 @@ export interface OperationResult<Data = any, Variables = any> {
   operation: Operation<Data, Variables>;
   /** The data returned from the Graphql server. */
   data?: Data;
+  /** The headers returned from the Graphql server response */
+  headers?: Headers;
   /** Any errors resulting from the operation. */
   error?: CombinedError;
   /** Optional extensions return by the Graphql server. */

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -8,6 +8,7 @@ export const makeResult = (
 ): OperationResult => ({
   operation,
   data: result.data,
+  headers: response.headers,
   error: Array.isArray(result.errors)
     ? new CombinedError({
         graphQLErrors: result.errors,


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Goal: Expose response `headers` inside `OperationResult`.  

Reason to do the change: 

Sometimes is necessary to capture the response headers after every request and fire some side effects based on them. 

An example of this is an Auth flow where the `access-token` changes after every request. The new token is send back by the server in an `access-token` response header. So is necessary to capture this header and save them so that the next request is sent with the correct headers. https://github.com/lynndylanhurley/devise_token_auth is an example of a popular JWT library following this scheme. 


## Set of changes

Affect packages: Core

Changes: 

- makeResult now includes `response.headers` in it's return value
- OperationResult interface now includes a `headers: Headers` property
