### PR TITLE
(docs) - Fix error in cache.inspectFields code sample

### DIFF
--- a/docs/graphcache/custom-updates.md
+++ b/docs/graphcache/custom-updates.md
@@ -203,7 +203,7 @@ const cache = cacheExchange({
 
         todosQueries.forEach(({ arguments }) => {
           cache.updateQuery(
-            { query: TODOS_QUERY, variables: x.arguments },
+            { query: TODOS_QUERY, variables: arguments },
             data => {
               data.todos.push(result.addTodo);
               return data;


### PR DESCRIPTION
## Summary / Set of changes
Contrary to a few lines up, in this closure `x` is already destructured
which means `arguments` exists, but `x.arguments` does not.

A small change makes sure the code works when copy pasted :)
