### PR TITLE
(graphcache) - Relay backwards pagination

### DIFF
--- a/.changeset/strange-scissors-swim.md
+++ b/.changeset/strange-scissors-swim.md
@@ -2,4 +2,4 @@
 '@urql/exchange-graphcache': patch
 ---
 
-Fix relay-pagination would bug out when requesting overlapping pages through the last parameter.
+Fix a Relay Pagination edge case where overlapping ends of pages queried using the `last` argument would be in reverse order.

--- a/.changeset/strange-scissors-swim.md
+++ b/.changeset/strange-scissors-swim.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix relay-pagination would bug out when requesting overlapping pages through the last parameter.

--- a/exchanges/graphcache/src/extras/relayPagination.ts
+++ b/exchanges/graphcache/src/extras/relayPagination.ts
@@ -240,8 +240,8 @@ export const relayPagination = (params: PaginationParams = {}): Resolver => {
         pageInfo.startCursor = page.pageInfo.startCursor;
         pageInfo.hasPreviousPage = page.pageInfo.hasPreviousPage;
       } else if (typeof args.last === 'number') {
-        endEdges = concatEdges(cache, endEdges, page.edges);
-        endNodes = concatNodes(endNodes, page.nodes);
+        endEdges = concatEdges(cache, page.edges, endEdges);
+        endNodes = concatNodes(page.nodes, endNodes);
         pageInfo = page.pageInfo;
       } else {
         startEdges = concatEdges(cache, startEdges, page.edges);


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/urql/issues/1297

## Summary

When we'd have two backwards overlapping pages the results would start mixing up.

## Set of changes

- Reverse the backwards pagination node - edge concatenation
