### PR TITLE
(introspection) - Improve schema minification by removing meta types

### DIFF
--- a/.changeset/orange-maps-raise.md
+++ b/.changeset/orange-maps-raise.md
@@ -1,0 +1,5 @@
+---
+'@urql/introspection': minor
+---
+
+Update `minifyIntrospectionQuery` utility to remove additional information on arguments and to filter out schema metadata types, like `__Field` and others.

--- a/packages/introspection/src/minifyIntrospectionQuery.ts
+++ b/packages/introspection/src/minifyIntrospectionQuery.ts
@@ -133,12 +133,25 @@ export const minifyIntrospectionQuery = (
   } = schema;
 
   const minifiedTypes = types
-    .filter(
-      type =>
-        type.kind === 'OBJECT' ||
-        type.kind === 'INTERFACE' ||
-        type.kind === 'UNION'
-    )
+    .filter(type => {
+      switch (type.name) {
+        case '__Directive':
+        case '__DirectiveLocation':
+        case '__EnumValue':
+        case '__InputValue':
+        case '__Field':
+        case '__Type':
+        case '__TypeKind':
+        case '__Schema':
+          return false;
+        default:
+          return (
+            type.kind === 'OBJECT' ||
+            type.kind === 'INTERFACE' ||
+            type.kind === 'UNION'
+          );
+      }
+    })
     .map(minifyIntrospectionType);
 
   minifiedTypes.push({ kind: 'SCALAR', name: anyType.name });

--- a/packages/introspection/src/minifyIntrospectionQuery.ts
+++ b/packages/introspection/src/minifyIntrospectionQuery.ts
@@ -57,9 +57,8 @@ const minifyIntrospectionType = (
               args:
                 field.args &&
                 field.args.map(arg => ({
-                  ...arg,
+                  name: arg.name,
                   type: mapType(arg.type, anyType),
-                  defaultValue: undefined,
                 })),
             } as any)
         ),
@@ -84,9 +83,8 @@ const minifyIntrospectionType = (
               args:
                 field.args &&
                 field.args.map(arg => ({
-                  ...arg,
+                  name: arg.name,
                   type: mapType(arg.type, anyType),
-                  defaultValue: undefined,
                 })),
             } as any)
         ),


### PR DESCRIPTION
## Summary

This removes more superfluous information from the minified schema introspection JSON data that `minifyIntrospectionQuery` generates. This has been checked to still be correctly parsed by `buildClientSchema`.

## Set of changes

- Remove metatypes from schema (See https://github.com/FormidableLabs/urql/commit/eb7abebe6ecb6ca9c907bfb475f8918cb2e94669)
- Remove additional JSON fields from arguments