### PR TITLE
(core) - Reemit results as stale if they're refetched in the background

### DIFF
--- a/.changeset/strong-emus-confess.md
+++ b/.changeset/strong-emus-confess.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Reemit an `OperationResult` as `stale: true` if it's being reexecuted as `network-only` operation to give bindings immediate feedback on background refetches.

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2,9 +2,19 @@ import { print } from 'graphql';
 
 /** NOTE: Testing in this file is designed to test both the client and its interaction with default Exchanges */
 
-import { Source, map, pipe, subscribe, filter, toArray, tap } from 'wonka';
+import {
+  Source,
+  delay,
+  map,
+  pipe,
+  subscribe,
+  filter,
+  toArray,
+  tap,
+} from 'wonka';
 import { gql } from './gql';
 import { Exchange, Operation, OperationResult } from './types';
+import { makeOperation } from './utils';
 import { createClient } from './client';
 import { queryOperation } from './test-utils';
 
@@ -379,5 +389,80 @@ describe('queuing behavior', () => {
 
     expect(output[1]).toBe(results[0]);
     expect(output[3]).toBe(results[1]);
+  });
+
+  it('reemits previous results as stale if the operation is reexecuted as network-only', async () => {
+    jest.useFakeTimers();
+
+    const output: OperationResult[] = [];
+
+    const exchange: Exchange = () => {
+      let countRes = 0;
+      return ops$ => {
+        return pipe(
+          ops$,
+          filter(op => op.kind !== 'teardown'),
+          map(op => ({
+            data: ++countRes,
+            operation: op,
+          })),
+          delay(1)
+        );
+      };
+    };
+
+    const client = createClient({
+      url: 'test',
+      exchanges: [exchange],
+    });
+
+    const { unsubscribe } = pipe(
+      client.executeRequestOperation(queryOperation),
+      subscribe(result => {
+        output.push(result);
+      })
+    );
+
+    jest.advanceTimersByTime(1);
+
+    expect(output.length).toBe(1);
+    expect(output[0]).toHaveProperty('data', 1);
+    expect(output[0]).toHaveProperty('operation.key', queryOperation.key);
+    expect(output[0]).toHaveProperty(
+      'operation.context.requestPolicy',
+      'cache-first'
+    );
+
+    client.reexecuteOperation(
+      makeOperation(queryOperation.kind, queryOperation, {
+        ...queryOperation.context,
+        requestPolicy: 'network-only',
+      })
+    );
+
+    await Promise.resolve();
+
+    expect(output.length).toBe(2);
+    expect(output[1]).toHaveProperty('data', 1);
+    expect(output[1]).toHaveProperty('stale', true);
+    expect(output[1]).toHaveProperty('operation.key', queryOperation.key);
+    expect(output[1]).toHaveProperty(
+      'operation.context.requestPolicy',
+      'cache-first'
+    );
+
+    jest.advanceTimersByTime(1);
+
+    expect(output.length).toBe(3);
+    expect(output[2]).toHaveProperty('data', 2);
+    expect(output[2]).toHaveProperty('stale', undefined);
+    expect(output[2]).toHaveProperty('operation.key', queryOperation.key);
+    expect(output[2]).toHaveProperty(
+      'operation.context.requestPolicy',
+      'network-only'
+    );
+
+    unsubscribe();
+    jest.useRealTimers();
   });
 });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -264,7 +264,7 @@ export class Client {
         (op: Operation) =>
           op.kind === operation.kind &&
           op.key === operation.key &&
-          op.context.requestPolicy === 'network-only'
+          op.context.requestPolicy !== 'cache-only'
       )
     );
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -271,15 +271,18 @@ export class Client {
     const result$ = pipe(
       operationResults$,
       takeUntil(teardown$),
-      switchMap(result =>
-        merge([
+      switchMap(result => {
+        if (result.stale) return fromValue(result);
+
+        return merge([
           fromValue(result),
           pipe(
             refetch$,
+            take(1),
             map(() => ({ ...result, stale: true }))
           ),
-        ])
-      ),
+        ]);
+      }),
       onStart<OperationResult>(() => {
         this.onOperationStart(operation);
       }),


### PR DESCRIPTION
Resolve #1372 

## Summary

Usually we have a couple of refetches that are emitted as `cache-and-network`. In these cases the cache exchanges (default or Graphcache) take care of emitting a first result with the `stale` flag set. In other cases we may have a subsequent `network-only` reexecution which happens in the background. In these cases no part of the exchange pipeline or the `Client` took responsibility of emitting a `stale` result.

This PR changes this behaviour to allows the `Client`'s `executeRequestOperation` stream to add-on a single `stale` result onto a prior result if it detects a `network-only` operation.

- Has been tested in `threed-web` against Graphcache's `cache.invalidate` which triggers a `network-only` refetch.
- This has also been fixed in 5c1b1fd to be applied to all operations that are not `cache-only`

## Set of changes

- Add a `switchMap` add-on stream per result that reemits the result as `stale` if it detects a `network-only` operation.
  - Only emit this `stale` add-on result when the previous result wasn't already `stale`
  - Ensure that this won't emit when the cache responds synchronously
  - Apply this to `cache-and-network` and `cache-first` (with cache misses) too
  - Emit this at most once since we expect a result afterwards