### PR TITLE
(react/preact) - Try out a weakmap to cache the suspense sources

### DIFF
--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -22,6 +22,7 @@ import {
   RequestPolicy,
   OperationResult,
   Operation,
+  GraphQLRequest,
 } from '@urql/core';
 
 import { useClient } from '../context';
@@ -89,7 +90,10 @@ function toSuspenseSource<T>(source: Source<T>): Source<T> {
 const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
   client.suspense && (!context || context.suspense !== false);
 
-const sources = new Map<number, Source<OperationResult>>();
+const sources = new WeakMap<
+  GraphQLRequest<any, any>,
+  Source<OperationResult>
+>();
 
 export function useQuery<Data = any, Variables = object>(
   args: UseQueryArgs<Variables, Data>
@@ -105,7 +109,7 @@ export function useQuery<Data = any, Variables = object>(
       // Determine whether suspense is enabled for the given operation
       const suspense = isSuspense(client, args.context);
       let source: Source<OperationResult> | void = suspense
-        ? sources.get(request.key)
+        ? sources.get(request)
         : undefined;
 
       if (!source) {
@@ -120,7 +124,7 @@ export function useQuery<Data = any, Variables = object>(
         if (suspense) {
           source = toSuspenseSource(source);
           if (typeof window !== 'undefined') {
-            sources.set(request.key, source);
+            sources.set(request, source);
           }
         }
       }
@@ -181,7 +185,7 @@ export function useQuery<Data = any, Variables = object>(
   );
 
   useEffect(() => {
-    sources.delete(request.key); // Delete any cached suspense source
+    sources.delete(request); // Delete any cached suspense source
     if (!isSuspense(client, args.context)) update(query$);
   }, [update, client, query$, request, args.context]);
 


### PR DESCRIPTION
## Summary

This changes the map used for the Suspense sources to a Weakmap that is keyed by the request object, this will prevent the cache in leaking across async renders.

## Set of changes

- Change Map to Weakmap