### PR TITLE
(docs) - Change wording in schema-awareness to reflect intent of minify

### DIFF
--- a/docs/graphcache/schema-awareness.md
+++ b/docs/graphcache/schema-awareness.md
@@ -107,9 +107,9 @@ fetch('http://localhost:3000/graphql', {
   });
 ```
 
-The `getIntrospectionQuery` doesn't only accept `IntrospectionQuery` JSON data as inputs, but also
+The `minifyIntrospectionQuery` doesn't only accept `IntrospectionQuery` JSON data as inputs, but also
 allows you to pass a JSON string, `GraphQLSchema`, or GraphQL Schema SDL strings. It's a convenience
-helper and not needed in the above example.
+helper and not needed to make schema-awareness work, minifying the introspected schema is an optimization step.
 
 ## Integrating a schema
 

--- a/docs/graphcache/schema-awareness.md
+++ b/docs/graphcache/schema-awareness.md
@@ -107,9 +107,9 @@ fetch('http://localhost:3000/graphql', {
   });
 ```
 
-The `minifyIntrospectionQuery` doesn't only accept `IntrospectionQuery` JSON data as inputs, but also
+The `getIntrospectionSchema ` doesn't only accept `IntrospectionQuery` JSON data as inputs, but also
 allows you to pass a JSON string, `GraphQLSchema`, or GraphQL Schema SDL strings. It's a convenience
-helper and not needed to make schema-awareness work, minifying the introspected schema is an optimization step.
+helper and not needed in the above example.
 
 ## Integrating a schema
 


### PR DESCRIPTION
This changes the wording of `schema-awareness.md` to reflect what `minifyIntrospectionQuery` can take as an argument and that it's not a requirement to make schema-awarenss work, it is an optimization step.

Closes https://github.com/FormidableLabs/urql/issues/1228