### PR TITLE
(graphcache) - Replace buildClientSchema with lean implementation

### DIFF
--- a/.changeset/nervous-beds-battle.md
+++ b/.changeset/nervous-beds-battle.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Replace `graphql/utilities/buildClientSchema.mjs` with a custom-tailored, lighter implementation built into `@urql/exchange-graphcache`. This will appear to increase its size by about `0.5kB gzip` but will actually save around `-5.8kB gzip` in any production bundle by using less of `graphql`'s code.

--- a/.changeset/nervous-beds-battle.md
+++ b/.changeset/nervous-beds-battle.md
@@ -2,4 +2,7 @@
 '@urql/exchange-graphcache': patch
 ---
 
-Replace `graphql/utilities/buildClientSchema.mjs` with a custom-tailored, lighter implementation built into `@urql/exchange-graphcache`. This will appear to increase its size by about `0.5kB gzip` but will actually save around `-5.8kB gzip` in any production bundle by using less of `graphql`'s code.
+Replace `graphql/utilities/buildClientSchema.mjs` with a custom-tailored, lighter implementation
+built into `@urql/exchange-graphcache`. This will appear to increase its size by about `0.2kB gzip`
+but will actually save around `8.5kB gzip` to `9.4kB gzip` in any production bundle by using less of
+`graphql`'s code.

