### PR TITLE
(docs) - Fix description of pause for useSubscription docs

### DIFF
--- a/docs/api/urql.md
+++ b/docs/api/urql.md
@@ -50,8 +50,7 @@ Accepts a single required options object as an input with the following properti
 | ---------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------- |
 | `query`                                              | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode. |
 | `variables`                                          | `?object`                | The variables to be used with the GraphQL request.                                 |
-| `pause`                                              | `?boolean`               | A boolean flag instructing [execution to be                                        |
-| paused](../basics/react-preact.md#pausing-usequery). |
+| `pause`                                              | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/react-preact.md#pausing-usequery). |
 | `context`                                            | `?object`                | Holds the contextual information for the query.                                    |
 
 The hook optionally accepts a second argument, which may be a handler function with a type signature


### PR DESCRIPTION

## Summary

A typo in the markdown broke the table
![afbeelding](https://user-images.githubusercontent.com/327697/110499195-4acb1500-80f8-11eb-9581-50323e1545d7.png)


## Set of changes

Fixed the typo :) 
