### PR TITLE
(refocus) - only use the refocus-exchange in a browser env

### DIFF
--- a/.changeset/afraid-lamps-provide.md
+++ b/.changeset/afraid-lamps-provide.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-refocus': patch
+---
+
+Prevent the refocus Exchange from being used on a Node env

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -3,6 +3,10 @@ import { Exchange, Operation } from '@urql/core';
 
 export const refocusExchange = (): Exchange => {
   return ({ client, forward }) => ops$ => {
+    if (typeof window === 'undefined') {
+      return forward(ops$)
+    }
+
     const watchedOperations = new Map<number, Operation>();
     const observedOperations = new Map<number, number>();
 

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -4,7 +4,7 @@ import { Exchange, Operation } from '@urql/core';
 export const refocusExchange = (): Exchange => {
   return ({ client, forward }) => ops$ => {
     if (typeof window === 'undefined') {
-      return forward(ops$)
+      return forward(ops$);
     }
 
     const watchedOperations = new Map<number, Operation>();


### PR DESCRIPTION
Fixes: https://github.com/FormidableLabs/urql/issues/1416

## Summary

In a node environment do nothing in the refocus-exchange.

## Set of changes

- In a node environment do nothing in the refocus-exchange.