--- a/exchanges/graphcache/src/ast/buildClientSchema.ts
+++ b/exchanges/graphcache/src/ast/buildClientSchema.ts
@@ -1,0 +1,189 @@
+import {
+  valueFromAST,
+  parseValue,
+  isUnionType,
+  isInterfaceType,
+  isObjectType,
+  IntrospectionField,
+  IntrospectionQuery,
+  IntrospectionInputValue,
+  IntrospectionNamedTypeRef,
+  IntrospectionTypeRef,
+  IntrospectionType,
+  GraphQLAbstractType,
+  GraphQLNamedType,
+  GraphQLUnionType,
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
+  GraphQLInputFieldConfig,
+  GraphQLEnumType,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLType
+} from 'graphql';
+
+interface InterfaceRefs {
+  objects: GraphQLObjectType[];
+  interfaces: GraphQLInterfaceType[];
+}
+
+export interface SchemaIntrospector {
+  getQueryType(): GraphQLObjectType | undefined;
+  getMutationType(): GraphQLObjectType | undefined;
+  getSubscriptionType(): GraphQLObjectType | undefined;
+  getType(name: string): GraphQLNamedType | undefined;
+  getTypeMap(): Record<string, GraphQLNamedType>;
+  getImplementations(iface: GraphQLInterfaceType): InterfaceRefs;
+  isSubType(abstract: GraphQLAbstractType, possible: GraphQLObjectType): boolean;
+}
+
+export const buildClientSchema = (
+  { __schema }: IntrospectionQuery
+): SchemaIntrospector => {
+  const typemap: Record<string, GraphQLNamedType> = {};
+  const implementations: Record<string, InterfaceRefs> = {};
+  const subTypeCache: Record<string, Record<string, GraphQLObjectType>> = {};
+
+  const getImplementations = (iface: GraphQLInterfaceType): InterfaceRefs =>
+    implementations[iface.name] || (implementations[iface.name] = {
+      objects: [],
+      interfaces: [],
+    });
+
+  const getNamedType = (ref: string | IntrospectionNamedTypeRef): GraphQLNamedType =>
+    typemap[(ref as any).name || ref];
+
+  const getType = (ref: IntrospectionTypeRef): GraphQLType => {
+    if (ref.kind === 'LIST') {
+      return new GraphQLList(getType(ref.ofType));
+    } else if (ref.kind === 'NON_NULL') {
+      return new GraphQLNonNull(getType(ref.ofType));
+    } else {
+      return getNamedType(ref);
+    }
+  };
+
+  const buildNameConfig = <T extends { name: string }>(x: T): { name: string } => ({
+    name: x.name
+  });
+
+  const buildNameMap = <T extends { name: string }>(arr: ReadonlyArray<T>): { [name: string]: T } => {
+    const map: Record<string, T> = {};
+    for (let i = 0; i < arr.length; i++)
+      map[arr[i].name] = arr[i];
+    return map;
+  };
+
+  const buildInputValue = (input: IntrospectionInputValue): GraphQLInputFieldConfig => {
+    const type = getType(input.type) as any;
+    return {
+      type,
+      defaultValue: input.defaultValue
+        ? valueFromAST(parseValue(input.defaultValue), type as any)
+        : undefined,
+    };
+  };
+
+  const buildField = (field: IntrospectionField): any => ({
+    name: field.name,
+    type: getType(field.type) as any,
+    args: buildNameMap(field.args.map(buildInputValue) as any),
+  });
+
+  const buildType = (type: IntrospectionType): GraphQLNamedType | void => {
+    switch (type.kind) {
+      case 'SCALAR':
+        return new GraphQLScalarType(buildNameConfig(type));
+      case 'ENUM':
+        return new GraphQLEnumType({
+          name: type.name,
+          values: buildNameMap(type.enumValues.map(buildNameConfig) as any),
+        } as any);
+      case 'OBJECT':
+        return new GraphQLObjectType({
+          name: type.name,
+          interfaces: () => (type.interfaces || []).map(getNamedType) as GraphQLInterfaceType[],
+          fields: () => buildNameMap(type.fields.map(buildField) as any),
+        } as any);
+      case 'INTERFACE':
+        return new GraphQLInterfaceType({
+          name: type.name,
+          interfaces: () => (type.interfaces || []).map(getNamedType) as GraphQLInterfaceType[],
+          fields: () => buildNameMap(type.fields.map(buildField)),
+        } as any);
+      case 'UNION':
+        return new GraphQLUnionType({
+          name: type.name,
+          types: () => (type.possibleTypes || []).map(getNamedType) as GraphQLObjectType[],
+        });
+      case 'INPUT_OBJECT':
+        return new GraphQLInputObjectType({
+          name: type.name,
+          fields: () => buildNameMap(type.inputFields.map(buildInputValue) as any),
+        } as any);
+    }
+  };
+
+  for (let i = 0; i < __schema.types.length; i++) {
+    const type = __schema.types[i];
+    if (type && type.name) {
+      const out = buildType(type);
+      if (out) typemap[type.name] = out;
+    }
+  }
+
+  for (const key in typemap) {
+    const type = typemap[key];
+    if (isInterfaceType(type)) {
+      const ifaces = type.getInterfaces();
+      for (let i = 0; i < ifaces.length; i++)
+        getImplementations(ifaces[i]).interfaces.push(type);
+    } else if (isObjectType(type)) {
+      const ifaces = type.getInterfaces();
+      for (let i = 0; i < ifaces.length; i++)
+        getImplementations(ifaces[i]).objects.push(type);
+    }
+  }
+
+  const schema = {
+    getQueryType() {
+      return (__schema.queryType && getNamedType(__schema.queryType.name) as GraphQLObjectType) || undefined;
+    },
+    getMutationType() {
+      return (__schema.mutationType && getNamedType(__schema.mutationType.name) as GraphQLObjectType) || undefined;
+    },
+    getSubscriptionType() {
+      return (__schema.subscriptionType && getNamedType(__schema.subscriptionType.name) as GraphQLObjectType) || undefined;
+    },
+    getType(name: string) {
+      return typemap[name];
+    },
+    getTypeMap() {
+      return typemap;
+    },
+    getImplementations,
+    isSubType(abstract: GraphQLAbstractType, possible: GraphQLObjectType) {
+      let map = subTypeCache[abstract.name];
+      if (map === undefined) {
+        map = Object.create(null);
+        if (isUnionType(abstract)) {
+          map = buildNameMap(abstract.getTypes());
+        } else {
+          const implementations = getImplementations(abstract);
+          map = Object.assign(
+            buildNameMap(implementations.objects),
+            buildNameMap(implementations.interfaces),
+          );
+        }
+
+        subTypeCache[abstract.name] = map;
+      }
+
+      return !!map[possible.name];
+    },
+  };
+
+  return schema;
+};

