### PR TITLE
(graphCache) - warn when using an interface or union type in the resolvers

### DIFF
--- a/.changeset/late-gifts-worry.md
+++ b/.changeset/late-gifts-worry.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Warn when using an interface or union field in the graphCache resolvers config.

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -379,8 +379,6 @@ on the default names `"Mutation"` and `"Subscription"`.
 
 ## (26) Invalid abstract resolver
 
-Invalid resolver: \`${name}\` does not match to a concrete type in the schema, but the \`resolvers\` option is referencing it. Implement the resolver for the types that ${kind === 'UNION' ? 'make up the union' : 'implement the interface'} instead.
-
 > Invalid resolver: `???` does not map to a concrete type in the schema,
 > but the resolvers option is referencing it. Implement the resolver for the types that `??` instead.
 

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -376,3 +376,17 @@ schema {
 
 Where `YourMutation` and `YourSubscription` are your custom Operation Root Types, instead of relying
 on the default names `"Mutation"` and `"Subscription"`.
+
+## (26) Invalid abstract resolver
+
+Invalid resolver: \`${name}\` does not match to a concrete type in the schema, but the \`resolvers\` option is referencing it. Implement the resolver for the types that ${kind === 'UNION' ? 'make up the union' : 'implement the interface'} instead.
+
+> Invalid resolver: `???` does not map to a concrete type in the schema,
+> but the resolvers option is referencing it. Implement the resolver for the types that `??` instead.
+
+When you're passing an introspected schema to the cache exchange, it is
+able to check whether your `opts.resolvers` is valid.
+This error occurs when you are using an `interface` or `union` rather than an
+implemented type for these.
+
+Check the type mentioned and change it to one of the specific types.

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -177,6 +177,18 @@ function warnAboutResolver(name: string): void {
   );
 }
 
+function warnAboutAbstractResolver(
+  name: string,
+  kind: 'UNION' | 'INTERFACE'
+): void {
+  warn(
+    `Invalid resolver: \`${name}\` does not match to a concrete type in the schema, but the \`resolvers\` option is referencing it. Implement the resolver for the types that ${
+      kind === 'UNION' ? 'make up the union' : 'implement the interface'
+    } instead.`,
+    26
+  );
+}
+
 export function expectValidResolversConfig(
   schema: SchemaIntrospector,
   resolvers: ResolverConfig
@@ -201,6 +213,14 @@ export function expectValidResolversConfig(
     } else {
       if (!schema.types[key]) {
         warnAboutResolver(key);
+      } else if (
+        schema.types[key].kind === 'INTERFACE' ||
+        schema.types[key].kind === 'UNION'
+      ) {
+        warnAboutAbstractResolver(
+          key,
+          schema.types[key].kind as 'INTERFACE' | 'UNION'
+        );
       } else {
         const validTypeProperties = (schema.types[key] as SchemaObject).fields;
         for (const resolverProperty in resolvers[key]) {

--- a/exchanges/graphcache/src/helpers/help.ts
+++ b/exchanges/graphcache/src/helpers/help.ts
@@ -30,7 +30,8 @@ export type ErrorCode =
   | 22
   | 23
   | 24
-  | 25;
+  | 25
+  | 26;
 
 type DebugNode = ExecutableDefinitionNode | InlineFragmentNode;
 

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -320,6 +320,26 @@ describe('Store with ResolverConfig', () => {
     expect(warnMessage).toContain('https://bit.ly/2XbVrpR#23');
   });
 
+  it('should warn when we use an interface type', function () {
+    new Store({
+      schema: minifyIntrospectionQuery(
+        require('../test-utils/simple_schema.json')
+      ),
+      resolvers: {
+        ITodo: {
+          complete: () => true,
+        },
+      },
+    });
+
+    expect(console.warn).toBeCalledTimes(1);
+    const warnMessage = mocked(console.warn).mock.calls[0][0];
+    expect(warnMessage).toContain(
+      'Invalid resolver: `ITodo` does not match to a concrete type in the schema, but the `resolvers` option is referencing it. Implement the resolver for the types that implement the interface instead.'
+    );
+    expect(warnMessage).toContain('https://bit.ly/2XbVrpR#26');
+  });
+
   it("should warn if a type's property doesn't exist in the schema", function () {
     new Store({
       schema: minifyIntrospectionQuery(


### PR DESCRIPTION
Resolves: https://github.com/FormidableLabs/urql/issues/1293

## Summary

Warn the user when using an abstract type in the resolvers config.

## Set of changes

- add dev-check to schema-predicates
- add documentation for said error