### PR TITLE
(breaking) - Remove pollInterval option from urql

### DIFF
--- a/.changeset/gorgeous-squids-exercise.md
+++ b/.changeset/gorgeous-squids-exercise.md
@@ -2,4 +2,4 @@
 '@urql/core': major
 ---
 
-Remove `pollInterval` feature from `OperationContext`. Instead consider using a source that uses `Wonka.interval` and `Wonka.switchMap` over `client.query()`'s source.
+**Breaking**: Remove `pollInterval` feature from `OperationContext`. Instead consider using a source that uses `Wonka.interval` and `Wonka.switchMap` over `client.query()`'s source.

--- a/.changeset/gorgeous-squids-exercise.md
+++ b/.changeset/gorgeous-squids-exercise.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': major
+---
+
+Remove `pollInterval` feature from `OperationContext`. Instead consider using a source that uses `Wonka.interval` and `Wonka.switchMap` over `client.query()`'s source.

--- a/.changeset/great-rice-lick.md
+++ b/.changeset/great-rice-lick.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': minor
+---
+
+Remove `pollInterval` option from `useQuery`. Please consider adding an interval manually calling `executeQuery()`.

--- a/.changeset/great-rice-lick.md
+++ b/.changeset/great-rice-lick.md
@@ -2,4 +2,4 @@
 '@urql/vue': minor
 ---
 
-Remove `pollInterval` option from `useQuery`. Please consider adding an interval manually calling `executeQuery()`.
+**Breaking**: Remove `pollInterval` option from `useQuery`. Please consider adding an interval manually calling `executeQuery()`.

--- a/.changeset/twelve-camels-sit.md
+++ b/.changeset/twelve-camels-sit.md
@@ -1,0 +1,6 @@
+---
+'urql': major
+'@urql/preact': major
+---
+
+Remove `pollInterval` option from `useQuery`. Instead please consider using `useEffect` calling `executeQuery` on an interval.

--- a/.changeset/twelve-camels-sit.md
+++ b/.changeset/twelve-camels-sit.md
@@ -3,4 +3,4 @@
 '@urql/preact': major
 ---
 