--- a/exchanges/graphcache/src/ast/buildClientSchema.ts
+++ b/exchanges/graphcache/src/ast/buildClientSchema.ts
@@ -33,10 +33,7 @@ export interface SchemaIntrospector {
   query: GraphQLObjectType | undefined;
   mutation: GraphQLObjectType | undefined;
   subscription: GraphQLObjectType | undefined;
-
-  getType(name: string): GraphQLNamedType | undefined;
-  getTypeMap(): Record<string, GraphQLNamedType>;
-  getImplementations(iface: GraphQLInterfaceType): InterfaceRefs;
+  types: Record<string, GraphQLNamedType>;
   isSubType(abstract: GraphQLAbstractType, possible: GraphQLObjectType): boolean;
 }
 
@@ -152,18 +149,10 @@ export const buildClientSchema = (
     query: (__schema.queryType && getNamedType(__schema.queryType.name) as GraphQLObjectType)!,
     mutation: (__schema.mutationType && getNamedType(__schema.mutationType.name) as GraphQLObjectType)!,
     subscription: (__schema.subscriptionType && getNamedType(__schema.subscriptionType.name) as GraphQLObjectType)!,
-
-    getType(name: string) {
-      return typemap[name];
-    },
-    getTypeMap() {
-      return typemap;
-    },
-    getImplementations,
+    types: typemap,
     isSubType(abstract: GraphQLAbstractType, possible: GraphQLObjectType) {
       let map = subTypeCache[abstract.name];
       if (map === undefined) {
-        map = Object.create(null);
         if (isUnionType(abstract)) {
           map = buildNameMap(abstract.getTypes());
         } else {

--- a/exchanges/graphcache/src/ast/buildClientSchema.ts
+++ b/exchanges/graphcache/src/ast/buildClientSchema.ts
@@ -30,9 +30,10 @@ interface InterfaceRefs {
 }
 
 export interface SchemaIntrospector {
-  getQueryType(): GraphQLObjectType | undefined;
-  getMutationType(): GraphQLObjectType | undefined;
-  getSubscriptionType(): GraphQLObjectType | undefined;
+  query: GraphQLObjectType | undefined;
+  mutation: GraphQLObjectType | undefined;
+  subscription: GraphQLObjectType | undefined;
+
   getType(name: string): GraphQLNamedType | undefined;
   getTypeMap(): Record<string, GraphQLNamedType>;
   getImplementations(iface: GraphQLInterfaceType): InterfaceRefs;
@@ -147,16 +148,11 @@ export const buildClientSchema = (
     }
   }
 
-  const schema = {
-    getQueryType() {
-      return (__schema.queryType && getNamedType(__schema.queryType.name) as GraphQLObjectType) || undefined;
-    },
-    getMutationType() {
-      return (__schema.mutationType && getNamedType(__schema.mutationType.name) as GraphQLObjectType) || undefined;
-    },
-    getSubscriptionType() {
-      return (__schema.subscriptionType && getNamedType(__schema.subscriptionType.name) as GraphQLObjectType) || undefined;
-    },
+  return {
+    query: (__schema.queryType && getNamedType(__schema.queryType.name) as GraphQLObjectType)!,
+    mutation: (__schema.mutationType && getNamedType(__schema.mutationType.name) as GraphQLObjectType)!,
+    subscription: (__schema.subscriptionType && getNamedType(__schema.subscriptionType.name) as GraphQLObjectType)!,
+
     getType(name: string) {
       return typemap[name];
     },
@@ -184,6 +180,4 @@ export const buildClientSchema = (
       return !!map[possible.name];
     },
   };
-
-  return schema;
 };

--- a/exchanges/graphcache/src/ast/index.ts
+++ b/exchanges/graphcache/src/ast/index.ts
@@ -1,3 +1,4 @@
+export * from './buildClientSchema';
 export * from './variables';
 export * from './traversal';
 export * from './schemaPredicates';

--- a/exchanges/graphcache/src/ast/index.ts
+++ b/exchanges/graphcache/src/ast/index.ts
@@ -1,5 +1,5 @@
-export * from './buildClientSchema';
 export * from './variables';
 export * from './traversal';
+export * from './schema';
 export * from './schemaPredicates';
 export * from './node';

--- a/exchanges/graphcache/src/ast/schema.ts
+++ b/exchanges/graphcache/src/ast/schema.ts
@@ -45,7 +45,9 @@ export const buildClientSchema = ({
     return map;
   };
 
-  const buildType = (type: IntrospectionType): SchemaObject | SchemaUnion | void => {
+  const buildType = (
+    type: IntrospectionType
+  ): SchemaObject | SchemaUnion | void => {
     switch (type.kind) {
       case 'OBJECT':
       case 'INTERFACE':
@@ -53,11 +55,13 @@ export const buildClientSchema = ({
           name: type.name,
           kind: type.kind as 'OBJECT' | 'INTERFACE',
           interfaces: buildNameMap(type.interfaces || []),
-          fields: buildNameMap(type.fields.map(field => ({
-            name: field.name,
-            type: field.type,
-            args: buildNameMap(field.args)
-          }))),
+          fields: buildNameMap(
+            type.fields.map(field => ({
+              name: field.name,
+              type: field.type,
+              args: buildNameMap(field.args),
+            }))
+          ),
         } as SchemaObject;
       case 'UNION':
         return {
@@ -79,7 +83,9 @@ export const buildClientSchema = ({
   return {
     query: __schema.queryType ? __schema.queryType.name : null,
     mutation: __schema.mutationType ? __schema.mutationType.name : null,
-    subscription: __schema.subscriptionType ? __schema.subscriptionType.name : null,
+    subscription: __schema.subscriptionType
+      ? __schema.subscriptionType.name
+      : null,
     types: typemap,
     isSubType(abstract: string, possible: string) {
       const abstractType = typemap[abstract];
@@ -88,7 +94,10 @@ export const buildClientSchema = ({
         return false;
       } else if (abstractType.kind === 'UNION') {
         return !!abstractType.types[possible];
-      } else if (abstractType.kind !== 'OBJECT' && possibleType.kind === 'OBJECT') {
+      } else if (
+        abstractType.kind !== 'OBJECT' &&
+        possibleType.kind === 'OBJECT'
+      ) {
         return !!possibleType.interfaces[abstract];
       } else {
         return abstract === possible;

--- a/exchanges/graphcache/src/ast/schemaPredicates.test.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.test.ts
@@ -1,6 +1,6 @@
 import { Kind, InlineFragmentNode } from 'graphql';
 import { mocked } from 'ts-jest/utils';
-import { buildClientSchema } from './buildClientSchema';
+import { buildClientSchema } from './schema';
 import * as SchemaPredicates from './schemaPredicates';
 
 describe('SchemaPredicates', () => {

--- a/exchanges/graphcache/src/ast/schemaPredicates.test.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.test.ts
@@ -1,5 +1,6 @@
-import { Kind, InlineFragmentNode, buildClientSchema } from 'graphql';
+import { Kind, InlineFragmentNode } from 'graphql';
 import { mocked } from 'ts-jest/utils';
+import { buildClientSchema } from './buildClientSchema';
 import * as SchemaPredicates from './schemaPredicates';
 
 describe('SchemaPredicates', () => {

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -4,7 +4,6 @@ import {
   isNonNullType,
   InlineFragmentNode,
   FragmentDefinitionNode,
-  GraphQLSchema,
   GraphQLAbstractType,
   GraphQLObjectType,
   GraphQLInterfaceType,
@@ -13,6 +12,8 @@ import {
 
 import { warn, invariant } from '../helpers/help';
 import { getTypeCondition } from './node';
+import { SchemaIntrospector } from './buildClientSchema';
+
 import {
   KeyingConfig,
   UpdateResolver,
@@ -23,7 +24,7 @@ import {
 const BUILTIN_FIELD_RE = /^__/;
 
 export const isFieldNullable = (
-  schema: GraphQLSchema,
+  schema: SchemaIntrospector,
   typename: string,
   fieldName: string
 ): boolean => {
@@ -33,7 +34,7 @@ export const isFieldNullable = (
 };
 
 export const isListNullable = (
-  schema: GraphQLSchema,
+  schema: SchemaIntrospector,
   typename: string,
   fieldName: string
 ): boolean => {
@@ -44,7 +45,7 @@ export const isListNullable = (
 };
 
 export const isFieldAvailableOnType = (
-  schema: GraphQLSchema,
+  schema: SchemaIntrospector,
   typename: string,
   fieldName: string
 ): boolean => {
@@ -53,7 +54,7 @@ export const isFieldAvailableOnType = (
 };
 
 export const isInterfaceOfType = (
-  schema: GraphQLSchema,
+  schema: SchemaIntrospector,
   node: InlineFragmentNode | FragmentDefinitionNode,
   typename: string | void
 ): boolean => {
@@ -70,11 +71,11 @@ export const isInterfaceOfType = (
 
   expectAbstractType(abstractType, typeCondition);
   expectObjectType(objectType, typename);
-  return schema.isPossibleType(abstractType, objectType);
+  return schema.isSubType(abstractType, objectType);
 };
 
 const getField = (
-  schema: GraphQLSchema,
+  schema: SchemaIntrospector,
   typename: string,
   fieldName: string
 ) => {
@@ -127,7 +128,7 @@ function expectAbstractType(
 }
 
 export function expectValidKeyingConfig(
-  schema: GraphQLSchema,
+  schema: SchemaIntrospector,
   keys: KeyingConfig
 ): void {
   if (process.env.NODE_ENV !== 'production') {
@@ -146,7 +147,7 @@ export function expectValidKeyingConfig(
 }
 
 export function expectValidUpdatesConfig(
-  schema: GraphQLSchema,
+  schema: SchemaIntrospector,
   updates: Record<string, Record<string, UpdateResolver>>
 ): void {
   if (process.env.NODE_ENV === 'production') {
@@ -191,7 +192,7 @@ function warnAboutResolver(name: string): void {
 }
 
 export function expectValidResolversConfig(
-  schema: GraphQLSchema,
+  schema: SchemaIntrospector,
   resolvers: ResolverConfig
 ): void {
   if (process.env.NODE_ENV === 'production') {
@@ -230,7 +231,7 @@ export function expectValidResolversConfig(
 }
 
 export function expectValidOptimisticMutationsConfig(
-  schema: GraphQLSchema,
+  schema: SchemaIntrospector,
   optimisticMutations: OptimisticMutationConfig
 ): void {
   if (process.env.NODE_ENV === 'production') {

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -154,9 +154,13 @@ export function expectValidUpdatesConfig(
   }
 
   const mutationFields = schema.mutation ? schema.mutation.getFields() : {};
-  const subscriptionFields = schema.subscription ? schema.subscription.getFields() : {};
-  const givenMutations = (schema.mutation && updates[schema.mutation.name]) || {};
-  const givenSubscription = (schema.subscription && updates[schema.subscription.name]) || {};
+  const subscriptionFields = schema.subscription
+    ? schema.subscription.getFields()
+    : {};
+  const givenMutations =
+    (schema.mutation && updates[schema.mutation.name]) || {};
+  const givenSubscription =
+    (schema.subscription && updates[schema.subscription.name]) || {};
 
   for (const fieldName in givenMutations) {
     if (mutationFields[fieldName] === undefined) {
@@ -212,7 +216,9 @@ export function expectValidResolversConfig(
       if (!schema.types[key]) {
         warnAboutResolver(key);
       } else {
-        const validTypeProperties = (schema.types[key] as GraphQLObjectType).getFields();
+        const validTypeProperties = (schema.types[
+          key
+        ] as GraphQLObjectType).getFields();
         for (const resolverProperty in resolvers[key]) {
           if (!validTypeProperties[resolverProperty]) {
             warnAboutResolver(key + '.' + resolverProperty);

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -2,7 +2,7 @@ import { InlineFragmentNode, FragmentDefinitionNode } from 'graphql';
 
 import { warn, invariant } from '../helpers/help';
 import { getTypeCondition } from './node';
-import { SchemaIntrospector, SchemaObject } from './buildClientSchema';
+import { SchemaIntrospector, SchemaObject } from './schema';
 
 import {
   KeyingConfig,
@@ -30,7 +30,8 @@ export const isListNullable = (
 ): boolean => {
   const field = getField(schema, typename, fieldName);
   if (!field) return false;
-  const ofType = field.type.kind === 'NON_NULL' ? field.type.ofType : field.type;
+  const ofType =
+    field.type.kind === 'NON_NULL' ? field.type.ofType : field.type;
   return ofType.kind === 'LIST' && ofType.ofType.kind !== 'NON_NULL';
 };
 
@@ -51,7 +52,10 @@ export const isInterfaceOfType = (
   if (!typename) return false;
   const typeCondition = getTypeCondition(node);
   if (!typeCondition || typename === typeCondition) return true;
-  if (schema.types[typeCondition] && schema.types[typeCondition].kind === 'OBJECT')
+  if (
+    schema.types[typeCondition] &&
+    schema.types[typeCondition].kind === 'OBJECT'
+  )
     return typeCondition === typename;
   expectAbstractType(schema, typeCondition!);
   expectObjectType(schema, typename!);
@@ -82,10 +86,7 @@ const getField = (
   return field;
 };
 
-function expectObjectType(
-  schema: SchemaIntrospector,
-  typename: string
-) {
+function expectObjectType(schema: SchemaIntrospector, typename: string) {
   invariant(
     schema.types[typename] && schema.types[typename].kind === 'OBJECT',
     'Invalid Object type: The type `' +
@@ -96,10 +97,7 @@ function expectObjectType(
   );
 }
 
-function expectAbstractType(
-  schema: SchemaIntrospector,
-  typename: string
-) {
+function expectAbstractType(schema: SchemaIntrospector, typename: string) {
   invariant(
     schema.types[typename] &&
       (schema.types[typename].kind === 'INTERFACE' ||
@@ -139,7 +137,8 @@ export function expectValidUpdatesConfig(
   }
 
   if (schema.mutation) {
-    const mutationFields = (schema.types[schema.mutation] as SchemaObject).fields;
+    const mutationFields = (schema.types[schema.mutation] as SchemaObject)
+      .fields;
     const givenMutations = updates[schema.mutation] || {};
     for (const fieldName in givenMutations) {
       if (mutationFields[fieldName] === undefined) {
@@ -154,7 +153,9 @@ export function expectValidUpdatesConfig(
   }
 
   if (schema.subscription) {
-    const subscriptionFields = (schema.types[schema.subscription] as SchemaObject).fields;
+    const subscriptionFields = (schema.types[
+      schema.subscription
+    ] as SchemaObject).fields;
     const givenSubscription = updates[schema.subscription] || {};
     for (const fieldName in givenSubscription) {
       if (subscriptionFields[fieldName] === undefined) {
@@ -187,7 +188,8 @@ export function expectValidResolversConfig(
   for (const key in resolvers) {
     if (key === 'Query') {
       if (schema.query) {
-        const validQueries = (schema.types[schema.query] as SchemaObject).fields;
+        const validQueries = (schema.types[schema.query] as SchemaObject)
+          .fields;
         for (const resolverQuery in resolvers.Query) {
           if (!validQueries[resolverQuery]) {
             warnAboutResolver('Query.' + resolverQuery);
@@ -220,7 +222,8 @@ export function expectValidOptimisticMutationsConfig(
   }
 
   if (schema.mutation) {
-    const validMutations = (schema.types[schema.mutation] as SchemaObject).fields;
+    const validMutations = (schema.types[schema.mutation] as SchemaObject)
+      .fields;
     for (const mutation in optimisticMutations) {
       if (!validMutations[mutation]) {
         warn(

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -154,12 +154,10 @@ export function expectValidUpdatesConfig(
     return;
   }
 
-  const mutation = schema.getMutationType();
-  const subscription = schema.getSubscriptionType();
-  const mutationFields = mutation ? mutation.getFields() : {};
-  const subscriptionFields = subscription ? subscription.getFields() : {};
-  const givenMutations = (mutation && updates[mutation.name]) || {};
-  const givenSubscription = (subscription && updates[subscription.name]) || {};
+  const mutationFields = schema.mutation ? schema.mutation.getFields() : {};
+  const subscriptionFields = schema.subscription ? schema.subscription.getFields() : {};
+  const givenMutations = (schema.mutation && updates[schema.mutation.name]) || {};
+  const givenSubscription = (schema.subscription && updates[schema.subscription.name]) || {};
 
   for (const fieldName in givenMutations) {
     if (mutationFields[fieldName] === undefined) {
@@ -202,9 +200,8 @@ export function expectValidResolversConfig(
   const validTypes = schema.getTypeMap();
   for (const key in resolvers) {
     if (key === 'Query') {
-      const queryType = schema.getQueryType();
-      if (queryType) {
-        const validQueries = queryType.getFields();
+      if (schema.query) {
+        const validQueries = schema.query.getFields();
         for (const resolverQuery in resolvers.Query) {
           if (!validQueries[resolverQuery]) {
             warnAboutResolver('Query.' + resolverQuery);
@@ -238,10 +235,7 @@ export function expectValidOptimisticMutationsConfig(
     return;
   }
 
-  const validMutations = schema.getMutationType()
-    ? (schema.getMutationType() as GraphQLObjectType).getFields()
-    : {};
-
+  const validMutations = schema.mutation ? schema.mutation.getFields() : {};
   for (const mutation in optimisticMutations) {
     if (!validMutations[mutation]) {
       warn(

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -62,11 +62,9 @@ export class Store implements Cache {
     let subscriptionName = 'Subscription';
     if (opts.schema) {
       const schema = (this.schema = buildClientSchema(opts.schema));
-      queryName = schema.query ? schema.query.name : queryName;
-      mutationName = schema.mutation ? schema.mutation.name : mutationName;
-      subscriptionName = schema.subscription
-        ? schema.subscription.name
-        : subscriptionName;
+      queryName = schema.query || queryName;
+      mutationName = schema.mutation || mutationName;
+      subscriptionName = schema.subscription || subscriptionName;
     }
 
     this.updates = {

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -62,14 +62,9 @@ export class Store implements Cache {
     let subscriptionName = 'Subscription';
     if (opts.schema) {
       const schema = (this.schema = buildClientSchema(opts.schema));
-      const queryType = schema.getQueryType();
-      const mutationType = schema.getMutationType();
-      const subscriptionType = schema.getSubscriptionType();
-      queryName = queryType ? queryType.name : queryName;
-      mutationName = mutationType ? mutationType.name : mutationName;
-      subscriptionName = subscriptionType
-        ? subscriptionType.name
-        : subscriptionName;
+      queryName = schema.query ? schema.query.name : queryName;
+      mutationName = schema.mutation ? schema.mutation.name : mutationName;
+      subscriptionName = schema.subscription ? schema.subscription.name : subscriptionName;
     }
 
     this.updates = {

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -22,11 +22,15 @@ import { writeFragment, startWrite } from '../operations/write';
 import { invalidateEntity } from '../operations/invalidate';
 import { keyOfField } from './keys';
 import * as InMemoryData from './data';
+
 import {
-  buildClientSchema,
   SchemaIntrospector,
-} from '../ast/buildClientSchema';
-import * as SchemaPredicates from '../ast/schemaPredicates';
+  buildClientSchema,
+  expectValidKeyingConfig,
+  expectValidUpdatesConfig,
+  expectValidResolversConfig,
+  expectValidOptimisticMutationsConfig,
+} from '../ast';
 
 type RootField = 'query' | 'mutation' | 'subscription';
 
@@ -87,10 +91,10 @@ export class Store implements Cache {
     this.data = InMemoryData.make(queryName);
 
     if (this.schema && process.env.NODE_ENV !== 'production') {
-      SchemaPredicates.expectValidKeyingConfig(this.schema, this.keys);
-      SchemaPredicates.expectValidUpdatesConfig(this.schema, this.updates);
-      SchemaPredicates.expectValidResolversConfig(this.schema, this.resolvers);
-      SchemaPredicates.expectValidOptimisticMutationsConfig(
+      expectValidKeyingConfig(this.schema, this.keys);
+      expectValidUpdatesConfig(this.schema, this.updates);
+      expectValidResolversConfig(this.schema, this.resolvers);
+      expectValidOptimisticMutationsConfig(
         this.schema,
         this.optimisticMutations
       );

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -1,7 +1,4 @@
-import {
-  DocumentNode,
-  IntrospectionQuery,
-} from 'graphql';
+import { DocumentNode, IntrospectionQuery } from 'graphql';
 
 import { TypedDocumentNode, formatDocument, createRequest } from '@urql/core';
 
@@ -25,7 +22,10 @@ import { writeFragment, startWrite } from '../operations/write';
 import { invalidateEntity } from '../operations/invalidate';
 import { keyOfField } from './keys';
 import * as InMemoryData from './data';
-import { buildClientSchema, SchemaIntrospector }from '../ast/buildClientSchema';
+import {
+  buildClientSchema,
+  SchemaIntrospector,
+} from '../ast/buildClientSchema';
 import * as SchemaPredicates from '../ast/schemaPredicates';
 
 type RootField = 'query' | 'mutation' | 'subscription';
@@ -64,7 +64,9 @@ export class Store implements Cache {
       const schema = (this.schema = buildClientSchema(opts.schema));
       queryName = schema.query ? schema.query.name : queryName;
       mutationName = schema.mutation ? schema.mutation.name : mutationName;
-      subscriptionName = schema.subscription ? schema.subscription.name : subscriptionName;
+      subscriptionName = schema.subscription
+        ? schema.subscription.name
+        : subscriptionName;
     }
 
     this.updates = {

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -1,8 +1,6 @@
 import {
-  buildClientSchema,
   DocumentNode,
   IntrospectionQuery,
-  GraphQLSchema,
 } from 'graphql';
 
 import { TypedDocumentNode, formatDocument, createRequest } from '@urql/core';
@@ -27,6 +25,7 @@ import { writeFragment, startWrite } from '../operations/write';
 import { invalidateEntity } from '../operations/invalidate';
 import { keyOfField } from './keys';
 import * as InMemoryData from './data';
+import { buildClientSchema, SchemaIntrospector }from '../ast/buildClientSchema';
 import * as SchemaPredicates from '../ast/schemaPredicates';
 
 type RootField = 'query' | 'mutation' | 'subscription';
@@ -46,7 +45,7 @@ export class Store implements Cache {
   updates: Record<string, Record<string, UpdateResolver>>;
   optimisticMutations: OptimisticMutationConfig;
   keys: KeyingConfig;
-  schema?: GraphQLSchema;
+  schema?: SchemaIntrospector;
 
   rootFields: { query: string; mutation: string; subscription: string };
   rootNames: { [name: string]: RootField };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,7 +2842,7 @@
     "@typescript-eslint/types" "4.6.1"
     eslint-visitor-keys "^2.0.0"
 
-"@urql/devtools@^2.0.2":
+"@urql/devtools@>=2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@urql/devtools/-/devtools-2.0.2.tgz#0991bc3bb09444b162ef56518b76f64f286954fc"
   integrity sha512-f3gIx4NDOuWdXC54m4VQlLKNtYHl6PITSEqexH6xiktzvH7QcwS5hNPg0Fkki8cas/DZtkmDpwxNV1uRZ5xlvA==


### PR DESCRIPTION
## Summary

Our largest impact on `@urql/exchange-graphcache` is our usage of `graphql/utilities/buildClientSchema` which uses `GraphQLSchema` and other heavy implementations, which are basically server-side implementations with a lot of invariants. Given that we know that with `@urql/introspection` and other introspection methods the result can be trusted we don't even need any of the strict validation of `buildClientSchema` and what it pulls in.

Furthmore, we don't need any of the `graphql/type/definition` types, e.g. `GraphQLObjectType` and helpers like `isObjectType` if we transform the client schema to a format that is just good enough for our purposes.

This change increases `@urql/exchange-graphcache`'s size slightly from `6.74kB gzip` to `6.93kB gzip`. However, the impact on what's pulled in from `graphql` is significant and we save in `-9.61kB gzip` (up to; lowest, `8.53kB`). This makes a **net impact** of `-9.42kB gzip`

## Set of changes

- Reimplement `buildClientSchema` and replace `GraphQLSchema` types
- Started to drill down `buildClientSchema` to what's necessary, but then transitioned to just using string-based schema structure
- Update `store.ts` and `schemaPredicates.ts` to use new implementation

No unit tests had to be updated, which is encouraging.
The only remaining usage of `graphql` compared to `@urql/core` is `valueFromASTUntyped`