### PR TITLE
(request-policy) - Fix conditions and time of upgrading operations

### DIFF
--- a/.changeset/small-apricots-exercise.md
+++ b/.changeset/small-apricots-exercise.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-request-policy': patch
+---
+
+Fix non-query operations being upgraded by `requestPolicyExchange` and time being stored by last issuance rather than last result.

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -1,4 +1,9 @@
-import { makeOperation, Operation, OperationResult, Exchange } from '@urql/core';
+import {
+  makeOperation,
+  Operation,
+  OperationResult,
+  Exchange,
+} from '@urql/core';
 import { pipe, tap, map } from 'wonka';
 
 const defaultTTL = 5 * 60 * 1000;
@@ -17,7 +22,8 @@ export const requestPolicyExchange = (options: Options): Exchange => ({
   const processIncomingOperation = (operation: Operation): Operation => {
     if (
       operation.kind !== 'query' ||
-      (operation.context.requestPolicy !== 'cache-first' && operation.context.requestPolicy !== 'cache-only') ||
+      (operation.context.requestPolicy !== 'cache-first' &&
+        operation.context.requestPolicy !== 'cache-only') ||
       !operations.has(operation.key)
     ) {
       return operation;

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -1,5 +1,5 @@
-import { makeOperation, Operation, Exchange } from '@urql/core';
-import { pipe, map } from 'wonka';
+import { makeOperation, Operation, OperationResult, Exchange } from '@urql/core';
+import { pipe, tap, map } from 'wonka';
 
 const defaultTTL = 5 * 60 * 1000;
 
@@ -12,27 +12,24 @@ export const requestPolicyExchange = (options: Options): Exchange => ({
   forward,
 }) => {
   const operations = new Map();
-
   const TTL = (options || {}).ttl || defaultTTL;
 
   const processIncomingOperation = (operation: Operation): Operation => {
     if (
-      operation.context.requestPolicy !== 'cache-first' &&
-      operation.context.requestPolicy !== 'cache-only'
-    )
-      return operation;
-    if (!operations.has(operation.key)) {
-      operations.set(operation.key, new Date());
+      operation.kind !== 'query' ||
+      (operation.context.requestPolicy !== 'cache-first' && operation.context.requestPolicy !== 'cache-only') ||
+      !operations.has(operation.key)
+    ) {
       return operation;
     }
 
     const lastOccurrence = operations.get(operation.key);
     const currentTime = new Date().getTime();
     if (
-      currentTime - lastOccurrence.getTime() > TTL &&
+      currentTime - lastOccurrence > TTL &&
       (options.shouldUpgrade ? options.shouldUpgrade(operation) : true)
     ) {
-      operations.set(operation.key, new Date());
+      operations.delete(operation.key);
       return makeOperation(operation.kind, operation, {
         ...operation.context,
         requestPolicy: 'cache-and-network',
@@ -42,7 +39,14 @@ export const requestPolicyExchange = (options: Options): Exchange => ({
     return operation;
   };
 
+  const processIncomingResults = (result: OperationResult): void => {
+    operations.set(result.operation.key, new Date().getTime());
+  };
+
   return ops$ => {
-    return forward(pipe(ops$, map(processIncomingOperation)));
+    return pipe(
+      forward(pipe(ops$, map(processIncomingOperation))),
+      tap(processIncomingResults)
+    );
   };
 };


### PR DESCRIPTION
Fix #1334

## Summary

Fix the exchange upgrading non-query operations and setting a last-occurence time by operations rather than results.
