### PR TITLE
docs: renamed 'custom updates' to 'cache updates'

### DIFF
--- a/docs/graphcache/cache-updates.md
+++ b/docs/graphcache/cache-updates.md
@@ -1,9 +1,9 @@
 ---
-title: Custom Updates
+title: Cache Updates
 order: 3
 ---
 
-# Custom Updates
+# Cache Updates
 
 Every time Graphcache sees a result from the API for a `subscription` or a `mutation` it will look at the response and traverse it.
 This process is the same as for queries but instead of starting at the Query root type,

--- a/packages/site/static.config.js
+++ b/packages/site/static.config.js
@@ -54,5 +54,9 @@ export default {
       path: '404',
       template: require.resolve('./src/screens/404'),
     },
+    {
+      path: '/docs/graphcache/custom-updates',
+      redirect: 'docs/graphcache/cache-updates',
+    },
   ],
 };


### PR DESCRIPTION
As it was discussed here https://github.com/FormidableLabs/urql/pull/1283