### PR TITLE
Add compatibility for Wonka compiled with ReScript >= 8

### DIFF
--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -74,8 +74,14 @@ function toSuspenseSource<T>(source: Source<T>): Source<T> {
     // If we haven't got a previous result then start suspending
     // otherwise issue the last known result immediately
     if (cache !== undefined) {
-      const signal = [cache] as [T] & { tag: 1 };
+      const signal = [cache] as [T] & { tag: 1, TAG: 1, _0: T };
       signal.tag = 1;
+      // ReScript has new variant encoding from version 8 onwards.
+      // Mirror the variant encoding above to a compatbile version
+      // so urql works with Wonka no matter with which version of
+      // ReScript it was compiled.
+      signal.TAG = signal.tag;
+      signal._0 = signal[0];
       sink(signal);
     } else {
       hasSuspended = true;

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -74,8 +74,14 @@ function toSuspenseSource<T>(source: Source<T>): Source<T> {
     // If we haven't got a previous result then start suspending
     // otherwise issue the last known result immediately
     if (cache !== undefined) {
-      const signal = [cache] as [T] & { tag: 1 };
+      const signal = [cache] as [T] & { tag: 1, TAG: 1, _0: T };
       signal.tag = 1;
+      // ReScript has new variant encoding from version 8 onwards.
+      // Mirror the variant encoding above to a compatbile version
+      // so urql works with Wonka no matter with which version of
+      // ReScript it was compiled.
+      signal.TAG = signal.tag;
+      signal._0 = signal[0];
       sink(signal);
     } else {
       hasSuspended = true;


### PR DESCRIPTION
## Summary
It took a bit of investigating but it turns out that when Wonka is compiled with ReScript >= 8 it's variant representation changes. Urql has one location where it manually encodes a variant in `userQuery`, thus this cause problems when Urql expects Wonka to be compiled with ReScript < 8, but that's not the case.

The full investigation story can be found in https://github.com/FormidableLabs/reason-urql/issues/232

I [searched for the usage of `.tag` in the codebase](https://github.com/FormidableLabs/urql/search?p=6&q=.tag) to find where this manual encoding was performed and only found this in `react-urql` and `preact-urql`.

A better change than my fix would be to let Wonka encode the variant (perhaps we can expose a function?) so that it automatically uses whatever encoding ReScript decided. This more properly decouples Urql from ReScript's internal decisions and avoids breakage in the future if they decide to further change this representation.

## Set of changes

Urql's useQuery for React and Preact now encodes it's cache results in a manner compatible with ReScript >= 8 as well as ReScript < 8 to ensure that Urql doesn't break when Wonka has been compiled with newer ReScript versions.