### PR TITLE
(svelte) - make the mutation request argument less strict

### DIFF
--- a/.changeset/fast-glasses-grin.md
+++ b/.changeset/fast-glasses-grin.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': patch
+---
+
+Make the Svelte `mutation` request input type of less strict

--- a/.changeset/fast-glasses-grin.md
+++ b/.changeset/fast-glasses-grin.md
@@ -2,4 +2,4 @@
 '@urql/svelte': patch
 ---
 
-Make the Svelte `mutation` request input type of less strict
+Allow `mutation` to accept a more partial `GraphQLRequest` object without a `key` or `variables`

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -6,6 +6,7 @@ import {
   OperationContext,
   OperationResult,
   GraphQLRequest,
+  TypedDocumentNode,
 } from '@urql/core';
 
 import {
@@ -23,6 +24,7 @@ import {
 import { OperationStore, operationStore } from './operationStore';
 import { getClient } from './context';
 import { _markStoreUpdate } from './internal';
+import { DocumentNode } from 'graphql';
 
 interface SourceRequest<Data = any, Variables = object>
   extends GraphQLRequest<Data, Variables> {
@@ -155,8 +157,14 @@ export type ExecuteMutation<Data = any, Variables = object> = (
   context?: Partial<OperationContext>
 ) => Promise<OperationStore<Data, Variables>>;
 
+interface GraphQLRequestInput<Data = any, Variables = object> {
+  key?: number;
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string;
+  variables?: Variables;
+}
+
 export function mutation<Data = any, Variables = object>(
-  input: GraphQLRequest<Data, Variables> | OperationStore<Data, Variables>
+  input: GraphQLRequestInput<Data, Variables> | OperationStore<Data, Variables>
 ): ExecuteMutation<Data, Variables> {
   const client = getClient();
 


### PR DESCRIPTION
resolves #1472 

## Summary

Allow for making requests without `variables` and a `string` query argument. This is already allowed in our `operationStore` typings https://github.com/FormidableLabs/urql/blob/main/packages/svelte-urql/src/operationStore.ts#L34

## Set of changes

- Allow for making requests without `variables` and a `string` query argument.