### PR TITLE
docs(subscriptions): change websocket protocol prefix

### DIFF
--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -48,7 +48,7 @@ package](https://github.com/apollographql/subscriptions-transport-ws).
 import { Client, defaultExchanges, subscriptionExchange } from 'urql';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 
-const subscriptionClient = new SubscriptionClient('wss://localhost/graphql', { reconnect: true });
+const subscriptionClient = new SubscriptionClient('ws://localhost/graphql', { reconnect: true });
 
 const client = new Client({
   url: '/graphql',
@@ -79,7 +79,7 @@ import { createClient, defaultExchanges, subscriptionExchange } from 'urql';
 import { createClient as createWSClient } from 'graphql-ws';
 
 const wsClient = createWSClient({
-  url: 'wss://localhost/graphql',
+  url: 'ws://localhost/graphql',
 });
 
 const client = createClient({


### PR DESCRIPTION
## Summary
Just tried using GraphQL Subscriptions with `subscriptions-transport-ws`. I can only get it to work when using `ws://`. No response whatsoever when using the `wss://` prefix. Not sure what is causing this because they should specify the same protocol, but I guess it would be a good change either way for consistency with other resources like the Apollo Docs.

## Set of changes

Changed `wss://` to `ws://`