### PR TITLE
(docs) add a search input to the sidebar

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@mdx-js/react": "^1.6.22",
     "formidable-oss-badges": "0.3.5",
+    "fuse.js": "^6.4.6",
     "history": "^4.7.2",
     "path": "^0.12.7",
     "preact": "^10.5.7",

--- a/packages/site/src/components/navigation.js
+++ b/packages/site/src/components/navigation.js
@@ -10,11 +10,11 @@ export const SidebarContainer = styled.div`
   right: 0;
   bottom: 0;
   min-height: 100%;
+  width: ${p => p.theme.layout.sidebar};
 
   @media ${({ theme }) => theme.media.sm} {
     display: block;
     position: relative;
-    width: ${p => p.theme.layout.sidebar};
     margin-left: calc(2 * ${p => p.theme.layout.stripes});
   }
 `;
@@ -49,12 +49,12 @@ export const SidebarWrapper = styled.aside`
   background-color: ${p => p.theme.colors.bg};
   border-right: 1px solid ${p => p.theme.colors.border};
   border-top: 1px solid ${p => p.theme.colors.border};
+  width: ${p => p.theme.layout.sidebar};
 
   @media ${({ theme }) => theme.media.sm} {
     border: none;
     background: none;
     padding-top: ${p => p.theme.spacing.md};
-    width: ${p => p.theme.layout.sidebar};
   }
 `;
 

--- a/packages/site/src/components/navigation.js
+++ b/packages/site/src/components/navigation.js
@@ -107,7 +107,8 @@ export const SidebarNavSubItem = styled(NavLink).attrs(() => ({}))`
   color: ${p => p.theme.colors.passive};
   font-weight: ${p => p.theme.fontWeights.body};
   text-decoration: none;
-  margin-top: ${p => p.theme.spacing.xs};
+  margin: ${p =>
+    `${p.theme.spacing.xs} 0 0 ${p.nested ? p.theme.spacing.sm : 0}`};
 
   &:first-child {
     margin-top: 0;

--- a/packages/site/src/components/sidebar-search-input.js
+++ b/packages/site/src/components/sidebar-search-input.js
@@ -3,16 +3,24 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const StyledInput = styled.input`
-  width: 100%;
+  background-color: rgba(255, 255, 255, 0.8);
+  border: none;
   border-radius: 0.5rem;
+  color: ${p => p.theme.colors.text};
+  font-family: ${p => p.theme.fonts.body};
   font-size: 1.6rem;
   line-height: 2.3rem;
   letter-spacing: -0.6px;
-  padding: 0.4rem 0.9rem 0.6rem;
-  color: ${({ theme }) => theme.colors.text};
-  background-color: rgba(255, 255, 255, 0.8);
-  border: none;
-  font-family: ${({ theme }) => theme.fonts.body};
+  margin: ${p =>
+    `${p.theme.spacing.sm} 0 ${p.theme.spacing.sm} calc(${p.theme.spacing.xs} * -1.5)`};
+  padding: ${p =>
+    `${p.theme.spacing.xs} calc(${p.theme.spacing.xs} * 1.5) ${p.theme.spacing.xs}`};
+  width: calc(100% + 1.8rem);
+  background-color: ${p => p.theme.colors.passiveBg};
+
+  @media ${p => p.theme.media.sm} {
+    background-color: ${p => p.theme.colors.bg};
+  }
 `;
 
 const SidebarSearchInput = ({ value, onHandleInputChange }) => (

--- a/packages/site/src/components/sidebar-search-input.js
+++ b/packages/site/src/components/sidebar-search-input.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const StyledInput = styled.input`
+  width: 100%;
+  border-radius: 0.5rem;
+  font-size: 1.6rem;
+  line-height: 2.3rem;
+  letter-spacing: -0.6px;
+  padding: 0.4rem 0.9rem 0.6rem;
+  color: ${({ theme }) => theme.colors.text};
+  background-color: rgba(255, 255, 255, 0.8);
+  border: none;
+  font-family: ${({ theme }) => theme.fonts.body};
+`;
+
+const SidebarSearchInput = ({ value, onHandleInputChange }) => (
+  <StyledInput
+    onChange={onHandleInputChange}
+    placeholder="Filter..."
+    type="search"
+    value={value}
+  />
+);
+
+SidebarSearchInput.propTypes = {
+  value: PropTypes.string,
+  onHandleInputChange: PropTypes.func,
+};
+
+export default SidebarSearchInput;

--- a/packages/site/src/components/sidebar.js
+++ b/packages/site/src/components/sidebar.js
@@ -23,30 +23,28 @@ import SidebarSearchInput from './sidebar-search-input';
 import logoSidebar from '../assets/sidebar-badge.svg';
 
 const HeroLogoLink = styled(Link)`
