### PR TITLE
(react/preact) - Fix issue where ssr would leak across renders

### DIFF
--- a/.changeset/twelve-icons-wonder.md
+++ b/.changeset/twelve-icons-wonder.md
@@ -1,0 +1,6 @@
+---
+"@urql/preact": patch
+"urql": patch
+---
+
+Fix issue where ssr would leak across renders even with new Clients, this was due to `useQuery` holding a global Map of operationKey to OperationResult.

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -90,7 +90,7 @@ function toSuspenseSource<T>(source: Source<T>): Source<T> {
 const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
   client.suspense && (!context || context.suspense !== false);
 
-type Sources = Map<number, Source<OperationResult>>
+type Sources = Map<number, Source<OperationResult>>;
 const sourcesByClient = new WeakMap<Client, Sources>();
 
 export function useQuery<Data = any, Variables = object>(
@@ -105,7 +105,7 @@ export function useQuery<Data = any, Variables = object>(
   const makeQuery$ = useCallback(
     (opts?: Partial<OperationContext>) => {
       let sources = sourcesByClient.get(client);
-      if (!sources) sourcesByClient.set(client, (sources = new Map()))
+      if (!sources) sourcesByClient.set(client, (sources = new Map()));
 
       // Determine whether suspense is enabled for the given operation
       const suspense = isSuspense(client, args.context);
@@ -187,7 +187,7 @@ export function useQuery<Data = any, Variables = object>(
 
   useEffect(() => {
     let sources = sourcesByClient.get(client);
-    if (!sources) sourcesByClient.set(client, (sources = new Map()))
+    if (!sources) sourcesByClient.set(client, (sources = new Map()));
 
     sources.delete(request.key); // Delete any cached suspense source
     if (!isSuspense(client, args.context)) update(query$);

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -90,12 +90,12 @@ function toSuspenseSource<T>(source: Source<T>): Source<T> {
 const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
   client.suspense && (!context || context.suspense !== false);
 
-const sources = new Map<number, Source<OperationResult>>();
-
 export function useQuery<Data = any, Variables = object>(
   args: UseQueryArgs<Variables, Data>
 ): UseQueryResponse<Data, Variables> {
   const client = useClient();
+  if (!client.sources) client.sources = new Map();
+  const sources = client.sources;
   // This creates a request which will keep a stable reference
   // if request.key doesn't change
   const request = useRequest<Data, Variables>(args.query, args.variables);

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -87,7 +87,7 @@ function toSuspenseSource<T>(source: Source<T>): Source<T> {
   };
 }
 
-type Sources = Map<number, Source<OperationResult>>
+type Sources = Map<number, Source<OperationResult>>;
 const sourcesByClient = new WeakMap<Client, Sources>();
 
 const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
@@ -106,7 +106,7 @@ export function useQuery<Data = any, Variables = object>(
   const makeQuery$ = useCallback(
     (opts?: Partial<OperationContext>) => {
       let sources = sourcesByClient.get(client);
-      if (!sources) sourcesByClient.set(client, (sources = new Map()))
+      if (!sources) sourcesByClient.set(client, (sources = new Map()));
 
       // Determine whether suspense is enabled for the given operation
       const suspense = isSuspense(client, args.context);
@@ -189,7 +189,7 @@ export function useQuery<Data = any, Variables = object>(
 
   useEffect(() => {
     let sources = sourcesByClient.get(client);
-    if (!sources) sourcesByClient.set(client, (sources = new Map()))
+    if (!sources) sourcesByClient.set(client, (sources = new Map()));
 
     sources.delete(request.key); // Delete any cached suspense source
     if (!isSuspense(client, args.context)) update(query$);


### PR DESCRIPTION
## Summary

When we'd invoke two parallel renders with two different clients  the global in `useQuery` would cause us to share data between the clients.

Resolves https://github.com/FormidableLabs/urql/issues/1272
Sandbox: https://codesandbox.io/s/urql-cross-request-cache-issue-forked-sx6oe?file=/src/useQuery.js

## Set of changes

- register sources on the urql-client
