### PR TITLE
docs: added 'Updating the cache after a mutation'

### DIFF
--- a/docs/basics/mutations.md
+++ b/docs/basics/mutations.md
@@ -45,6 +45,11 @@ Unlike the `useQuery` hook, the `useMutation` hook doesn't execute automatically
 our example, no mutation will be performed. To execute our mutation we instead have to call the
 execute function — `updateTodo` in our example — which is the second item in the tuple.
 
+### Updating the cache after a mutation
+
+If a mutation updates a single existing entity, `urql` can automatically update that entity’s value in its cache. To do so, the mutation must return the id of the modified entity, along with the values of the fields that were modified. You can clearly see that in the example above.
+However if mutation affects other entities, you may want to [set up manual updates that react to mutations.](https://formidable.com/open-source/urql/docs/graphcache/custom-updates/)
+
 ### Using the mutation result
 
 When calling our `updateTodo` function we have two ways of getting to the result as it comes back


### PR DESCRIPTION
## Summary

After scrolling through all the docs haven't found any mentions about automatic cache updates after a mutation. but I think it's really important to mention what mutation should return specific fields in order to automatic updates come to action.

## Set of changes

Added a brief paragraph about this feature so it's more understandable to newcomers.
