### PR TITLE
(react) - shield for cross-component updates

### DIFF
--- a/.changeset/silly-walls-cover.md
+++ b/.changeset/silly-walls-cover.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Fix case where identical `useQuery` calls would result in cross-component updates.


### PR DESCRIPTION
## Summary

Fixes https://github.com/FormidableLabs/urql/issues/1382

## Set of changes

- Shields for `useQuery` updating during the update of another component.
