### PR TITLE
(graphcache) support relayPagination cache refresh

### DIFF
--- a/.changeset/shaggy-rats-own.md
+++ b/.changeset/shaggy-rats-own.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Add option `cleanOnEmptyCursors` to helper `relayPagination`. With this enabled, when resolve a page with both before & after cursors empty, cache for all prior & subsequent pages are invalidated, and will not be included in resolving outcome.

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -8,6 +8,13 @@ export interface Fragments {
   [fragmentName: string]: void | FragmentDefinitionNode;
 }
 
+export interface ConnectionArgs {
+  first?: number;
+  last?: number;
+  after?: string;
+  before?: string;
+}
+
 // Scalar types are not entities as part of response data
 export type Primitive = null | number | boolean | string;
 


### PR DESCRIPTION
Related to #672 

## Summary

This is an attempt to allow force refreshing pagination cache inside helper relayPagination.

Basically, with this new option enabled, when we want to invalidate pagination cache, we reload first page with an empty cursor

I think naming of this new option can be improved, but this is the best I can come up now.

## Set of changes
- Add `relayPagination` option `cleanCacheOnEmptyCursors`