### PR TITLE
(react) - Fix Suspense-on-update giving stale results in Concurrent Mode

### DIFF
--- a/.changeset/many-rats-buy.md
+++ b/.changeset/many-rats-buy.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Fix edge cases related to Suspense triggering on an update in Concurrent Mode. Previously it was possible for stale state to be preserved across the Suspense update instead of the new state showing up. This has been fixed by preventing the suspending query source from closing prematurely.

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -1,5 +1,5 @@
 import { DocumentNode } from 'graphql';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 
 import {
   Source,
@@ -180,24 +180,12 @@ export function useQuery<Data = any, Variables = object>(
     [update, makeQuery$]
   );
 
-  const [suspend, setSuspend] = useState<[Promise<any> | null]>([null]);
-
   useEffect(() => {
-    try {
-      sources.delete(request.key); // Delete any cached suspense source
-      update(query$);
-    } catch (promise) {
-      if (promise != null && promise.then) {
-        setSuspend([promise]);
-      }
-    }
+    sources.delete(request.key); // Delete any cached suspense source
+    if (isSuspense(client, args.context)) update(query$);
   }, [update, client, query$, request, args.context]);
 
-  if (suspend[0]) {
-    const promise = suspend[0];
-    suspend[0] = null;
-    throw promise;
-  }
+  if (isSuspense(client, args.context)) update(query$);
 
   return [state, executeQuery];
 }

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -63,7 +63,7 @@ function toSuspenseSource<T>(source: Source<T>): Source<T> {
       shared,
       onPush(result => {
         // The first result that is received will resolve the Suspense promise
-        if (cache === undefined) resolve(result);
+        if (resolve && cache === undefined) resolve(result);
         cache = result;
       })
     )(sink);

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -182,7 +182,7 @@ export function useQuery<Data = any, Variables = object>(
 
   useEffect(() => {
     sources.delete(request.key); // Delete any cached suspense source
-    if (isSuspense(client, args.context)) update(query$);
+    if (!isSuspense(client, args.context)) update(query$);
   }, [update, client, query$, request, args.context]);
 
   if (isSuspense(client, args.context)) update(query$);

--- a/packages/react-urql/src/hooks/useSource.ts
+++ b/packages/react-urql/src/hooks/useSource.ts
@@ -5,6 +5,7 @@ import {
   Source,
   fromValue,
   makeSubject,
+  takeWhile,
   pipe,
   map,
   concat,
@@ -58,6 +59,7 @@ export function useSource<T, R>(
     try {
       pipe(
         transform(input$),
+        takeWhile(() => currentInit),
         subscribe(value => {
           state = value;
         })


### PR DESCRIPTION
Resolve #1303

## Summary

Fix edge cases related to Suspense triggering on an update in Concurrent Mode. Previously it was possible for stale state to be preserved across the Suspense update instead of the new state showing up. This has been fixed by preventing the suspending query source from closing prematurely.

See CodeSandbox for reproduction / fix in action: https://codesandbox.io/s/optimistic-andras-f2j1q?file=/src/useQuery.ts

For some next steps it'd be interesting to explore ways to remove the `toSuspenseSource` cache in `useQuery` for another solution that's more in-line with per-client shortterm caches, e.g. https://github.com/FormidableLabs/urql/tree/refactor/shared-sources

## Set of changes

- Don't close `toSuspenseSource` sources prematurely when throwing suspense promise
- Fix cached values in `toSuspenseSource` from being sent without a prior `Pull` event
- Remove delay on resolving the suspense promise
- Prevent leaks in `useSource` when the initial state getter throws a suspense promise
