### PR TITLE
(docs) - Fix outdated type in next-urql section

### DIFF
--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -83,7 +83,7 @@ Next allows you to override the root of your application using a special page ca
 The `clientOptions` argument is required. It represents all of the options you want to enable on your `urql` Client instance. It has the following union type:
 
 ```typescript
-type NextUrqlClientConfig = (ssrExchange: SSRExchange, ctx?: NextPageContext) => ClientOptions;
+type NextUrqlClientConfig = (ssrExchange: SSRExchange, ctx?: PartialNextContext) => ClientOptions;
 ```
 
 The `ClientOptions` `interface` comes from `urql` itself and has the following type:


### PR DESCRIPTION
Fixes a mistake in the `next-urql` docs.
`NextUrqlClientConfig` now uses `PartialNextContext` instead of `NextPageContext`.

https://github.com/FormidableLabs/urql/blob/e723365575203ff242bc9867f6e43fb43fb2e51e/packages/next-urql/src/types.ts#L21-L23