### PR TITLE
(docs) clarify necessity of `__typename` for abstract types in readFr…

### DIFF
--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -315,8 +315,9 @@ cache.readFragment(
 ); // Data or null
 ```
 
-Note that the `__typename` may be left out on the partial entity, since the `__typename` is already
-present on the fragment itself.
+Note that the `__typename` may be left out on the partial entity if the fragment isn't on an
+interface or union type, since in that case the `__typename` is already present on the fragment
+itself.
 
 If any fields on the fragment require variables, you can pass them as the third argument like so:
 


### PR DESCRIPTION
…agment

## Summary

If you're using a fragment on an abstract type in `readFragment` then you must specify the concrete type of the entity that you're trying to match. Not doing so will cause a cache miss.


## Set of changes

This PR updates the `readFragment` documentation to add this snippet of information.