-  display: flex;
+  display: none;
   flex-direction: row;
   justify-content: center;
   margin-bottom: ${p => p.theme.spacing.sm};
   align-self: center;
+
+  @media ${p => p.theme.media.sm} {
+    display: flex;
+  }
 `;
 
 const HeroLogo = styled.img.attrs(() => ({
   src: logoSidebar,
   alt: 'urql',
 }))`
-  display: none;
   width: ${p => p.theme.layout.logo};
   height: ${p => p.theme.layout.logo};
-
-  @media ${p => p.theme.media.sm} {
-    display: block;
-  }
 `;
 
 const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  padding-top: ${p => p.theme.spacing.xs};
   padding-bottom: ${p => p.theme.spacing.lg};
 `;
 
@@ -62,14 +60,14 @@ export const relative = (from, to) => {
   return { pathname };
 };
 
-export const SidebarStyling = ({ children, sidebarOpen, closeSidebar }) => {
+export const SidebarStyling = ({ children, sidebarOpen }) => {
   const basepath = useBasepath() || '';
   const homepage = basepath ? `/${basepath}/` : '/';
 
   return (
     <>
       <SideBarStripes />
-      <SidebarContainer hidden={!sidebarOpen} onClick={closeSidebar}>
+      <SidebarContainer hidden={!sidebarOpen}>
         <SidebarWrapper>
           <HeroLogoLink to={homepage}>
             <HeroLogo />
@@ -147,7 +145,7 @@ const highlightText = (text, indices) => (
   </>
 );
 
-const Sidebar = props => {
+const Sidebar = ({ closeSidebar, ...props }) => {
   const [filterTerm, setFilterTerm] = useState('');
   const location = useLocation();
   const tree = useMarkdownTree();
@@ -186,6 +184,7 @@ const Sidebar = props => {
             to={relative(pathname, page.path)}
             // If there is an active filter term in place, expand all headings
             isActive={() => isActive}
+            onClick={closeSidebar}
           >
             {page.matchedIndices
               ? highlightText(page.frontmatter.title, page.matchedIndices)
@@ -218,7 +217,7 @@ const Sidebar = props => {
         </Fragment>
       );
     });
-  }, [location, tree, filterTerm]);
+  }, [location, tree, filterTerm, closeSidebar]);
 
   return (
     <SidebarStyling {...props}>

--- a/packages/site/src/styles/theme.js
+++ b/packages/site/src/styles/theme.js
@@ -30,7 +30,7 @@ export const layout = {
   page: '144rem',
   header: '4.8rem',
   stripes: '0.7rem',
-  sidebar: '26rem',
+  sidebar: '28rem',
   legend: '22rem',
   logo: '12rem',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7702,6 +7702,11 @@ fuse.js@^3.6.1:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.6.1.tgz#7de85fdd6e1b3377c23ce010892656385fd9b10c"
   integrity sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==
 
+fuse.js@^6.4.6:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.6.tgz#62f216c110e5aa22486aff20be7896d19a059b79"
+  integrity sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->
Resolves #1064 

## Summary

The reasoning behind this change is mostly explained in the above issue. 

We want to add the capability to search the docs for relevant content based on the page title or subheading(s).

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- add `< SidebarSearchInput />`
- filter sidebar headings and subheadings based on input 
- while searching, include matching H3 headers in the sidebar
- highlight matching substrings by wrapping them in `<strong>`
- add `fuse.js` fuzzy-search dep
- increase the sidebar width

![searching via the sidebar](https://user-images.githubusercontent.com/35961363/104107640-b5590380-52b5-11eb-874b-54b1513363eb.gif)


## Outstanding points

- Depending on how we like the current design we may want to relocate the search bar to the header, showing relevant matches in a dropdown as opposed to the sidebar