### PR TITLE
(core) - Fix formatDocument edge case and add caching

### DIFF
--- a/.changeset/nice-rivers-run.md
+++ b/.changeset/nice-rivers-run.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix edge case in `formatDocument`, which fails to add a `__typename` field if it has been aliased to a different name.

--- a/.changeset/serious-gorillas-develop.md
+++ b/.changeset/serious-gorillas-develop.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Cache results of `formatDocument` by the input document's key.

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -26,7 +26,7 @@ export const keyDocument = (
     key = hashQuery(q);
     query =
       docs[key] !== undefined ? docs[key] : parse(q, { noLocation: true });
-  } else if ((q as any).__key !== undefined) {
+  } else if ((q as any).__key != null) {
     key = (q as any).__key;
     query = q;
   } else {

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -8,14 +8,10 @@ export interface KeyedDocumentNode extends DocumentNode {
   __key: number;
 }
 
-interface Documents {
-  [key: number]: KeyedDocumentNode;
-}
-
 const hashQuery = (q: string): number =>
   hash(q.replace(/([\s,]|#[^\n\r]+)+/g, ' ').trim());
 
-const docs: Documents = Object.create(null);
+const docs = new Map<number, KeyedDocumentNode>();
 
 export const keyDocument = (
   q: string | DocumentNode | TypedDocumentNode
@@ -24,18 +20,17 @@ export const keyDocument = (
   let query: DocumentNode;
   if (typeof q === 'string') {
     key = hashQuery(q);
-    query =
-      docs[key] !== undefined ? docs[key] : parse(q, { noLocation: true });
+    query = docs.get(key) || parse(q, { noLocation: true });
   } else if ((q as any).__key != null) {
     key = (q as any).__key;
     query = q;
   } else {
     key = hashQuery(print(q));
-    query = docs[key] !== undefined ? docs[key] : q;
+    query = docs.get(key) || q;
   }
 
   (query as KeyedDocumentNode).__key = key;
-  docs[key] = query as KeyedDocumentNode;
+  docs.set(key, query as KeyedDocumentNode);
   return query as KeyedDocumentNode;
 };
 

--- a/packages/core/src/utils/typenames.test.ts
+++ b/packages/core/src/utils/typenames.test.ts
@@ -85,6 +85,26 @@ describe('formatTypeNames', () => {
                   "
             `);
   });
+
+  it('does add typenames when it is aliased', () => {
+    expect(
+      formatTypeNames(`{
+      todos {
+        id
+        typename: __typename
+      }
+    }`)
+    ).toMatchInlineSnapshot(`
+                  "{
+                    todos {
+                      id
+                      typename: __typename
+                      __typename
+                    }
+                  }
+                  "
+            `);
+  });
 });
 
 describe('collectTypesFromResponse', () => {

--- a/packages/core/src/utils/typenames.test.ts
+++ b/packages/core/src/utils/typenames.test.ts
@@ -50,7 +50,7 @@ describe('formatTypeNames', () => {
   });
 
   it('preserves custom properties', () => {
-    const doc = parse(`{ id todos { id } }`) as any;
+    const doc = parse(`{ todos { id } }`) as any;
     doc.documentId = '123';
     expect((formatDocument(doc) as any).documentId).toBe(doc.documentId);
   });

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -14,15 +14,16 @@ interface EntityLike {
   __typename: string | null | void;
 }
 
-const collectTypes = (obj: EntityLike | EntityLike[], types: string[] = []) => {
+const collectTypes = (
+  obj: EntityLike | EntityLike[],
+  types: { [typename: string]: unknown }
+) => {
   if (Array.isArray(obj)) {
-    obj.forEach(inner => {
-      collectTypes(inner, types);
-    });
+    for (let i = 0; i < obj.length; i++) collectTypes(obj[i], types);
   } else if (typeof obj === 'object' && obj !== null) {
     for (const key in obj) {
       if (key === '__typename' && typeof obj[key] === 'string') {
-        types.push(obj[key] as string);
+        types[obj[key] as string] = 0;
       } else {
         collectTypes(obj[key], types);
       }
@@ -33,7 +34,7 @@ const collectTypes = (obj: EntityLike | EntityLike[], types: string[] = []) => {
 };
 
 export const collectTypesFromResponse = (response: object) =>
-  collectTypes(response as EntityLike).filter((v, i, a) => a.indexOf(v) === i);
+  Object.keys(collectTypes(response as EntityLike, {}));
 
 const formatNode = (node: FieldNode | InlineFragmentNode) => {
   if (

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -37,7 +37,10 @@ const formatNode = (node: FieldNode | InlineFragmentNode) => {
   if (
     node.selectionSet &&
     !node.selectionSet.selections.some(
-      node => node.kind === Kind.FIELD && node.name.value === '__typename'
+      node =>
+        node.kind === Kind.FIELD &&
+        node.name.value === '__typename' &&
+        !node.alias
     )
   ) {
     return {

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -65,24 +65,20 @@ const formatNode = (node: FieldNode | InlineFragmentNode) => {
   }
 };
 
-interface Documents {
-  [key: number]: KeyedDocumentNode;
-}
-
-const docs: Documents = Object.create(null);
+const formattedDocs = new Map<number, KeyedDocumentNode>();
 
 export const formatDocument = <T extends DocumentNode>(node: T): T => {
   const query = keyDocument(node);
 
-  let result = docs[query.__key];
-  if (!docs[query.__key]) {
-    result = visit(node, {
+  let result = formattedDocs.get(query.__key);
+  if (!result) {
+    result = visit(query, {
       Field: formatNode,
       InlineFragment: formatNode,
     }) as KeyedDocumentNode;
     // Ensure that the hash of the resulting document won't suddenly change
     result.__key = query.__key;
-    docs[query.__key] = result;
+    formattedDocs.set(query.__key, result);
   }
 
   return (result as unknown) as T;


### PR DESCRIPTION
## Summary

Fix an edge case in `formatDocument` for aliased fields and add in-memory caching to it via the document key.

## Set of changes

- Add `keyDocument` for `formatDocument` to cache its result
- Add `alias` check to `formatDocument`'s visit function
- Code golf `collectTypesFromResponse` a little