### PR TITLE
(docs) - Overhaul "Local Resolvers" & "Cache Updates" Graphcache docs pages

### DIFF
--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -343,8 +343,8 @@ cache.readFragment(
 );
 ```
 
-[Read more about using `readFragment` on the ["Computed Queries"
-page.](../graphcache/computed-queries.md#reading-a-fragment)
+[Read more about using `readFragment` on the ["Local Resolvers"
+page.](../graphcache/local-resolvers.md#reading-a-fragment)
 
 ### readQuery
 
@@ -368,8 +368,8 @@ cache.readQuery({
 ); // Data or null
 ```
 
-[Read more about using `readQuery` on the ["Computed Queries"
-page.](../graphcache/computed-queries.md#reading-a-query)
+[Read more about using `readQuery` on the ["Local Resolvers"
+page.](../graphcache/local-resolvers.md#reading-a-query)
 
 ### writeFragment
 

--- a/docs/graphcache/README.md
+++ b/docs/graphcache/README.md
@@ -28,7 +28,7 @@ default.
   a normalized data structure. Query, mutation, and subscription results may update one another if
   they share data, and the app will rerender or refetch data accordingly. This often allows your app
   to make fewer API requests, since data may already be in the cache.
-- 💾 [**Custom cache resolvers**](./computed-queries.md) Since all queries are fully resolved in the
+- 💾 [**Custom cache resolvers**](./local-resolvers.md) Since all queries are fully resolved in the
   cache before and after they're sent, you can add custom resolvers that enable you to format data,
   implement pagination, or implement cache redirects.
 - 💭 [**Subscription and Mutation updates**](./custom-updates.md) You can implement update functions

--- a/docs/graphcache/cache-updates.md
+++ b/docs/graphcache/cache-updates.md
@@ -17,7 +17,7 @@ configuration to set up manual updates that react to mutations or subscriptions.
 ## Data Updates
 
 The `updates` configuration is similar to our `resolvers` configuration that we've [previously looked
-at on the "Computed Queries" page.](./computed-queries.md) We pass a resolver-like function into the
+at on the "Local Resolvers" page.](./local-resolvers.md) We pass a resolver-like function into the
 configuration that receives cache-specific arguments. Instead of the `parent` argument we'll however
 receive the subscription's or mutation's `data` instead.
 
@@ -38,8 +38,8 @@ const cache = cacheExchange({
 });
 ```
 
-Inside these update functions, apart from the `cache` methods that we've seen in ["Computed
-Query"](./computed-queries.md) to read from the cached data, we can also use other `cache` methods to
+Inside these update functions, apart from the `cache` methods that we've seen on the ["Local
+Resolvers" page](./local-resolvers.md) to read from the cached data, we can also use other `cache` methods to
 write to the cached data.
 
 ### cache.updateQuery
@@ -284,7 +284,7 @@ reverted if the GraphQL mutation fails.
 The `optimistic` functions receive the same arguments as `resolvers` functions, except for `parent`:
 
 - `variables` – The variables used to execute the mutation.
-- `cache` – The cache we've already seen in [resolvers](./computed-queries.md) and in the previous
+- `cache` – The cache we've already seen in [resolvers](./local-resolvers.md) and in the previous
   examples on this page. In optimistic updates it's useful to retrieve more data from the cache.
 - `info` – Contains the used fragments and field arguments.
 

--- a/docs/graphcache/local-resolvers.md
+++ b/docs/graphcache/local-resolvers.md
@@ -5,7 +5,7 @@ order: 2
 
 # Local Resolvers
 
-Previously we've learned about local resolvers [on the "Normalized Caching"
+Previously, we've learned about local resolvers [on the "Normalized Caching"
 page](./normalized-caching.md#manually-resolving-entities). They allow us to change the data that
 Graphcache reads as it queries against its local cache, return links that would otherwise not be
 cached, or even transform scalar records on the fly.

--- a/docs/graphcache/local-resolvers.md
+++ b/docs/graphcache/local-resolvers.md
@@ -1,9 +1,9 @@
 ---
-title: Computed Queries
+title: Local Resolvers
 order: 2
 ---
 
-# Computed Queries
+# Local Resolvers
 
 When dealing with data we could have special cases where we want to transform
 the data between the API and frontend logic. For example:

--- a/docs/graphcache/local-resolvers.md
+++ b/docs/graphcache/local-resolvers.md
@@ -65,6 +65,56 @@ record field into a link, i.e. replace a scalar with an entity. Instead, local r
 to transform records, like dates in our previous example, or to imitate server-side logic to allow
 Graphcache to retrieve more data from its cache without sending a query to our API.
 
+## Transforming Records
+
+As we've explored in the ["Normalized Caching" page's section on
+records](./normalized-caching.md#storing-normalized-data), "records" are scalars and any fields in
+your query without selection sets. This could be a field with a string value, number, or any other
+field that resolves to a [scalar type](https://graphql.org/learn/schema/#scalar-types) rather than
+another entity i.e. object type.
+
+At the beginning of this page we've already seen an example of a local resolver that we've attached
+to a record field where we've added a resolver to a `Todo.updatedAt` field:
+
+```js
+cacheExchange({
+  resolvers: {
+    Todo: {
+      updatedAt: parent => new Date(parent.updatedAt),
+    },
+  },
+});
+```
+
+A query that contains this field may look like `{ todo { updatedAt } }`, which clearly shows us that
+this field is a scalar since it doesn't have any selection set on the `updatedAt` field. In our
+example, we access this field's value and parse it as a `new Date()`.
+
+This shows us that it doesn't matter for scalar fields what kind of value we return. We may parse
+strings into more granular JS-native objects or replace values entirely.
+
+Furthermore, if we have a field that accepts arguments we can use those as well:
+
+```js
+cacheExchange({
+  resolvers: {
+    Todo: {
+      text: (parent, args) => {
+        return args.capitalize && parent.text
+          ? parent.text.toUpperCase()
+          : parent.text;
+      },
+    },
+  },
+});
+```
+
+This is actually unlikely to be of use with records and scalar values as our API will have to be
+able to use these arguments just as well. In other words, while you may be able to pass any
+arguments to a field in your query, your GraphQL API's schema must accept these arguments in the
+first place. However, this is still useful if we're trying to imitate what the API is doing, which
+will become more relevant in the following examples and sections.
+
 ## Cache parameter
 
 This is the main point of communication with the cache, it will give us access to

--- a/docs/graphcache/local-resolvers.md
+++ b/docs/graphcache/local-resolvers.md
@@ -533,4 +533,4 @@ cannot be stiched together.
 
 ### Reading on
 
-[On the next page we'll learn about "Custom updates".](./custom-updates.md)
+[On the next page we'll learn about "Cache Updates".](./cache-updates.md)

--- a/docs/graphcache/normalized-caching.md
+++ b/docs/graphcache/normalized-caching.md
@@ -445,4 +445,4 @@ As we can see, we may perform manual changes inside of `updates` functions, whic
 affect other parts of the cache (like `Query.todos` here) beyond the automatic updates that a
 normalized cache is expected to perform.
 
-[Read more about creating custom updates on the "Custom Updates" page.](./custom-updates.md)
+[Read more about writing cache updates on the "Cache Updates" page.](./cache-updates.md)

--- a/docs/graphcache/normalized-caching.md
+++ b/docs/graphcache/normalized-caching.md
@@ -372,7 +372,7 @@ resolvers may be used for:
   relational cached data of _Graphcache_, which means that it can emulate infinite pagination and
   other complex behaviour.
 
-[Read more about local resolvers ont the following page, "Custom Queries".](./custom-queries.md)
+[Read more about resolvers on the following page about "Local Resolvers".](./local-resolvers.md)
 
 ### Manual cache updates
 

--- a/packages/site/static.config.js
+++ b/packages/site/static.config.js
@@ -78,5 +78,10 @@ export default {
       path: '/docs/graphcache/custom-updates',
       redirect: '/docs/graphcache/cache-updates',
     },
+    {
+      path: '/docs/graphcache/computed-queries',
+      redirect: '/docs/graphcache/local-resolvers',
+    },
+
   ],
 };

--- a/packages/site/static.config.js
+++ b/packages/site/static.config.js
@@ -82,6 +82,5 @@ export default {
       path: '/docs/graphcache/computed-queries',
       redirect: '/docs/graphcache/local-resolvers',
     },
-
   ],
 };


### PR DESCRIPTION
Resolve #1362

This is a compelte overhaul and basically a rewrite of the "Local Resolvers" (prev. known as "Computed Queries") and "Cache Updates" pages. The goal is to categorise all APIs and supported use-cases by actual examples rather than by API surfaces, since the latter is covered by the API docs.

**Preview Link:** https://formidable-com-urql-staging-1412.surge.sh