### PR TITLE
(react/preact) - Suspense with child queries sharing data

### DIFF
--- a/.changeset/little-mice-shave.md
+++ b/.changeset/little-mice-shave.md
@@ -1,0 +1,6 @@
+---
+"@urql/preact": patch
+"urql": patch
+---
+
+Fix Suspense when results share data, this would return partial results for graphCache and not update to the eventual data

--- a/packages/preact-urql/src/hooks/useSource.ts
+++ b/packages/preact-urql/src/hooks/useSource.ts
@@ -33,13 +33,17 @@ export function useSource<T, R>(
   const [state, setState] = useState<R>(() => {
     currentInit = true;
     let state: R;
-    pipe(
-      transform(fromValue(input)),
-      subscribe(value => {
-        state = value;
-      })
-    ).unsubscribe();
-    currentInit = false;
+    try {
+      pipe(
+        transform(fromValue(input)),
+        subscribe(value => {
+          state = value;
+        })
+      ).unsubscribe();
+    } finally {
+      currentInit = false;
+    }
+
     return state!;
   });
 

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -55,13 +55,17 @@ export function useSource<T, R>(
   const [state, setState] = useState<R>(() => {
     currentInit = true;
     let state: R;
-    pipe(
-      transform(input$),
-      subscribe(value => {
-        state = value;
-      })
-    ).unsubscribe();
-    currentInit = false;
+    try {
+      pipe(
+        transform(input$),
+        subscribe(value => {
+          state = value;
+        })
+      ).unsubscribe();
+    } finally {
+      currentInit = false;
+    }
+
     return state!;
   });
 


### PR DESCRIPTION
## Summary

Fix Suspense when results share data, this would return partial results for graphCache and not update to the eventual data

Fixes: https://github.com/FormidableLabs/urql/issues/1249 https://codesandbox.io/s/modest-chatterjee-s6c2g

## Set of changes

- Always reset the `currentInit` for state initialization