### PR TITLE
 (core) - Fix graphql-tag/loader document.loc.source usage 

### DIFF
--- a/.changeset/clever-islands-do.md
+++ b/.changeset/clever-islands-do.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Add a workaround for `graphql-tag/loader`, which provides filtered query documents (where the original document contains multiple operations) without updating or providing a correct `document.loc.source.body` string.

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -33,24 +33,22 @@ export const stringifyDocument = (
     } else {
       str = print(str);
     }
+
+    // Add location information to stringified node
+    if (!(node as WritableLocation).loc) {
+      (node as WritableLocation).loc = {
+        start: 0,
+        end: str.length,
+        source: {
+          body: str,
+          name: 'gql',
+          locationOffset: { line: 1, column: 1 },
+        },
+      } as Location;
+    }
   }
 
-  str = str.replace(/([\s,]|#[^\n\r]+)+/g, ' ').trim();
-
-  // Add location information to stringified node
-  if (typeof node !== 'string' && !node.loc) {
-    (node as WritableLocation).loc = {
-      start: 0,
-      end: str.length,
-      source: {
-        body: str,
-        name: 'gql',
-        locationOffset: { line: 1, column: 1 },
-      },
-    } as Location;
-  }
-
-  return str;
+  return str.replace(/([\s,]|#[^\n\r]+)+/g, ' ').trim();
 };
 
 const docs = new Map<number, KeyedDocumentNode>();

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -24,13 +24,18 @@ export interface KeyedDocumentNode extends DocumentNode {
 export const stringifyDocument = (
   node: string | DefinitionNode | DocumentNode
 ): string => {
-  // Stringify or normalise input
-  const str = (typeof node !== 'string'
-    ? (node.loc && node.loc.source.body) || print(node)
-    : node
-  )
-    .replace(/([\s,]|#[^\n\r]+)+/g, ' ')
-    .trim();
+  let str = node;
+  if (typeof str !== 'string') {
+    if (str.loc && str.loc.source.body) {
+      const operationName = 'definitions' in str && getOperationName(str);
+      str = str.loc.source.body;
+      if (operationName) str = `# ${operationName}\n${str}`;
+    } else {
+      str = print(str);
+    }
+  }
+
+  str = str.replace(/([\s,]|#[^\n\r]+)+/g, ' ').trim();
 
   // Add location information to stringified node
   if (typeof node !== 'string' && !node.loc) {

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -24,18 +24,18 @@ export interface KeyedDocumentNode extends DocumentNode {
 export const stringifyDocument = (
   node: string | DefinitionNode | DocumentNode
 ): string => {
-  let str = node;
-  if (typeof str !== 'string') {
-    if (str.loc && str.loc.source.body) {
-      const operationName = 'definitions' in str && getOperationName(str);
-      str = str.loc.source.body;
+  let str = (typeof node !== 'string'
+    ? (node.loc && node.loc.source.body) || print(node)
+    : node
+  )
+    .replace(/([\s,]|#[^\n\r]+)+/g, ' ')
+    .trim();
+
+  if (typeof node !== 'string') {
+    if (node.loc) {
+      const operationName = 'definitions' in node && getOperationName(node);
       if (operationName) str = `# ${operationName}\n${str}`;
     } else {
-      str = print(str);
-    }
-
-    // Add location information to stringified node
-    if (!(node as WritableLocation).loc) {
       (node as WritableLocation).loc = {
         start: 0,
         end: str.length,
@@ -48,7 +48,7 @@ export const stringifyDocument = (
     }
   }
 
-  return str.replace(/([\s,]|#[^\n\r]+)+/g, ' ').trim();
+  return str;
 };
 
 const docs = new Map<number, KeyedDocumentNode>();


### PR DESCRIPTION
Resolve #1298 

## Summary

For output from graphql-tag/loader we need to add a workaround
to request.ts which adds the operation name to the document's
string since `document.loc.source` isn't reliable and potentially
points to the original query document which may contain all
operations rather than just one.

## Set of changes

- Add `getOperationName` to document strings in `request.ts` which are eventually used as hashes
