### PR TITLE
(graphcache) - Allow partial schema to be passed for altered root names

### DIFF
--- a/.changeset/blue-bees-join.md
+++ b/.changeset/blue-bees-join.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Allow `schema` option to be passed with a partial introspection result that only contains `queryType`, `mutationType`, and `subscriptionType` with their respective names. This allows you to pass `{ __schema: { queryType: { name: 'Query' } } }` and the likes to Graphcache's `cacheExchange` to alter the default root names without enabling full schema awareness.

--- a/exchanges/graphcache/src/ast/schema.ts
+++ b/exchanges/graphcache/src/ast/schema.ts
@@ -34,9 +34,10 @@ export interface SchemaIntrospector {
 }
 
 export interface PartialIntrospectionSchema {
-  queryType: { name: string; };
-  mutationType?: { name: string; };
-  subscriptionType?: { name: string; };
+  queryType: { name: string; kind?: any };
+  mutationType?: { name: string; kind?: any };
+  subscriptionType?: { name: string; kind?: any };
+  types?: IntrospectionSchema['types'];
 }
 
 export type IntrospectionData =
@@ -83,7 +84,7 @@ export const buildClientSchema = ({
     }
   };
 
-  const schema: SchemaIntrospector= {
+  const schema: SchemaIntrospector = {
     query: __schema.queryType ? __schema.queryType.name : null,
     mutation: __schema.mutationType ? __schema.mutationType.name : null,
     subscription: __schema.subscriptionType

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -53,8 +53,8 @@ export const isInterfaceOfType = (
   const typeCondition = getTypeCondition(node);
   if (!typeCondition || typename === typeCondition) return true;
   if (
-    schema.types[typeCondition] &&
-    schema.types[typeCondition].kind === 'OBJECT'
+    schema.types![typeCondition] &&
+    schema.types![typeCondition].kind === 'OBJECT'
   )
     return typeCondition === typename;
   expectAbstractType(schema, typeCondition!);
@@ -68,7 +68,7 @@ const getField = (
   fieldName: string
 ) => {
   expectObjectType(schema, typename);
-  const object = schema.types[typename] as SchemaObject;
+  const object = schema.types![typename] as SchemaObject;
   const field = object.fields[fieldName];
   if (!field) {
     warn(
@@ -88,7 +88,7 @@ const getField = (
 
 function expectObjectType(schema: SchemaIntrospector, typename: string) {
   invariant(
-    schema.types[typename] && schema.types[typename].kind === 'OBJECT',
+    schema.types![typename] && schema.types![typename].kind === 'OBJECT',
     'Invalid Object type: The type `' +
       typename +
       '` is not an object in the defined schema, ' +
@@ -99,9 +99,9 @@ function expectObjectType(schema: SchemaIntrospector, typename: string) {
 
 function expectAbstractType(schema: SchemaIntrospector, typename: string) {
   invariant(
-    schema.types[typename] &&
-      (schema.types[typename].kind === 'INTERFACE' ||
-        schema.types[typename].kind === 'UNION'),
+    schema.types![typename] &&
+      (schema.types![typename].kind === 'INTERFACE' ||
+        schema.types![typename].kind === 'UNION'),
     'Invalid Abstract type: The type `' +
       typename +
       '` is not an Interface or Union type in the defined schema, ' +
@@ -116,7 +116,7 @@ export function expectValidKeyingConfig(
 ): void {
   if (process.env.NODE_ENV !== 'production') {
     for (const key in keys) {
-      if (!schema.types[key]) {
+      if (!schema.types![key]) {
         warn(
           'Invalid Object type: The type `' +
             key +
@@ -137,7 +137,7 @@ export function expectValidUpdatesConfig(
   }
 
   if (schema.mutation) {
-    const mutationFields = (schema.types[schema.mutation] as SchemaObject)
+    const mutationFields = (schema.types![schema.mutation] as SchemaObject)
       .fields;
     const givenMutations = updates[schema.mutation] || {};
     for (const fieldName in givenMutations) {
@@ -153,7 +153,7 @@ export function expectValidUpdatesConfig(
   }
 
   if (schema.subscription) {
-    const subscriptionFields = (schema.types[
+    const subscriptionFields = (schema.types![
       schema.subscription
     ] as SchemaObject).fields;
     const givenSubscription = updates[schema.subscription] || {};
@@ -200,7 +200,7 @@ export function expectValidResolversConfig(
   for (const key in resolvers) {
     if (key === 'Query') {
       if (schema.query) {
-        const validQueries = (schema.types[schema.query] as SchemaObject)
+        const validQueries = (schema.types![schema.query] as SchemaObject)
           .fields;
         for (const resolverQuery in resolvers.Query) {
           if (!validQueries[resolverQuery]) {
@@ -211,18 +211,18 @@ export function expectValidResolversConfig(
         warnAboutResolver('Query');
       }
     } else {
-      if (!schema.types[key]) {
+      if (!schema.types![key]) {
         warnAboutResolver(key);
       } else if (
-        schema.types[key].kind === 'INTERFACE' ||
-        schema.types[key].kind === 'UNION'
+        schema.types![key].kind === 'INTERFACE' ||
+        schema.types![key].kind === 'UNION'
       ) {
         warnAboutAbstractResolver(
           key,
-          schema.types[key].kind as 'INTERFACE' | 'UNION'
+          schema.types![key].kind as 'INTERFACE' | 'UNION'
         );
       } else {
-        const validTypeProperties = (schema.types[key] as SchemaObject).fields;
+        const validTypeProperties = (schema.types![key] as SchemaObject).fields;
         for (const resolverProperty in resolvers[key]) {
           if (!validTypeProperties[resolverProperty]) {
             warnAboutResolver(key + '.' + resolverProperty);
@@ -242,7 +242,7 @@ export function expectValidOptimisticMutationsConfig(
   }
 
   if (schema.mutation) {
-    const validMutations = (schema.types[schema.mutation] as SchemaObject)
+    const validMutations = (schema.types![schema.mutation] as SchemaObject)
       .fields;
     for (const mutation in optimisticMutations) {
       if (!validMutations[mutation]) {

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -1,5 +1,3 @@
-import { IntrospectionQuery } from 'graphql';
-
 import {
   Exchange,
   formatDocument,
@@ -30,7 +28,7 @@ import {
 import { query, write, writeOptimistic } from './operations';
 import { makeDict, isDictEmpty } from './helpers/dict';
 import { addCacheOutcome, toRequestPolicy } from './helpers/operation';
-import { filterVariables, getMainOperation } from './ast';
+import { IntrospectionData, filterVariables, getMainOperation } from './ast';
 import { Store, noopDataState, hydrateData, reserveLayer } from './store';
 
 import {
@@ -57,7 +55,7 @@ export interface CacheExchangeOpts {
   resolvers?: ResolverConfig;
   optimistic?: OptimisticMutationConfig;
   keys?: KeyingConfig;
-  schema?: IntrospectionQuery;
+  schema?: IntrospectionData;
   storage?: StorageAdapter;
 }
 

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -20,12 +20,13 @@ import {
   getName,
 } from './ast';
 
-import { makeDict } from './helpers/dict';
 import {
   SerializedRequest,
   OptimisticMutationConfig,
   Variables,
 } from './types';
+
+import { makeDict } from './helpers/dict';
 import { cacheExchange, CacheExchangeOpts } from './cacheExchange';
 import { toRequestPolicy } from './helpers/operation';
 

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -892,7 +892,7 @@ describe('Store with storage', () => {
           subscriptionType: {
             name: 'subscription_root',
           },
-        }
+        },
       },
       updates: {
         Mutation: {

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -881,9 +881,19 @@ describe('Store with storage', () => {
     const fakeUpdater = jest.fn();
 
     const store = new Store({
-      schema: minifyIntrospectionQuery(
-        require('../test-utils/altered_root_schema.json')
-      ),
+      schema: {
+        __schema: {
+          queryType: {
+            name: 'query_root',
+          },
+          mutationType: {
+            name: 'mutation_root',
+          },
+          subscriptionType: {
+            name: 'subscription_root',
+          },
+        }
+      },
       updates: {
         Mutation: {
           toggleTodo: fakeUpdater,

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -1,5 +1,4 @@
-import { DocumentNode, IntrospectionQuery } from 'graphql';
-
+import { DocumentNode } from 'graphql';
 import { TypedDocumentNode, formatDocument, createRequest } from '@urql/core';
 
 import {
@@ -25,6 +24,7 @@ import { keyOfField } from './keys';
 import * as InMemoryData from './data';
 
 import {
+  IntrospectionData,
   SchemaIntrospector,
   buildClientSchema,
   expectValidKeyingConfig,
@@ -40,7 +40,7 @@ export interface StoreOpts {
   resolvers?: ResolverConfig;
   optimistic?: OptimisticMutationConfig;
   keys?: KeyingConfig;
-  schema?: IntrospectionQuery;
+  schema?: IntrospectionData;
 }
 
 export class Store implements Cache {
@@ -66,10 +66,12 @@ export class Store implements Cache {
     let mutationName = 'Mutation';
     let subscriptionName = 'Subscription';
     if (opts.schema) {
-      const schema = (this.schema = buildClientSchema(opts.schema));
+      const schema = buildClientSchema(opts.schema);
       queryName = schema.query || queryName;
       mutationName = schema.mutation || mutationName;
       subscriptionName = schema.subscription || subscriptionName;
+      // Only add schema introspector if it has types info
+      if (schema.types) this.schema = schema;
     }
 
     this.updates = {


### PR DESCRIPTION
Resolve #1378

## Summary

I had some of these changes done in a forgotten branch but never proposed / opened this since we didn't have a corresponding RFC just yet, and I didn't have time to write it up.

Basically, we should allow the root names to be altered without enabling full schema awareness for exceptional cases where schema awareness is explicitly not wanted. This is rather rare with the advent of GraphQL Code Generator's built-in plugin to resolve this at build time / deploy time but it may be helpful still.

It's now possible to pass only the root names like so:

```js
const introspection = {
  __schema: {
    queryType: {
      name: 'query_root',
    },
    mutationType: {
      name: 'mutation_root',
    },
    subscriptionType: {
      name: 'subscription_root',
    },
  },
};

cacheExchange({ schema: introspection });
```

## Set of changes

- Make `SchemaIntrospector.types` optional and don't add it for partial schema introspection results
- Prevent `this.schema` from being set on `Store` when `SchemaIntrospector.types` is missing
- Update types in `schemaPredicates.ts` and fix up a test for this use-case
- Allow a partial introspection result to be passed to `schema`