### PR TITLE
 (core) - Add fragment deduping to gql tag 

### DIFF
--- a/.changeset/gentle-wasps-play.md
+++ b/.changeset/gentle-wasps-play.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Add fragment deduplication to `gql` tag. Identical fragments can now be interpolated multiple times without a warning being triggered or them being duplicated in `gql`'s output.

--- a/exchanges/execute/src/execute.test.ts
+++ b/exchanges/execute/src/execute.test.ts
@@ -4,7 +4,7 @@ jest.mock('graphql', () => {
   return {
     __esModule: true,
     ...graphql,
-    print: jest.fn(a => a as any),
+    print: jest.fn(() => '{ placeholder }'),
     execute: jest.fn(() => ({ key: 'value' })),
   };
 });

--- a/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
+++ b/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
@@ -142,13 +142,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -312,13 +312,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -484,13 +484,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -632,13 +632,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 102,
-        "source": Source {
+        "source": Object {
           "body": "mutation uploadProfilePicture($picture: File) { uploadProfilePicture(picture: $picture) { location } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -786,13 +786,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 108,
-        "source": Source {
+        "source": Object {
           "body": "mutation uploadProfilePictures($pictures: [File]) { uploadProfilePicture(pictures: $pictures) { location } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },

--- a/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
+++ b/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
@@ -141,22 +141,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -319,22 +311,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -499,22 +483,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -655,20 +631,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 134,
+        "end": 102,
         "source": Source {
-          "body": "
-    mutation uploadProfilePicture($picture: File) {
-      uploadProfilePicture(picture: $picture) {
-        location
-      }
-    }
-  ",
+          "body": "mutation uploadProfilePicture($picture: File) { uploadProfilePicture(picture: $picture) { location } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -815,20 +785,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 140,
+        "end": 108,
         "source": Source {
-          "body": "
-    mutation uploadProfilePictures($pictures: [File]) {
-      uploadProfilePicture(pictures: $pictures) {
-        location
-      }
-    }
-  ",
+          "body": "mutation uploadProfilePictures($pictures: [File]) { uploadProfilePicture(pictures: $pictures) { location } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },

--- a/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -141,22 +141,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -319,22 +311,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -499,22 +483,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },

--- a/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -142,13 +142,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -312,13 +312,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -484,13 +484,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },

--- a/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -115,20 +115,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 106,
+        "end": 74,
         "source": Source {
-          "body": "
-    subscription subscribeToUser($user: String) {
-      user(user: $user) {
-        name
-      }
-    }
-  ",
+          "body": "subscription subscribeToUser($user: String) { user(user: $user) { name } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },

--- a/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -116,13 +116,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 74,
-        "source": Source {
+        "source": Object {
           "body": "subscription subscribeToUser($user: String) { user(user: $user) { name } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },

--- a/packages/core/src/gql.test.ts
+++ b/packages/core/src/gql.test.ts
@@ -1,4 +1,4 @@
-import { Source, parse, print } from 'graphql';
+import { parse, print } from 'graphql';
 import { gql } from './gql';
 import { keyDocument } from './utils';
 
@@ -25,7 +25,7 @@ it('parses GraphQL Documents', () => {
   expect(doc.loc).toEqual({
     start: 0,
     end: 15,
-    source: new Source('{ gql testing }'),
+    source: expect.anything(),
   });
 });
 

--- a/packages/core/src/gql.test.ts
+++ b/packages/core/src/gql.test.ts
@@ -3,15 +3,22 @@ import { gql } from './gql';
 import { keyDocument } from './utils';
 
 it('parses GraphQL Documents', () => {
-  expect(gql('{ test }').definitions).toEqual(
-    parse('{ test }', { noLocation: true }).definitions
-  );
-  expect(gql('{ test }')).toBe(keyDocument('{ test }'));
+  const doc = gql`
+    {
+      gql
+      testing
+    }
+  `;
 
-  expect(gql('{ test }').loc).toEqual({
+  expect(doc.definitions).toEqual(
+    parse('{ gql testing }', { noLocation: true }).definitions
+  );
+
+  expect(doc).toBe(keyDocument('{ gql testing }'));
+  expect(doc.loc).toEqual({
     start: 0,
-    end: 8,
-    source: new Source('{ test }', 'gql'),
+    end: 15,
+    source: new Source('{ gql testing }'),
   });
 });
 

--- a/packages/core/src/gql.ts
+++ b/packages/core/src/gql.ts
@@ -2,20 +2,13 @@
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import {
-  Source,
   DocumentNode,
   DefinitionNode,
   FragmentDefinitionNode,
-  Location,
   Kind,
-  print,
 } from 'graphql';
 
 import { keyDocument, stringifyDocument } from './utils';
-
-type WritableDocumentNode = {
-  -readonly [K in keyof DocumentNode]: DocumentNode[K];
-};
 
 const applyDefinitions = (
   fragmentNames: Map<string, string>,
@@ -83,17 +76,10 @@ function gql(/* arguments */) {
   for (let i = 0; i < interpolations.length; i++)
     applyDefinitions(fragmentNames, definitions, interpolations[i].definitions);
 
-  const doc: WritableDocumentNode = {
+  return keyDocument({
     kind: Kind.DOCUMENT,
     definitions,
-    loc: undefined,
-  };
-
-  const str = print(doc);
-  doc.loc = { start: 0, end: str.length, source: new Source(str) } as Location;
-
-  // Add source for compatibility with graphql-tag, which keyDocument() will also reuse for hashing
-  return keyDocument(doc);
+  });
 }
 
 export { gql };

--- a/packages/core/src/gql.ts
+++ b/packages/core/src/gql.ts
@@ -1,10 +1,50 @@
 /* eslint-disable prefer-rest-params */
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { Source, Location, DocumentNode, Kind, print } from 'graphql';
-import { keyDocument } from './utils';
+
+import {
+  Source,
+  DocumentNode,
+  DefinitionNode,
+  FragmentDefinitionNode,
+  Location,
+  Kind,
+  print,
+} from 'graphql';
+
+import { keyDocument, stringifyDocument } from './utils';
 
 type WritableDocumentNode = {
   -readonly [K in keyof DocumentNode]: DocumentNode[K];
+};
+
+const applyDefinitions = (
+  fragmentNames: Map<string, string>,
+  target: DefinitionNode[],
+  source: Array<DefinitionNode> | ReadonlyArray<DefinitionNode>
+) => {
+  for (let i = 0; i < source.length; i++) {
+    const definition = source[i];
+    if (source[i].kind === Kind.FRAGMENT_DEFINITION) {
+      const name = (source[i] as FragmentDefinitionNode).name.value;
+      const value = stringifyDocument(definition);
+      // Fragments will be deduplicated according to this Map
+      const prevValue = fragmentNames.get(name);
+      if (prevValue === undefined) {
+        fragmentNames.set(name, value);
+        target.push(source[i]);
+      } else if (process.env.NODE_ENV !== 'production' && prevValue !== value) {
+        // Fragments with the same names is expected to have the same contents
+        console.warn(
+          '[WARNING: Duplicate Fragment] A fragment with name `' +
+            name +
+            '` already exists in this document.\n' +
+            'While fragment names may not be unique across your source, each name must be unique per document.'
+        );
+      }
+    } else {
+      target.push(source[i]);
+    }
+  }
 };
 
 function gql<Data = any, Variables = object>(
@@ -17,48 +57,43 @@ function gql<Data = any, Variables = object>(
 ): TypedDocumentNode<Data, Variables>;
 
 function gql(/* arguments */) {
+  const fragmentNames = new Map<string, string>();
+  const definitions: DefinitionNode[] = [];
+  const interpolations: DocumentNode[] = [];
+
+  // Apply the entire tagged template body's definitions
   let body: string = Array.isArray(arguments[0])
     ? arguments[0][0]
     : arguments[0] || '';
   for (let i = 1; i < arguments.length; i++) {
     const value = arguments[i];
-    body +=
-      value && value.kind === Kind.DOCUMENT
-        ? value.loc
-          ? value.loc.source.body
-          : print(value)
-        : value;
+    if (value && value.kind === Kind.DOCUMENT) {
+      interpolations.push(value);
+    } else {
+      body += value;
+    }
+
     body += arguments[0][i];
   }
 
-  const doc = keyDocument(body);
-  if (process.env.NODE_ENV !== 'production') {
-    const fragmentNames = new Set();
-    for (let i = 0; i < doc.definitions.length; i++) {
-      const definition = doc.definitions[i];
-      if (definition.kind === Kind.FRAGMENT_DEFINITION) {
-        const name = definition.name.value;
-        if (fragmentNames.has(name)) {
-          console.warn(
-            '[WARNING: Duplicate Fragment] A fragment with name `' +
-              name +
-              '` already exists in this document.\n' +
-              'While fragment names may not be unique across your source, each name must be unique per document.'
-          );
-        } else {
-          fragmentNames.add(name);
-        }
-      }
-    }
-  }
+  // Apply the tag's body definitions
+  applyDefinitions(fragmentNames, definitions, keyDocument(body).definitions);
 
-  (doc as WritableDocumentNode).loc = {
-    start: 0,
-    end: body.length,
-    source: new Source(body, 'gql'),
-  } as Location;
+  // Copy over each interpolated document's definitions
+  for (let i = 0; i < interpolations.length; i++)
+    applyDefinitions(fragmentNames, definitions, interpolations[i].definitions);
 
-  return doc;
+  const doc: WritableDocumentNode = {
+    kind: Kind.DOCUMENT,
+    definitions,
+    loc: undefined,
+  };
+
+  const str = print(doc);
+  doc.loc = { start: 0, end: str.length, source: new Source(str) } as Location;
+
+  // Add source for compatibility with graphql-tag, which keyDocument() will also reuse for hashing
+  return keyDocument(doc);
 }
 
 export { gql };

--- a/packages/core/src/gql.ts
+++ b/packages/core/src/gql.ts
@@ -16,10 +16,9 @@ const applyDefinitions = (
   source: Array<DefinitionNode> | ReadonlyArray<DefinitionNode>
 ) => {
   for (let i = 0; i < source.length; i++) {
-    const definition = source[i];
     if (source[i].kind === Kind.FRAGMENT_DEFINITION) {
       const name = (source[i] as FragmentDefinitionNode).name.value;
-      const value = stringifyDocument(definition);
+      const value = stringifyDocument(source[i]);
       // Fragments will be deduplicated according to this Map
       const prevValue = fragmentNames.get(name);
       if (prevValue === undefined) {

--- a/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
+++ b/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
@@ -141,22 +141,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -309,22 +301,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -477,22 +461,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -649,22 +625,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },
@@ -837,22 +805,14 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 124,
+        "end": 76,
         "source": Source {
-          "body": "
-    query getUser($name: String) {
-      user(name: $name) {
-        id
-        firstName
-        lastName
-      }
-    }
-  ",
+          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "gql",
+          "name": "GraphQL request",
         },
         "start": 0,
       },

--- a/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
+++ b/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
@@ -142,13 +142,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -302,13 +302,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -462,13 +462,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -626,13 +626,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },
@@ -806,13 +806,13 @@ Object {
       "kind": "Document",
       "loc": Object {
         "end": 76,
-        "source": Source {
+        "source": Object {
           "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
           },
-          "name": "GraphQL request",
+          "name": "gql",
         },
         "start": 0,
       },

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -1,6 +1,6 @@
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+
 import {
-  Source,
   Location,
   DefinitionNode,
   DocumentNode,
@@ -8,6 +8,7 @@ import {
   parse,
   print,
 } from 'graphql';
+
 import { hash, phash } from './hash';
 import { stringifyVariables } from './stringifyVariables';
 import { GraphQLRequest } from '../types';
@@ -36,7 +37,11 @@ export const stringifyDocument = (
     (node as WritableLocation).loc = {
       start: 0,
       end: str.length,
-      source: new Source(str),
+      source: {
+        body: str,
+        name: 'gql',
+        locationOffset: { line: 1, column: 1 },
+      },
     } as Location;
   }
 

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -56,11 +56,8 @@ export const keyDocument = (q: string | DocumentNode): KeyedDocumentNode => {
   if (typeof q === 'string') {
     key = hash(stringifyDocument(q));
     query = docs.get(key) || parse(q, { noLocation: true });
-  } else if ((q as any).__key != null) {
-    key = (q as any).__key;
-    query = q;
   } else {
-    key = hash(stringifyDocument(q));
+    key = (q as KeyedDocumentNode).__key || hash(stringifyDocument(q));
     query = docs.get(key) || q;
   }
 


### PR DESCRIPTION
## Summary

This change implements a missing feature of the `gql` tag. While it previously warned about fragments with duplicate names, it didn't check whether these fragments were identical and deduplicated them. This change implements fragment deduplication and solidifies some of our `DocumentNode#__key` and `ASTNode#loc` additions.

## Set of changes

- Incrementally add an operation's definitions to a new `gql` document
- Add `ASTNode.loc` in `stringifyDocument`
- Switch `gql` to apply this behaviour to raw `DocumentNode` inputs only
