### PR TITLE
(react/preact) - add displayName to the context provider

### DIFF
--- a/.changeset/kind-cooks-invite.md
+++ b/.changeset/kind-cooks-invite.md
@@ -1,0 +1,6 @@
+---
+'@urql/preact': patch
+'urql': patch
+---
+
+Add a displayName to the Provider

--- a/packages/preact-urql/src/context.ts
+++ b/packages/preact-urql/src/context.ts
@@ -9,6 +9,7 @@ const defaultClient = createClient({ url: '/graphql' });
 export const Context = createContext<Client>(defaultClient);
 export const Provider = Context.Provider;
 export const Consumer = Context.Consumer;
+Provider.displayName = 'UrqlProvider';
 
 let hasWarnedAboutDefault = false;
 

--- a/packages/preact-urql/src/context.ts
+++ b/packages/preact-urql/src/context.ts
@@ -9,7 +9,7 @@ const defaultClient = createClient({ url: '/graphql' });
 export const Context = createContext<Client>(defaultClient);
 export const Provider = Context.Provider;
 export const Consumer = Context.Consumer;
-Provider.displayName = 'UrqlProvider';
+Context.displayName = 'UrqlContext';
 
 let hasWarnedAboutDefault = false;
 

--- a/packages/react-urql/src/context.ts
+++ b/packages/react-urql/src/context.ts
@@ -8,6 +8,7 @@ const defaultClient = createClient({ url: '/graphql' });
 export const Context = createContext<Client>(defaultClient);
 export const Provider = Context.Provider;
 export const Consumer = Context.Consumer;
+Provider.displayName = 'UrqlProvider';
 
 let hasWarnedAboutDefault = false;
 

--- a/packages/react-urql/src/context.ts
+++ b/packages/react-urql/src/context.ts
@@ -8,7 +8,7 @@ const defaultClient = createClient({ url: '/graphql' });
 export const Context = createContext<Client>(defaultClient);
 export const Provider = Context.Provider;
 export const Consumer = Context.Consumer;
-Provider.displayName = 'UrqlProvider';
+Context.displayName = 'UrqlContext';
 
 let hasWarnedAboutDefault = false;
 


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/urql/issues/1398

## Summary

Adds a displayName for the DevTools

## Set of changes

- add displayName property