-Remove `pollInterval` option from `useQuery`. Instead please consider using `useEffect` calling `executeQuery` on an interval.
+**Breaking**: Remove `pollInterval` option from `useQuery`. Instead please consider using `useEffect` calling `executeQuery` on an interval.

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -46,11 +46,6 @@ the query sources, the `Client` will dispatch a "teardown" operation.
   instead.](#clientquery)
 - [See `createRequest` for a utility that creates `GraphQLRequest` objects.](#createrequest)
 
-A feature that is specific to `client.executeQuery` and isn't supported by
-`client.executeSubscription` and `client.executeMutation` is polling. You may optionally pass a
-`pollInterval` option on the `OperationContext` object, which will instruct the query to reexecute
-repeatedly in the interval you pass.
-
 ### client.executeSubscription
 
 This is functionally the same as `client.executeQuery`, but creates operations for subscriptions
@@ -211,7 +206,6 @@ properties you'll likely see some options that exist on the `Client` as well.
 | `fetch`               | `typeof fetch`                        | An alternative implementation of `fetch` that will be used by the `fetchExchange` instead of `window.fetch`           |
 | `requestPolicy`       | `RequestPolicy`                       | An optional [request policy](/basics/querying-data#request-policy) that should be used specifying the cache strategy. |
 | `url`                 | `string`                              | The GraphQL endpoint                                                                                                  |
-| `pollInterval`        | `?number`                             | Every `pollInterval` milliseconds the query will be refetched.                                                        |
 | `meta`                | `?OperationDebugMeta`                 | Metadata that is only available in development for devtools.                                                          |
 | `suspense`            | `?boolean`                            | Whether suspense is enabled.                                                                                          |
 | `preferGetMethod`     | `?boolean`                            | Instructs the `fetchExchange` to use HTTP GET for queries.                                                            |

--- a/docs/api/urql.md
+++ b/docs/api/urql.md
@@ -15,7 +15,6 @@ Accepts a single required options object as an input with the following properti
 | `variables`     | `?object`                | The variables to be used with the GraphQL request.                                                       |
 | `requestPolicy` | `?RequestPolicy`         | An optional [request policy](./core.md#requestpolicy) that should be used specifying the cache strategy. |
 | `pause`         | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/queries.md#pausing-usequery).              |
-| `pollInterval`  | `?number`                | Every `pollInterval` milliseconds the query will be reexecuted.                                          |
 | `context`       | `?object`                | Holds the contextual information for the query.                                                          |
 
 This hook returns a tuple of the shape `[result, executeQuery]`.

--- a/docs/api/vue.md
+++ b/docs/api/vue.md
@@ -15,7 +15,6 @@ Accepts a single required options object as an input with the following properti
 | `variables`     | `?object`                | The variables to be used with the GraphQL request.                                                       |
 | `requestPolicy` | `?RequestPolicy`         | An optional [request policy](./core.md#requestpolicy) that should be used specifying the cache strategy. |
 | `pause`         | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/vue.md#pausing-usequery).                  |
-| `pollInterval`  | `?number`                | Every `pollInterval` milliseconds the query will be reexecuted.                                          |
 | `context`       | `?object`                | Holds the contextual information for the query.                                                          |
 
 Each of these inputs may also be [reactive](https://v3.vuejs.org/api/refs-api.html) (e.g. a `ref`)

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -220,24 +220,6 @@ describe('executeQuery', () => {
 
     expect(receivedOps[0]).toHaveProperty('context.url', url);
   });
-
-  it('polls when pollInterval is specified', () => {
-    jest.useFakeTimers();
-    const { unsubscribe } = pipe(
-      client.executeQuery(query, { pollInterval: 100 }),
-      subscribe(x => x)
-    );
-
-    expect(receivedOps.length).toEqual(1);
-    jest.advanceTimersByTime(200);
-    expect(receivedOps.length).toEqual(5);
-    expect(receivedOps[0].kind).toEqual('query');
-    expect(receivedOps[1].kind).toEqual('teardown');
-    expect(receivedOps[2].kind).toEqual('query');
-    expect(receivedOps[3].kind).toEqual('teardown');
-    expect(receivedOps[4].kind).toEqual('query');
-    unsubscribe();
-  });
 });
 
 describe('executeMutation', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -10,10 +10,6 @@ import {
   Source,
   take,
   takeUntil,
-  merge,
-  interval,
-  fromValue,
-  switchMap,
   publish,
   subscribe,
   map,
@@ -268,13 +264,6 @@ export class Client {
         this.onOperationEnd(operation);
       })
     );
-
-    if (operation.kind === 'query' && operation.context.pollInterval) {
-      return pipe(
-        merge([fromValue(0), interval(operation.context.pollInterval)]),
-        switchMap(() => result$)
-      );
-    }
 
     return result$;
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -47,7 +47,6 @@ export interface OperationContext {
   fetchOptions?: RequestInit | (() => RequestInit);
   requestPolicy: RequestPolicy;
   url: string;
-  pollInterval?: number;
   meta?: OperationDebugMeta;
   suspense?: boolean;
   preferGetMethod?: boolean;

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -32,7 +32,6 @@ export interface UseQueryArgs<Variables = object, Data = any> {
   query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
   variables?: Variables;
   requestPolicy?: RequestPolicy;
-  pollInterval?: number;
   context?: Partial<OperationContext>;
   pause?: boolean;
 }
@@ -112,7 +111,6 @@ export function useQuery<Data = any, Variables = object>(
       if (!source) {
         source = client.executeQuery(request, {
           requestPolicy: args.requestPolicy,
-          pollInterval: args.pollInterval,
           ...args.context,
           ...opts,
         });
@@ -128,7 +126,7 @@ export function useQuery<Data = any, Variables = object>(
 
       return source;
     },
-    [client, request, args.requestPolicy, args.pollInterval, args.context]
+    [client, request, args.requestPolicy, args.context]
   );
 
   const query$ = useMemo(() => {

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -21,7 +21,6 @@ export interface UseQueryArgs<Variables = object, Data = any> {
   query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
   variables?: Variables;
   requestPolicy?: RequestPolicy;
-  pollInterval?: number;
   context?: Partial<OperationContext>;
   pause?: boolean;
 }
@@ -56,7 +55,6 @@ export function useQuery<Data = any, Variables = object>(
 
     const source = client.executeQuery(request, {
       requestPolicy: args.requestPolicy,
-      pollInterval: args.pollInterval,
       ...args.context,
     });
 
@@ -68,15 +66,7 @@ export function useQuery<Data = any, Variables = object>(
           })
         )
       : source;
-  }, [
-    client,
-    request,
-    suspense,
-    args.pause,
-    args.requestPolicy,
-    args.pollInterval,
-    args.context,
-  ]);
+  }, [client, request, suspense, args.pause, args.requestPolicy, args.context]);
 
   const getSnapshot = useCallback(
     (
@@ -121,7 +111,6 @@ export function useQuery<Data = any, Variables = object>(
     client,
     request,
     args.requestPolicy,
-    args.pollInterval,
     args.context,
     args.pause,
   ] as const;
@@ -187,7 +176,6 @@ export function useQuery<Data = any, Variables = object>(
     (opts?: Partial<OperationContext>) => {
       const context = {
         requestPolicy: args.requestPolicy,
-        pollInterval: args.pollInterval,
         ...args.context,
         ...opts,
       };
@@ -203,14 +191,7 @@ export function useQuery<Data = any, Variables = object>(
         return state[1] !== nextResult ? [source, nextResult, state[2]] : state;
       });
     },
-    [
-      client,
-      request,
-      getSnapshot,
-      args.requestPolicy,
-      args.pollInterval,
-      args.context,
-    ]
+    [client, request, getSnapshot, args.requestPolicy, args.context]
   );
 
   return [currentResult, executeQuery];

--- a/packages/vue-urql/src/useQuery.test.ts
+++ b/packages/vue-urql/src/useQuery.test.ts
@@ -49,7 +49,6 @@ describe('useQuery', () => {
         context: undefined,
       },
       {
-        pollInterval: undefined,
         requestPolicy: undefined,
       }
     );
@@ -130,42 +129,5 @@ describe('useQuery', () => {
 
     expect(query.fetching).toBe(false);
     expect(query.data).toEqual({ test: true });
-  });
-
-  it('updates when polling', async () => {
-    const subject = makeSubject<any>();
-    const executeQuery = jest
-      .spyOn(client, 'executeQuery')
-      .mockImplementation(() => subject.source);
-
-    const _query = useQuery({
-      query: `{ test }`,
-      pollInterval: 500,
-      requestPolicy: 'cache-first',
-    });
-    const query = reactive(_query);
-
-    expect(executeQuery).toHaveBeenCalledWith(
-      {
-        key: expect.any(Number),
-        query: expect.any(Object),
-        variables: {},
-        context: undefined,
-      },
-      {
-        pollInterval: 500,
-        requestPolicy: 'cache-first',
-      }
-    );
-
-    expect(query.fetching).toBe(true);
-
-    subject.next({ data: { test: true } });
-
-    expect(query.fetching).toBe(false);
-    expect(query.data).toEqual({ test: true });
-
-    subject.next({ data: { test: false } });
-    expect(query.data).toEqual({ test: false });
   });
 });

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -38,7 +38,6 @@ export interface UseQueryArgs<T = any, V = object> {
   query: MaybeRef<TypedDocumentNode<T, V> | DocumentNode | string>;
   variables?: MaybeRef<V>;
   requestPolicy?: MaybeRef<RequestPolicy>;
-  pollInterval?: MaybeRef<number>;
   context?: MaybeRef<Partial<OperationContext>>;
   pause?: MaybeRef<boolean>;
 }
@@ -132,7 +131,6 @@ export function useQuery<T = any, V = object>(
       next.value(
         client.executeQuery<T, V>(request.value, {
           requestPolicy: args.requestPolicy,
-          pollInterval: args.pollInterval,
           ...args.context,
           ...opts,
         })
@@ -199,7 +197,6 @@ export function useQuery<T = any, V = object>(
       !isPaused.value
         ? client.executeQuery<T, V>(request.value, {
             requestPolicy: args.requestPolicy,
-            pollInterval: args.pollInterval,
             ...args.context,
           })
         : undefined


### PR DESCRIPTION
Resolves #531

## Summary

This PR removes the `pollInterval` option from `@urql/core` and all bindings. Generally it isn't hard to replace `pollInterval` in user-land with even more correct behaviour, as it can ultimately read the results of the bindings and react to those accordingly.

### React / Preact replacement

This just demonstrates that it's rather simple to replace the implementation in React-land.

```js
const [result, executeQuery] = useQuery(...);

useEffect(() => {
  if (!result.fetching) {
    const id = setTimeout(() => executeQuery({ requestPolicy: 'network-only' }), 5000);
    return () => clearTimeout(id);
  }
}, [result.fetching, executeQuery]);
```

**NOTE re #531**: It's worth noting that this PR doesn't resolve the issue explicitly, however we see it as much easier to implement effects in user-land that call `executeQuery` to refresh the results on an interval.

## Set of changes

- Remove `pollInterval` from `@urql/core`
- Remove `pollInterval` from `useQuery` in `urql`
- Remove `pollInterval` from `useQuery` in `@urql/preact`
- Remove `pollInterval` from `useQuery` in `@urql/vue`
