### PR TITLE
(graphcache) - Handle fields with associated GraphQLError as cache misses and provide errors to updaters

### DIFF
--- a/.changeset/smart-emus-jam.md
+++ b/.changeset/smart-emus-jam.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': major
+---
+
+Add improved error awareness to Graphcache. When Graphcache now receives a `GraphQLError` (via a `CombinedError`) it checks whether the `GraphQLError`'s `path` matches up with `null` values in the `data`. Any `null` values that the write operation now sees in the data will be replaced with a "cache miss" value (i.e. `undefined`) when it has an associated error. This means that errored fields from your GraphQL API will be marked as uncached and won't be cached. Instead the client will now attempt a refetch of the data so that errors aren't preventing future refetches or with schema awareness it will attempt a refetch automatically. Additionally, the `updates` functions will now be able to check whether the current field has any errors associated with it with `info.error`.

--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -119,6 +119,13 @@ An `UpdateResolver` receives four arguments when it's called: `result`, `args`, 
 | `cache`  | `Cache`  | The cache using which data can be read or written. [See `Cache`.](#cache)                                   |
 | `info`   | `Info`   | Additional metadata and information about the current operation and the current field. [See `Info`.](#info) |
 
+It's possible to derive more information about the current update using the `info` argument. For
+instance this metadata contains the current `fieldName` of the updater which may be used to make an
+updater function more reusable, along with `parentKey` and other key fields. It also contains
+`variables` and `fragments` which remain the same for the entire write operation, and additionally
+it may have the `error` field set to describe whether the current field is `null` because the API
+encountered a `GraphQLError`.
+
 [Read more about how to set up `updates` on the "Custom Updates"
 page.](../graphcache/custom-updates.md)
 
@@ -463,17 +470,18 @@ This is a metadata object that is passed to every resolver and updater function.
 information about the current GraphQL document and query, and also some information on the current
 field that a given resolver or updater is called on.
 
-| Argument         | Type                                         | Description                                                                                                                                                  |
-| ---------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `parent`         | `Data`                                       | The field's parent entity's data, as it was written or read up until now, which means it may be incomplete. [Use `cache.resolve`](#resolve) to read from it. |
-| `parentTypeName` | `string`                                     | The field's parent entity's typename                                                                                                                         |
-| `parentKey`      | `string`                                     | The field's parent entity's cache key (if any)                                                                                                               |
-| `parentFieldKey` | `string`                                     | The current key's cache key, which is the parent entity's key combined with the current field's key (This is mostly obsolete)                                |
-| `fieldName`      | `string`                                     | The current field's name                                                                                                                                     |
-| `fragments`      | `{ [name: string]: FragmentDefinitionNode }` | A dictionary of fragments from the current GraphQL document                                                                                                  |
-| `variables`      | `object`                                     | The current GraphQL operation's variables (may be an empty object)                                                                                           |
-| `partial`        | `?boolean`                                   | This may be set to `true` at any point in time (by your custom resolver or by _Graphcache_) to indicate that some data is uncached and missing               |
-| `optimistic`     | `?boolean`                                   | This is only `true` when an optimistic mutation update is running                                                                                            |
+| Argument         | Type                                         | Description                                                                                                                                                                                              |
+| ---------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `parent`         | `Data`                                       | The field's parent entity's data, as it was written or read up until now, which means it may be incomplete. [Use `cache.resolve`](#resolve) to read from it.                                             |
+| `parentTypeName` | `string`                                     | The field's parent entity's typename                                                                                                                                                                     |
+| `parentKey`      | `string`                                     | The field's parent entity's cache key (if any)                                                                                                                                                           |
+| `parentFieldKey` | `string`                                     | The current key's cache key, which is the parent entity's key combined with the current field's key (This is mostly obsolete)                                                                            |
+| `fieldName`      | `string`                                     | The current field's name                                                                                                                                                                                 |
+| `fragments`      | `{ [name: string]: FragmentDefinitionNode }` | A dictionary of fragments from the current GraphQL document                                                                                                                                              |
+| `variables`      | `object`                                     | The current GraphQL operation's variables (may be an empty object)                                                                                                                                       |
+| `error`          | `GraphQLError \| undefined`                  | The current GraphQLError for a given field. This will always be `undefined` for resolvers and optimistic updaters, but may be present for updaters when the API has returned an error for a given field. |
+| `partial`        | `?boolean`                                   | This may be set to `true` at any point in time (by your custom resolver or by _Graphcache_) to indicate that some data is uncached and missing                                                           |
+| `optimistic`     | `?boolean`                                   | This is only `true` when an optimistic mutation update is running                                                                                                                                        |
 
 > **Note:** Using `info` is regarded as a last resort. Please only use information from it if
 > there's no other solution to get to the metadata you need. We don't regard the `Info` API as

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -225,8 +225,13 @@ export const cacheExchange = (opts?: CacheExchangeOpts): Exchange => ({
     if (result.data) {
       // Write the result to cache and collect all dependencies that need to be
       // updated
-      const writeDependencies = write(store, operation, result.data, key)
-        .dependencies;
+      const writeDependencies = write(
+        store,
+        operation,
+        result.data,
+        result.error,
+        key
+      ).dependencies;
       collectPendingOperations(pendingOperations, writeDependencies);
 
       const queryResult = query(store, operation, result.data, key);

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -130,7 +130,8 @@ const readRoot = (
     const fieldAlias = getFieldAlias(node);
     const fieldValue = originalData[fieldAlias];
     // Add the current alias to the walked path before processing the field's value
-    if (process.env.NODE_ENV !== 'production') ctx.path.push(fieldAlias);
+    if (process.env.NODE_ENV !== 'production')
+      ctx.__internal.path.push(fieldAlias);
     // Process the root field's value
     if (node.selectionSet && fieldValue !== null) {
       const fieldData = ensureData(fieldValue);
@@ -139,7 +140,7 @@ const readRoot = (
       data[fieldAlias] = fieldValue;
     }
     // After processing the field, remove the current alias from the path again
-    if (process.env.NODE_ENV !== 'production') ctx.path.pop();
+    if (process.env.NODE_ENV !== 'production') ctx.__internal.path.pop();
   }
 
   return data;
@@ -154,11 +155,11 @@ const readRootField = (
     const newData = new Array(originalData.length);
     for (let i = 0, l = originalData.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value
-      if (process.env.NODE_ENV !== 'production') ctx.path.push(i);
+      if (process.env.NODE_ENV !== 'production') ctx.__internal.path.push(i);
       // Recursively read the root field's value
       newData[i] = readRootField(ctx, select, originalData[i]);
       // After processing the field, remove the current index from the path
-      if (process.env.NODE_ENV !== 'production') ctx.path.pop();
+      if (process.env.NODE_ENV !== 'production') ctx.__internal.path.pop();
     }
 
     return newData;
@@ -311,7 +312,8 @@ const readSelection = (
     // means that the value is missing from the cache
     let dataFieldValue: void | DataField;
     // Add the current alias to the walked path before processing the field's value
-    if (process.env.NODE_ENV !== 'production') ctx.path.push(fieldAlias);
+    if (process.env.NODE_ENV !== 'production')
+      ctx.__internal.path.push(fieldAlias);
 
     if (resultValue !== undefined && node.selectionSet === undefined) {
       // The field is a scalar and can be retrieved directly from the result
@@ -395,7 +397,7 @@ const readSelection = (
     }
 
     // After processing the field, remove the current alias from the path again
-    if (process.env.NODE_ENV !== 'production') ctx.path.pop();
+    if (process.env.NODE_ENV !== 'production') ctx.__internal.path.pop();
     // Now that dataFieldValue has been retrieved it'll be set on data
     // If it's uncached (undefined) but nullable we can continue assembling
     // a partial query result
@@ -440,7 +442,7 @@ const resolveResolverResult = (
     const data = new Array(result.length);
     for (let i = 0, l = result.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value
-      if (process.env.NODE_ENV !== 'production') ctx.path.push(i);
+      if (process.env.NODE_ENV !== 'production') ctx.__internal.path.push(i);
       // Recursively read resolver result
       const childResult = resolveResolverResult(
         ctx,
@@ -453,7 +455,7 @@ const resolveResolverResult = (
         result[i]
       );
       // After processing the field, remove the current index from the path
-      if (process.env.NODE_ENV !== 'production') ctx.path.pop();
+      if (process.env.NODE_ENV !== 'production') ctx.__internal.path.pop();
       // Check the result for cache-missed values
       if (childResult === undefined && !_isListNullable) {
         return undefined;
@@ -502,7 +504,7 @@ const resolveLink = (
     const newLink = new Array(link.length);
     for (let i = 0, l = link.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value
-      if (process.env.NODE_ENV !== 'production') ctx.path.push(i);
+      if (process.env.NODE_ENV !== 'production') ctx.__internal.path.push(i);
       // Recursively read the link
       const childLink = resolveLink(
         ctx,
@@ -513,7 +515,7 @@ const resolveLink = (
         prevData != null ? prevData[i] : undefined
       );
       // After processing the field, remove the current index from the path
-      if (process.env.NODE_ENV !== 'production') ctx.path.pop();
+      if (process.env.NODE_ENV !== 'production') ctx.__internal.path.pop();
       // Check the result for cache-missed values
       if (childLink === undefined && !_isListNullable) {
         return undefined;

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -129,12 +129,17 @@ const readRoot = (
   while ((node = iterate())) {
     const fieldAlias = getFieldAlias(node);
     const fieldValue = originalData[fieldAlias];
+    // Add the current alias to the walked path before processing the field's value
+    ctx.path.push(fieldAlias);
+    // Process the root field's value
     if (node.selectionSet && fieldValue !== null) {
       const fieldData = ensureData(fieldValue);
       data[fieldAlias] = readRootField(ctx, getSelectionSet(node), fieldData);
     } else {
       data[fieldAlias] = fieldValue;
     }
+    // After processing the field, remove the current alias from the path again
+    ctx.path.pop();
   }
 
   return data;
@@ -147,8 +152,15 @@ const readRootField = (
 ): Data | NullArray<Data> | null => {
   if (Array.isArray(originalData)) {
     const newData = new Array(originalData.length);
-    for (let i = 0, l = originalData.length; i < l; i++)
+    for (let i = 0, l = originalData.length; i < l; i++) {
+      // Add the current index to the walked path before reading the field's value
+      ctx.path.push(i);
+      // Recursively read the root field's value
       newData[i] = readRootField(ctx, select, originalData[i]);
+      // After processing the field, remove the current index from the path
+      ctx.path.pop();
+    }
+
     return newData;
   } else if (originalData === null) {
     return null;
@@ -289,14 +301,18 @@ const readSelection = (
       isFieldAvailableOnType(store.schema, typename, fieldName);
     }
 
-    // We temporarily store the data field in here, but undefined
-    // means that the value is missing from the cache
-    let dataFieldValue: void | DataField;
-
+    // We directly assign typenames and skip the field afterwards
     if (fieldName === '__typename') {
       data[fieldAlias] = typename;
       continue;
-    } else if (resultValue !== undefined && node.selectionSet === undefined) {
+    }
+
+    // We temporarily store the data field in here, but undefined
+    // means that the value is missing from the cache
+    let dataFieldValue: void | DataField;
+    // Add the current alias to the walked path before processing the field's value
+    ctx.path.push(fieldAlias);
+    if (resultValue !== undefined && node.selectionSet === undefined) {
       // The field is a scalar and can be retrieved directly from the result
       dataFieldValue = resultValue;
     } else if (
@@ -377,6 +393,8 @@ const readSelection = (
       }
     }
 
+    // After processing the field, remove the current alias from the path again
+    ctx.path.pop();
     // Now that dataFieldValue has been retrieved it'll be set on data
     // If it's uncached (undefined) but nullable we can continue assembling
     // a partial query result
@@ -420,6 +438,8 @@ const resolveResolverResult = (
       !store.schema || isListNullable(store.schema, typename, fieldName);
     const data = new Array(result.length);
     for (let i = 0, l = result.length; i < l; i++) {
+      // Add the current index to the walked path before reading the field's value
+      ctx.path.push(i);
       // Recursively read resolver result
       const childResult = resolveResolverResult(
         ctx,
@@ -431,7 +451,9 @@ const resolveResolverResult = (
         prevData != null ? prevData[i] : undefined,
         result[i]
       );
-
+      // After processing the field, remove the current index from the path
+      ctx.path.pop();
+      // Check the result for cache-missed values
       if (childResult === undefined && !_isListNullable) {
         return undefined;
       } else {
@@ -478,6 +500,9 @@ const resolveLink = (
       store.schema && isListNullable(store.schema, typename, fieldName);
     const newLink = new Array(link.length);
     for (let i = 0, l = link.length; i < l; i++) {
+      // Add the current index to the walked path before reading the field's value
+      ctx.path.push(i);
+      // Recursively read the link
       const childLink = resolveLink(
         ctx,
         link[i],
@@ -486,6 +511,9 @@ const resolveLink = (
         select,
         prevData != null ? prevData[i] : undefined
       );
+      // After processing the field, remove the current index from the path
+      ctx.path.pop();
+      // Check the result for cache-missed values
       if (childLink === undefined && !_isListNullable) {
         return undefined;
       } else {

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -130,7 +130,7 @@ const readRoot = (
     const fieldAlias = getFieldAlias(node);
     const fieldValue = originalData[fieldAlias];
     // Add the current alias to the walked path before processing the field's value
-    ctx.path.push(fieldAlias);
+    if (process.env.NODE_ENV !== 'production') ctx.path.push(fieldAlias);
     // Process the root field's value
     if (node.selectionSet && fieldValue !== null) {
       const fieldData = ensureData(fieldValue);
@@ -139,7 +139,7 @@ const readRoot = (
       data[fieldAlias] = fieldValue;
     }
     // After processing the field, remove the current alias from the path again
-    ctx.path.pop();
+    if (process.env.NODE_ENV !== 'production') ctx.path.pop();
   }
 
   return data;
@@ -154,11 +154,11 @@ const readRootField = (
     const newData = new Array(originalData.length);
     for (let i = 0, l = originalData.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value
-      ctx.path.push(i);
+      if (process.env.NODE_ENV !== 'production') ctx.path.push(i);
       // Recursively read the root field's value
       newData[i] = readRootField(ctx, select, originalData[i]);
       // After processing the field, remove the current index from the path
-      ctx.path.pop();
+      if (process.env.NODE_ENV !== 'production') ctx.path.pop();
     }
 
     return newData;
@@ -311,7 +311,8 @@ const readSelection = (
     // means that the value is missing from the cache
     let dataFieldValue: void | DataField;
     // Add the current alias to the walked path before processing the field's value
-    ctx.path.push(fieldAlias);
+    if (process.env.NODE_ENV !== 'production') ctx.path.push(fieldAlias);
+
     if (resultValue !== undefined && node.selectionSet === undefined) {
       // The field is a scalar and can be retrieved directly from the result
       dataFieldValue = resultValue;
@@ -394,7 +395,7 @@ const readSelection = (
     }
 
     // After processing the field, remove the current alias from the path again
-    ctx.path.pop();
+    if (process.env.NODE_ENV !== 'production') ctx.path.pop();
     // Now that dataFieldValue has been retrieved it'll be set on data
     // If it's uncached (undefined) but nullable we can continue assembling
     // a partial query result
@@ -439,7 +440,7 @@ const resolveResolverResult = (
     const data = new Array(result.length);
     for (let i = 0, l = result.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value
-      ctx.path.push(i);
+      if (process.env.NODE_ENV !== 'production') ctx.path.push(i);
       // Recursively read resolver result
       const childResult = resolveResolverResult(
         ctx,
@@ -452,7 +453,7 @@ const resolveResolverResult = (
         result[i]
       );
       // After processing the field, remove the current index from the path
-      ctx.path.pop();
+      if (process.env.NODE_ENV !== 'production') ctx.path.pop();
       // Check the result for cache-missed values
       if (childResult === undefined && !_isListNullable) {
         return undefined;
@@ -501,7 +502,7 @@ const resolveLink = (
     const newLink = new Array(link.length);
     for (let i = 0, l = link.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value
-      ctx.path.push(i);
+      if (process.env.NODE_ENV !== 'production') ctx.path.push(i);
       // Recursively read the link
       const childLink = resolveLink(
         ctx,
@@ -512,7 +513,7 @@ const resolveLink = (
         prevData != null ? prevData[i] : undefined
       );
       // After processing the field, remove the current index from the path
-      ctx.path.pop();
+      if (process.env.NODE_ENV !== 'production') ctx.path.pop();
       // Check the result for cache-missed values
       if (childLink === undefined && !_isListNullable) {
         return undefined;

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -55,10 +55,9 @@ export const initErrorMap = (error?: CombinedError | undefined) => {
   }
 };
 
-export const isFieldMissing = (ctx: Context): boolean => {
-  // Checks whether the current data field is a cache miss because of a GraphQLError
-  return ctx.path.length > 0 && !!errorMap && !!errorMap[ctx.path.join('.')];
-};
+// Checks whether the current data field is a cache miss because of a GraphQLError
+export const getFieldError = (ctx: Context): GraphQLError | undefined =>
+  ctx.path.length > 0 && !!errorMap ? errorMap[ctx.path.join('.')] : undefined;
 
 export const makeContext = (
   store: Store,
@@ -96,7 +95,7 @@ export const updateContext = (
   ctx.parentKey = entityKey;
   ctx.parentFieldKey = fieldKey;
   ctx.fieldName = fieldName;
-  ctx.error = errorMap && errorMap[ctx.path.join('.')];
+  ctx.error = getFieldError(ctx);
 };
 
 const isFragmentHeuristicallyMatching = (

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -41,12 +41,10 @@ export interface Context {
 
 export const contextRef: { current: Context | null } = { current: null };
 
-let errorMap: { [path: string]: GraphQLError } | undefined;
-
 // Checks whether the current data field is a cache miss because of a GraphQLError
 export const getFieldError = (ctx: Context): GraphQLError | undefined =>
-  ctx.__internal.path.length > 0 && !!errorMap
-    ? errorMap[ctx.__internal.path.join('.')]
+  ctx.__internal.path.length > 0 && ctx.__internal.errorMap
+    ? ctx.__internal.errorMap[ctx.__internal.path.join('.')]
     : undefined;
 
 export const makeContext = (

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -26,6 +26,7 @@ export interface Context {
   fieldName: string;
   partial: boolean;
   optimistic: boolean;
+  path: Array<string | number>;
 }
 
 export const contextRef: { current: Context | null } = { current: null };
@@ -48,6 +49,7 @@ export const makeContext = (
   fieldName: '',
   partial: false,
   optimistic: !!optimistic,
+  path: [],
 });
 
 export const updateContext = (

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -42,13 +42,22 @@ let errorMap: { [path: string]: GraphQLError } | undefined;
 
 export const initErrorMap = (error?: CombinedError | undefined) => {
   errorMap = undefined;
-  for (let i = 0; error && i < error.graphQLErrors.length; i++) {
+  for (
+    let i = 0;
+    error && error.graphQLErrors && i < error.graphQLErrors.length;
+    i++
+  ) {
     const graphQLError = error.graphQLErrors[i];
     if (graphQLError.path && graphQLError.path.length) {
       if (!errorMap) errorMap = Object.create(null);
       errorMap![graphQLError.path.join('.')] = graphQLError;
     }
   }
+};
+
+export const isFieldMissing = (ctx: Context): boolean => {
+  // Checks whether the current data field is a cache miss because of a GraphQLError
+  return ctx.path.length > 0 && !!errorMap && !!errorMap[ctx.path.join('.')];
 };
 
 export const makeContext = (

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -299,20 +299,20 @@ const writeSelection = (
     }
 
     if (isRoot) {
-      // We have to update the context to reflect up-to-date ResolveInfo
-      updateContext(
-        ctx,
-        data,
-        typename,
-        typename,
-        joinKeys(typename, fieldKey),
-        fieldName
-      );
-
       // We run side-effect updates after the default, normalized updates
       // so that the data is already available in-store if necessary
       const updater = ctx.store.updates[typename][fieldName];
       if (updater) {
+        // We have to update the context to reflect up-to-date ResolveInfo
+        updateContext(
+          ctx,
+          data,
+          typename,
+          typename,
+          joinKeys(typename, fieldKey),
+          fieldName
+        );
+
         data[fieldName] = fieldValue;
         updater(data, fieldArgs || {}, ctx.store, ctx);
       }

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -44,7 +44,7 @@ import {
   makeContext,
   updateContext,
   initErrorMap,
-  isFieldMissing,
+  getFieldError,
 } from './shared';
 
 export interface WriteResult {
@@ -290,7 +290,7 @@ const writeSelection = (
       InMemoryData.writeRecord(
         entityKey || typename,
         fieldKey,
-        (fieldValue !== null || !isFieldMissing(ctx)
+        (fieldValue !== null || !getFieldError(ctx)
           ? fieldValue
           : undefined) as EntityField
       );
@@ -349,7 +349,7 @@ const writeField = (
 
     return newData;
   } else if (data === null) {
-    return isFieldMissing(ctx) ? undefined : null;
+    return getFieldError(ctx) ? undefined : null;
   }
 
   const entityKey = ctx.store.keyOfEntity(data);

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -44,6 +44,7 @@ import {
   makeContext,
   updateContext,
   initErrorMap,
+  isFieldMissing,
 } from './shared';
 
 export interface WriteResult {
@@ -289,7 +290,9 @@ const writeSelection = (
       InMemoryData.writeRecord(
         entityKey || typename,
         fieldKey,
-        fieldValue as EntityField
+        (fieldValue !== null || !isFieldMissing(ctx)
+          ? fieldValue
+          : undefined) as EntityField
       );
     }
 
@@ -326,7 +329,7 @@ const writeField = (
   select: SelectionSet,
   data: null | Data | NullArray<Data>,
   parentFieldKey?: string
-): Link => {
+): Link | undefined => {
   if (Array.isArray(data)) {
     const newData = new Array(data.length);
     for (let i = 0, l = data.length; i < l; i++) {
@@ -346,7 +349,7 @@ const writeField = (
 
     return newData;
   } else if (data === null) {
-    return null;
+    return isFieldMissing(ctx) ? undefined : null;
   }
 
   const entityKey = ctx.store.keyOfEntity(data);

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -1,4 +1,5 @@
 import { FieldNode, DocumentNode, FragmentDefinitionNode } from 'graphql';
+import { CombinedError } from '@urql/core';
 
 import {
   getFragments,
@@ -35,12 +36,14 @@ import {
 } from '../store';
 
 import * as InMemoryData from '../store/data';
+
 import {
   Context,
   makeSelectionIterator,
   ensureData,
   makeContext,
   updateContext,
+  initErrorMap,
 } from './shared';
 
 export interface WriteResult {
@@ -53,8 +56,10 @@ export const write = (
   store: Store,
   request: OperationRequest,
   data: Data,
+  error?: CombinedError | undefined,
   key?: number
 ): WriteResult => {
+  initErrorMap(error);
   initDataState('write', store.data, key || null);
   const result = startWrite(store, request, data);
   clearDataState();
@@ -96,6 +101,7 @@ export const writeOptimistic = (
   request: OperationRequest,
   key: number
 ): WriteResult => {
+  initErrorMap();
   initDataState('write', store.data, key, true);
 
   const operation = getMainOperation(request.query);

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -1,5 +1,5 @@
 import { TypedDocumentNode } from '@urql/core';
-import { DocumentNode, FragmentDefinitionNode } from 'graphql';
+import { GraphQLError, DocumentNode, FragmentDefinitionNode } from 'graphql';
 
 // Helper types
 export type NullArray<T> = Array<null | T>;
@@ -65,6 +65,7 @@ export interface ResolveInfo {
   fieldName: string;
   fragments: Fragments;
   variables: Variables;
+  error: GraphQLError | undefined;
   partial?: boolean;
   optimistic?: boolean;
   // path: Array<string | number>; is not actively exposed as it leaks alias information and is hence not reliably stable

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -67,6 +67,7 @@ export interface ResolveInfo {
   variables: Variables;
   partial?: boolean;
   optimistic?: boolean;
+  // path: Array<string | number>; is not actively exposed as it leaks alias information and is hence not reliably stable
 }
 
 export interface QueryInput<T = Data, V = Variables> {

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -68,7 +68,7 @@ export interface ResolveInfo {
   error: GraphQLError | undefined;
   partial?: boolean;
   optimistic?: boolean;
-  // path: Array<string | number>; is not actively exposed as it leaks alias information and is hence not reliably stable
+  __internal?: unknown;
 }
 
 export interface QueryInput<T = Data, V = Variables> {


### PR DESCRIPTION
Resolve #1344

## Summary

This change attempts to improve Graphcache's error handling and error awareness. Instead of ignoring the added information that `GraphQLError#path` may provide for individual null'ed out fields, Graphcache now processes these errors and dynamically replaces `null` values (links and records) as it writes them with `undefined` — i.e. uncached / cache misses — when an associated `GraphQLError` has been received for a given field.

## Set of changes

- Add `Context.__internal.path` tracking the current data path via aliases and indices
- Add `Context.__internal.errorMap` tracking the current `CombinedError`'s `GraphQLError`s by their paths
- Add `Context.error` which shows an updater its current field's error if any exists
- Replace `fieldValue` in `write` with `undefined` rather than `null` if the current field has an associated error to it

Size change from `6.87kB gzip` to `7.07kB gzip` (an increase of `0.2kB gzip`)