### PR TITLE
(next-urql) - Use uppercase for React components

### DIFF
--- a/.changeset/large-ladybugs-burn.md
+++ b/.changeset/large-ladybugs-burn.md
@@ -1,0 +1,5 @@
+---
+"next-urql": patch
+---
+
+Fix `withUrqlClient` fast-refresh detection

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -36,7 +36,7 @@ export function withUrqlClient(
       (AppOrPage.getInitialProps || options!.ssr) && !options!.neverSuspend
     );
 
-    const withUrql = ({ urqlClient, urqlState, ...rest }: WithUrqlProps) => {
+    const WithUrql = ({ urqlClient, urqlState, ...rest }: WithUrqlProps) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const forceUpdate = useState(0);
 
@@ -84,10 +84,10 @@ export function withUrqlClient(
 
     // Set the displayName to indicate use of withUrqlClient.
     const displayName = AppOrPage.displayName || AppOrPage.name || 'Component';
-    withUrql.displayName = `withUrqlClient(${displayName})`;
+    WithUrql.displayName = `withUrqlClient(${displayName})`;
 
     if (AppOrPage.getInitialProps || options!.ssr) {
-      withUrql.getInitialProps = async (appOrPageCtx: NextUrqlPageContext) => {
+      WithUrql.getInitialProps = async (appOrPageCtx: NextUrqlPageContext) => {
         const AppTree = appOrPageCtx.AppTree!;
 
         // Determine if we are wrapping an App component or a Page component.
@@ -143,6 +143,6 @@ export function withUrqlClient(
       };
     }
 
-    return withUrql;
+    return WithUrql;
   };
 }


### PR DESCRIPTION
Fixes: https://github.com/FormidableLabs/urql/issues/1301

## Summary

React-refresh babel requires components to start with an upper case letter to be incorporated in the signing flow.

## Set of changes

- `withUrql` renamed to `WithUrql` 
