### PR TITLE
(graphcache) - add null as a possible type for args in invalidate

### DIFF
--- a/.changeset/tiny-badgers-pretend.md
+++ b/.changeset/tiny-badgers-pretend.md
@@ -1,0 +1,5 @@
+---
+"@urql/exchange-graphcache": patch
+---
+
+Fix, add null as a possible type for the variables argument in `cache.invalidate`

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -9,7 +9,7 @@ interface PartialFieldInfo {
 export const invalidateEntity = (
   entityKey: string,
   field?: string,
-  args?: Variables
+  args?: Variables | null
 ) => {
   const fields: PartialFieldInfo[] = field
     ? [{ fieldKey: keyOfField(field, args) }]

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -143,7 +143,11 @@ export class Store implements Cache {
 
   resolveFieldByKey = this.resolve;
 
-  invalidate(entity: Data | string | null, field?: string, args?: Variables | null) {
+  invalidate(
+    entity: Data | string | null,
+    field?: string,
+    args?: Variables | null
+  ) {
     const entityKey = this.keyOfEntity(entity);
 
     invariant(

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -143,7 +143,7 @@ export class Store implements Cache {
 
   resolveFieldByKey = this.resolve;
 
-  invalidate(entity: Data | string | null, field?: string, args?: Variables) {
+  invalidate(entity: Data | string | null, field?: string, args?: Variables | null) {
     const entityKey = this.keyOfEntity(entity);
 
     invariant(


### PR DESCRIPTION
Fixes: https://github.com/FormidableLabs/urql/issues/1262

## Summary

This PR adds `null`  as a possible type for the variables argument in `invalidate` and `keyOfField`.

## Set of changes

- Add `null` as a type for `cache.invalidate` variables
