### PR TITLE
(graphcache) - Fix API results from being reused incorrectly for queries 

### DIFF
--- a/.changeset/wise-rats-whisper.md
+++ b/.changeset/wise-rats-whisper.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix reusing original query data from APIs accidentally, which can lead to subtle mismatches in results when the API's incoming `query` results are being updated by the `cacheExchange`, to apply resolvers. Specifically this may lead to relations from being set back to `null` when the resolver returns a different list of links than the result, since some `null` relations may unintentionally exist but aren't related. If you're using `relayPagination` then this fix is critical.

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1062,9 +1062,7 @@ describe('custom resolvers', () => {
     expect(fakeResolver).toHaveBeenCalledTimes(1);
     expect(result).toHaveBeenCalledTimes(1);
     expect(result.mock.calls[0][0].data).toEqual({
-      __typename: 'Query',
       author: {
-        __typename: 'Author',
         id: '123',
         name: 'newName',
       },
@@ -1430,7 +1428,6 @@ describe('schema awareness', () => {
     expect(response).toHaveBeenCalledTimes(1);
     expect(reexec).toHaveBeenCalledTimes(0);
     expect(result.mock.calls[0][0].data).toEqual({
-      __typename: 'Query',
       todos: [
         {
           __typename: 'Todo',

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -168,7 +168,10 @@ describe('offline', () => {
 
     next(queryOp);
     expect(result).toBeCalledTimes(1);
-    expect(result.mock.calls[0][0].data).toEqual(queryOneData);
+    expect(result.mock.calls[0][0].data).toEqual({
+      ...queryOneData,
+      __typename: undefined,
+    });
 
     next(mutationOp);
     expect(result).toBeCalledTimes(1);

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -206,6 +206,8 @@ describe('Query', () => {
     );
 
     expect(result.data).toEqual(expected);
+    expect(result.data).not.toBe(expected);
+    expect(result.data!.todos![0]).not.toBe(expected!.todos![0]);
   });
 
   // Issue#64

--- a/exchanges/graphcache/src/operations/query.test.ts
+++ b/exchanges/graphcache/src/operations/query.test.ts
@@ -3,6 +3,7 @@
 import { gql } from '@urql/core';
 import { minifyIntrospectionQuery } from '@urql/introspection';
 
+import { Data } from '../types';
 import { Store } from '../store';
 import { write } from './write';
 import { query } from './query';
@@ -156,7 +157,7 @@ describe('Query', () => {
       },
     });
 
-    const expected = {
+    const expected = ({
       todos: [
         {
           __typename: 'TodoEdge',
@@ -180,7 +181,7 @@ describe('Query', () => {
           },
         },
       ],
-    } as Data;
+    } as any) as Data;
 
     write(store, { query: TODO_QUERY }, expected);
 
@@ -188,6 +189,7 @@ describe('Query', () => {
       store,
       { query: TODO_QUERY },
       {
+        __typename: 'Query',
         todos: [
           // NOTE: This is a partial list of later results
           {

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -105,8 +105,8 @@ export const read = (
 
   return {
     dependencies: getCurrentDependencies(),
-    partial: data === undefined ? false : ctx.partial,
-    data: data === undefined ? null : data,
+    partial: ctx.partial || !data,
+    data: data || null,
   };
 };
 
@@ -125,7 +125,7 @@ const readRoot = (
   data.__typename = originalData.__typename;
 
   let node: FieldNode | void;
-  while ((node = iterate()) !== undefined) {
+  while ((node = iterate())) {
     const fieldAlias = getFieldAlias(node);
     const fieldValue = originalData[fieldAlias];
     if (node.selectionSet && fieldValue !== null) {
@@ -174,7 +174,7 @@ export const readFragment = (
   const fragments = getFragments(query);
   const names = Object.keys(fragments);
   const fragment = fragments[names[0]] as FragmentDefinitionNode;
-  if (fragment === undefined) {
+  if (!fragment) {
     warn(
       'readFragment(...) was called with an empty fragment.\n' +
         'You have to call it with at least one fragment in your GraphQL document.',
@@ -349,7 +349,7 @@ const readSelection = (
         // current field
         return undefined;
       }
-    } else if (node.selectionSet === undefined) {
+    } else if (!node.selectionSet) {
       // The field is a scalar but isn't on the result, so it's retrieved from the cache
       dataFieldValue = fieldValue;
     } else if (resultValue !== undefined) {

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -144,7 +144,7 @@ export const writeFragment = (
   const fragments = getFragments(query);
   const names = Object.keys(fragments);
   const fragment = fragments[names[0]] as FragmentDefinitionNode;
-  if (fragment === undefined) {
+  if (!fragment) {
     return warn(
       'writeFragment(...) was called with an empty fragment.\n' +
         'You have to call it with at least one fragment in your GraphQL document.',
@@ -336,7 +336,7 @@ const writeField = (
 
   if (
     parentFieldKey &&
-    ctx.store.keys[data.__typename] === undefined &&
+    !ctx.store.keys[data.__typename] &&
     entityKey === null &&
     typeof typename === 'string' &&
     !KEYLESS_TYPE_RE.test(typename)


### PR DESCRIPTION
This was originally reported by @sarmeyer.

Tracking down what the root culprit and intended fix is was difficult since the effects of this bug were subtle, the cause was hard to find, and this can poorly by fixed by several small issues. Ultimately, tl;dr, the bug can be seen here: https://github.com/FormidableLabs/urql/blob/eee828914fb6083b2aaa3203484ed6b36b7beff5/exchanges/graphcache/src/operations/query.ts#L93-L97

## Summary

Fix reusing original query data from APIs accidentally, which can lead to subtle mismatches in results when the API's incoming `query` results are being updated by the `cacheExchange`, to apply resolvers. Specifically this may lead to relations from being set back to `null` when the resolver returns a different list of links than the result, since some `null` relations may unintentionally exist but aren't related. If you're using `relayPagination` then this fix is critical.

## Investigation

When a result comes back from the API it is both written to the cached, but the `cacheExchange` also queries it again from the API, to update its data using `resolvers`. This is a great technique to get any API result from looking the same as if it was directly queried from the cache.

For mutations and subscriptions this is also nice, because we have a special `readRoot` case that copies values over from the `originalData`, since not all fields on "root results" are cached, since they're not normalised. This is easily confused with `readSelection`'s concept of `data` which is the **target** where we write results too. At some point we must've gotten either confused or assumed that it'd be great for `readSelection` (which is for normalised data) to _also_ use the original API data as its `data` input.

This becomes a problem because it's not necessary and can cause bugs. It's not necessary because we're dealing with normalised data, so the data should be completely queryable from the cache and reusing the original data will just cause confusion. It also causes bugs — which is how @sarmeyer discovered this — because if a resolver returns a list of items that in turn have links (i.e. relations) to other entities, then the result's original data may have items in a different order or length. This data will still be used, but if it's set to `null` then another special case causes the field to be considered `null` again, whether that's actually correct **or not**, see: https://github.com/FormidableLabs/urql/blob/eee828914fb6083b2aaa3203484ed6b36b7beff5/exchanges/graphcache/src/operations/query.ts#L499

In this line we check whether `prevData === null`. This is important because a past selection set may have contained _uncached_ fields but a future one for the same path in the query may not, which would mean that the data would be returned even though it contained _uncached fields_. This test illustrates why this check exists: https://github.com/FormidableLabs/urql/blob/eee828914fb6083b2aaa3203484ed6b36b7beff5/exchanges/graphcache/src/operations/query.test.ts#L225-L233

But when we use the API result as an input then `prevData` isn't just the data that Graphcache built up from its cache, it's also the data from the API result that's being reused. And when a list contains unrelated items with `null` fields then this check will instead cause this relation to become `null` although the cached data exists.

Another side-effect of this bug is that because API results are reused, some references/objects/instances are _overwritten_ by Graphcache, which is bad. It should never mutate data it gets from the API, but just write it to its cache then create a _new_ query result.

## Set of changes

- Add a reproduction test case
- Fix some tests that should've warned us about this being a problem 🤦 
- Ensure that `readSelection` in `read` always gets a _new, empty_ object to write to.