### PR TITLE
(graphcache) - Prefer updated layer in re-query

### DIFF
--- a/.changeset/silly-peaches-compete.md
+++ b/.changeset/silly-peaches-compete.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix edge-case where query results would pick up invalidated fields from mutation results as they're written to the cache. This would cause invalid cache misses although the result was expected to just be passed through from the API result.

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -229,7 +229,7 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
         .dependencies;
       collectPendingOperations(pendingOperations, writeDependencies);
 
-      const queryResult = query(store, operation, result.data);
+      const queryResult = query(store, operation, result.data, key);
       result.data = queryResult.data;
       if (operation.kind === 'query') {
         // Collect the query's dependencies for future pending operation updates

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -61,9 +61,10 @@ export interface QueryResult {
 export const query = (
   store: Store,
   request: OperationRequest,
-  data?: Data
+  data?: Data,
+  key?: number
 ): QueryResult => {
-  initDataState('read', store.data, null);
+  initDataState('read', store.data, (data && key) || null);
   const result = read(store, request, data);
   clearDataState();
   return result;

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -239,6 +239,15 @@ const getNode = <T>(
 ): T | undefined => {
   let node: Dict<T | undefined> | undefined;
 
+  if (
+    currentOperation === 'read' &&
+    currentOptimisticKey &&
+    map.optimistic[currentOptimisticKey]
+  ) {
+    node = map.optimistic[currentOptimisticKey].get(entityKey);
+    if (node !== undefined && fieldKey in node) return node[fieldKey];
+  }
+
   // This first iterates over optimistic layers (in order)
   for (let i = 0, l = currentData!.optimisticOrder.length; i < l; i++) {
     const layerKey = currentData!.optimisticOrder[i];

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -238,23 +238,23 @@ const getNode = <T>(
   fieldKey: string
 ): T | undefined => {
   let node: Dict<T | undefined> | undefined;
-
-  if (
+  // A read may be initialised to skip layers until its own, which is useful for
+  // reading back written data. It won't skip over optimistic layers however
+  let skip =
+    !currentOptimistic &&
     currentOperation === 'read' &&
     currentOptimisticKey &&
-    map.optimistic[currentOptimisticKey]
-  ) {
-    node = map.optimistic[currentOptimisticKey].get(entityKey);
-    if (node !== undefined && fieldKey in node) return node[fieldKey];
-  }
-
+    currentData!.commutativeKeys.has(currentOptimisticKey);
   // This first iterates over optimistic layers (in order)
   for (let i = 0, l = currentData!.optimisticOrder.length; i < l; i++) {
     const layerKey = currentData!.optimisticOrder[i];
     const optimistic = map.optimistic[layerKey];
+    // If we're reading starting from a specific layer, we skip until a match
+    skip = skip && layerKey !== currentOptimisticKey;
     // If the node and node value exists it is returned, including undefined
     if (
       optimistic &&
+      (!skip || !currentData!.commutativeKeys.has(layerKey)) &&
       (!currentOptimistic ||
         currentOperation === 'write' ||
         currentData!.commutativeKeys.has(layerKey)) &&


### PR DESCRIPTION
Resolve #1253 

## Summary

In Graphcache, results from the API update the cache and are then re-queried to execute resolvers and apply optimistic updates. The latter is unlikely to take effect, since optimistic updates block queries. However the former is pretty important for consistency.

A race condition could be triggered by invalidating data or rewriting it in a mutation. A subsequent query result (where the query was triggered before the mutation result) would then read the new/rewritten data instead of its own as it just wrote it. Instead we'll want this re-queried data to always prioritise reading its own data over the mutation data, but still prioritise optimistic layers over its own.

This change adds an exception for re-queried API data to prioritise its own layer and read from it first, skipping over higher layers as necessary, while still including data from potentially lower layers.

## Set of changes

- Add `skip` logic to `getNode` in `query` operation.
