### PR TITLE
(graphcache) - Alias resolvers/updates parent to its parentKey in cache methods

### DIFF
--- a/.changeset/ten-kangaroos-march.md
+++ b/.changeset/ten-kangaroos-march.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Update `cache` methods, for instance `cache.resolve`, to consistently accept the `parent` argument from `resolvers` and `updates` and alias it to the parent's key (which is usually found on `info.parentKey`). This usage of `cache.resolve(parent, ...)` was intuitive and is now supported as expected.

--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -71,6 +71,22 @@ A `Resolver` receives four arguments when it's called: `parent`, `args`, `cache`
 | `cache`  | `Cache`  | The cache using which data can be read or written. [See `Cache`.](#cache)                                   |
 | `info`   | `Info`   | Additional metadata and information about the current operation and the current field. [See `Info`.](#info) |
 
+We can use the arguments it receives to either return new data based on just the arguments and other
+cache information, but we may also read information about the parent and return new data for the
+current field.
+
+```js
+{
+  Todo: {
+    createdAt(parent, args, cache) {
+      // Read `createdAt` on the parent but return a Date instance
+      const date = cache.resolve(parent, 'createdAt');
+      return new Date(date);
+    }
+  }
+}
+```
+
 [Read more about how to set up `resolvers` on the "Computed Queries"
 page.](../graphcache/computed-queries.md)
 
@@ -262,6 +278,7 @@ differing arguments) that is known to the cache. The `FieldInfo` interface has t
 
 This works on any given entity. When calling this method the cache works in reverse on its data
 structure, by parsing the entity's individual field keys.
+p
 
 ```js
 cache.inspectFields({ __typename: 'Query' });
@@ -444,16 +461,17 @@ This is a metadata object that is passed to every resolver and updater function.
 information about the current GraphQL document and query, and also some information on the current
 field that a given resolver or updater is called on.
 
-| Argument         | Type                                         | Description                                                                                                                                    |
-| ---------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `parentTypeName` | `string`                                     | The field's parent entity's typename                                                                                                           |
-| `parentKey`      | `string`                                     | The field's parent entity's cache key (if any)                                                                                                 |
-| `parentFieldKey` | `string`                                     | The current key's cache key, which is the parent entity's key combined with the current field's key (This is mostly obsolete)                  |
-| `fieldName`      | `string`                                     | The current field's name                                                                                                                       |
-| `fragments`      | `{ [name: string]: FragmentDefinitionNode }` | A dictionary of fragments from the current GraphQL document                                                                                    |
-| `variables`      | `object`                                     | The current GraphQL operation's variables (may be an empty object)                                                                             |
-| `partial`        | `?boolean`                                   | This may be set to `true` at any point in time (by your custom resolver or by _Graphcache_) to indicate that some data is uncached and missing |
-| `optimistic`     | `?boolean`                                   | This is only `true` when an optimistic mutation update is running                                                                              |
+| Argument         | Type                                         | Description                                                                                                                                                  |
+| ---------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `parent`         | `Data`                                       | The field's parent entity's data, as it was written or read up until now, which means it may be incomplete. [Use `cache.resolve`](#resolve) to read from it. |
+| `parentTypeName` | `string`                                     | The field's parent entity's typename                                                                                                                         |
+| `parentKey`      | `string`                                     | The field's parent entity's cache key (if any)                                                                                                               |
+| `parentFieldKey` | `string`                                     | The current key's cache key, which is the parent entity's key combined with the current field's key (This is mostly obsolete)                                |
+| `fieldName`      | `string`                                     | The current field's name                                                                                                                                     |
+| `fragments`      | `{ [name: string]: FragmentDefinitionNode }` | A dictionary of fragments from the current GraphQL document                                                                                                  |
+| `variables`      | `object`                                     | The current GraphQL operation's variables (may be an empty object)                                                                                           |
+| `partial`        | `?boolean`                                   | This may be set to `true` at any point in time (by your custom resolver or by _Graphcache_) to indicate that some data is uncached and missing               |
+| `optimistic`     | `?boolean`                                   | This is only `true` when an optimistic mutation update is running                                                                                            |
 
 > **Note:** Using `info` is regarded as a last resort. Please only use information from it if
 > there's no other solution to get to the metadata you need. We don't regard the `Info` API as

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -190,9 +190,7 @@ export const readFragment = (
   }
 
   const entityKey =
-    typeof entity !== 'string'
-      ? store.keyOfEntity({ __typename: typename, ...entity } as Data)
-      : entity;
+    typeof entity !== 'string' ? store.keyOfEntity(entity as Data) : entity;
 
   if (!entityKey) {
     warn(
@@ -311,7 +309,7 @@ const readSelection = (
     ) {
       // We have to update the information in context to reflect the info
       // that the resolver will receive
-      updateContext(ctx, typename, entityKey, key, fieldName);
+      updateContext(ctx, data, typename, entityKey, key, fieldName);
 
       // We have a resolver for this field.
       // Prepare the actual fieldValue, so that the resolver can use it

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -185,13 +185,9 @@ export const readFragment = (
   }
 
   const typename = getFragmentTypeName(fragment);
-  if (typeof entity !== 'string' && !entity.__typename) {
+  if (typeof entity !== 'string' && !entity.__typename)
     entity.__typename = typename;
-  }
-
-  const entityKey =
-    typeof entity !== 'string' ? store.keyOfEntity(entity as Data) : entity;
-
+  const entityKey = store.keyOfEntity(entity as Data);
   if (!entityKey) {
     warn(
       "Can't generate a key for readFragment(...).\n" +

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -22,7 +22,7 @@ export interface Context {
   parentTypeName: string;
   parentKey: string;
   parentFieldKey: string;
-  parent: Data | null;
+  parent: Data;
   fieldName: string;
   partial: boolean;
   optimistic: boolean;

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -22,10 +22,13 @@ export interface Context {
   parentTypeName: string;
   parentKey: string;
   parentFieldKey: string;
+  parent: Data | null;
   fieldName: string;
   partial: boolean;
   optimistic: boolean;
 }
+
+export const contextRef: { current: Context | null } = { current: null };
 
 export const makeContext = (
   store: Store,
@@ -38,6 +41,7 @@ export const makeContext = (
   store,
   variables,
   fragments,
+  parent: { __typename: typename },
   parentTypeName: typename,
   parentKey: entityKey,
   parentFieldKey: '',
@@ -48,11 +52,14 @@ export const makeContext = (
 
 export const updateContext = (
   ctx: Context,
+  data: Data,
   typename: string,
   entityKey: string,
   fieldKey: string,
   fieldName: string
 ) => {
+  contextRef.current = ctx;
+  ctx.parent = data;
   ctx.parentTypeName = typename;
   ctx.parentKey = entityKey;
   ctx.parentFieldKey = fieldKey;

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -253,7 +253,7 @@ const writeSelection = (
 
       if (!resolver) continue;
       // We have to update the context to reflect up-to-date ResolveInfo
-      updateContext(ctx, typename, typename, fieldKey, fieldName);
+      updateContext(ctx, data, typename, typename, fieldKey, fieldName);
       fieldValue = data[fieldAlias] = ensureData(
         resolver(fieldArgs || {}, ctx.store, ctx)
       );
@@ -286,6 +286,7 @@ const writeSelection = (
       // We have to update the context to reflect up-to-date ResolveInfo
       updateContext(
         ctx,
+        data,
         typename,
         typename,
         joinKeys(typename, fieldKey),

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -75,7 +75,7 @@ export interface QueryInput<T = Data, V = Variables> {
 
 export interface Cache {
   /** keyOfEntity() returns the key for an entity or null if it's unkeyable */
-  keyOfEntity(data: Data): string | null;
+  keyOfEntity(data: Data | null | string): string | null;
 
   /** keyOfField() returns the key for a field */
   keyOfField(
@@ -97,7 +97,11 @@ export interface Cache {
   inspectFields(entity: Data | string | null): FieldInfo[];
 
   /** invalidate() invalidates an entity or a specific field of an entity */
-  invalidate(entity: Data | string, fieldName?: string, args?: Variables): void;
+  invalidate(
+    entity: Data | string | null,
+    fieldName?: string,
+    args?: Variables
+  ): void;
 
   /** updateQuery() can be used to update the data of a given query using an updater function */
   updateQuery<T = Data, V = Variables>(

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -58,6 +58,7 @@ export interface OperationRequest {
 }
 
 export interface ResolveInfo {
+  parent: Data;
   parentTypeName: string;
   parentKey: string;
   parentFieldKey: string;


### PR DESCRIPTION
Resolves #1207

## Summary

This updates the shared context object to be provided on a global ref, which is then used in various cache methods, via `cache.keyOfEntity`, to alias the `parent` argument, which can be found on resolvers and updaters, to `info.parentKey`. This is done by adding (publicly) `info.parent`, which is the current parent's data as it is. (This avoids us having to share it on a separate object)

This further refactors `store.keyOfEntity` to take care of all key normalisation that has been done repeatedly in separate methods before, which further ensures that `cache[method](parent)` is going to work consistently as expected.

The reasoning here is that writing resolvers with `parent` as the first argument to further cache methods is so intuitive that we even did it ourselves in the docs, without thinking about it, although its support wasn't guaranteed as #1185 demonstrates. As an example:

```js
cacheExchange({
  resolvers: {
    Todo: {
      createdAt(parent, args, cache) {
        const date = cache.resolve(parent, 'createdAt');
        return new Date(date);
      }
    }
  },
})
```

## Set of changes

- Add `parent` field to `Context` and `ResolveInfo`
- Add global ref for the current `Context` to be exposed
- Add `store.keyOfEntity` alias if `entity === ctx.parent` to `ctx.parentKey`
- Refactor store methods to decrease repetition
- Update API docs
