### PR TITLE
Small typo fixes in docs

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -33,7 +33,7 @@ The auth token is usually valid for a shorter duration of time (e.g. 1 week) tha
 (e.g. 6 months), and the latter can be used to request a new
 auth token if the auth token has expired. The refresh logic is triggered either when the JWT is known to be invalid (e.g. by decoding it and inspecting the expiry date),
 or when an API request returns with an unauthorized response. For graphQL APIs, it is usually an error code, instead of a 401 HTTP response, but both can be supported.
-When the token as been successfully refreshed (this can be done as a mutation to the graphQL API or a request to a different API endpoint, depending on implementation),
+When the token has been successfully refreshed (this can be done as a mutation to the graphQL API or a request to a different API endpoint, depending on implementation),
 we will save the new token in persisted storage, and retry the failed request with the new auth header. The user should be logged out and persisted storage cleared if
 the refresh fails or if the re-executing the query with the new token fails with an auth error for the second time.
 

--- a/docs/advanced/persistence-and-uploads.md
+++ b/docs/advanced/persistence-and-uploads.md
@@ -8,7 +8,7 @@ order: 1
 `urql` supports both [Automatic Persisted
 Queries](https://www.apollographql.com/docs/apollo-server/performance/apq/) and [File
 Uploads](https://www.apollographql.com/docs/apollo-server/data/file-uploads/).
-Both of these features is implemented by enhancing or swapping out the default
+Both of these features are implemented by enhancing or swapping out the default
 [`fetchExchange`](../api/core.md#fetchexchange).
 
 ## Automatic Persisted Queries
@@ -25,7 +25,7 @@ respond using a `PersistedQueryNotFound` error. In that case the client is suppo
 the full GraphQL query, and the hash together, which will cause the query to be "registered" with the
 server.
 
-Additionally we could also decide to send these hashed queries as GET requests instead of POST
+Additionally, we could also decide to send these hashed queries as GET requests instead of POST
 requests. If we only send the persisted queries with hashes as GET requests then they become a lot
 easier for a CDN to cache, as by default most caches would not cache POST requests automatically.
 

--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -31,7 +31,7 @@ page.](./authoring-exchanges.md) or what they are [on the "Architecture"
 page.](../architecture.md)
 
 In the above example, we add the `subscriptionExchange` to the `Client` with the default exchanges
-add before it. The `subscriptionExchange` is a factory that accepts additional options and returns
+added before it. The `subscriptionExchange` is a factory that accepts additional options and returns
 the actual `Exchange` function. It does not make any assumption over the transport protocol and
 scheme that is used. Instead, we need to pass a `forwardSubscription` function, which is called with
 an "enriched" _Operation_ every time the `Client` attempts to execute a GraphQL Subscription.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,7 @@ one big stream. The `Client` sees an incoming flow of all of our operations.
 As we've learned before, each operation carries a `key` and each result we receive carries the
 original `operation`. Because an `OperationResult` also carries an `operation` property the `Client`
 will always know which results correspond to an individual operation.
-However, internally, all of our operations are processed at the same time concurrently. However from
+However, internally, all of our operations are processed at the same time concurrently. However, from
 our perspective:
 
 - We subscribe to a "stream" and expect to get results on a callback
@@ -132,7 +132,7 @@ The default set of exchanges that `@urql/core` contains and applies to a `Client
 - `fetchExchange`: Sends an operation to the API using `fetch` and adds results to the output stream
 
 When we don't pass the `exchanges` option manually to our `Client` then these are the ones that will
-be applied. As we can see, an exchange exters a lot of power over our operations and results. They
+be applied. As we can see, an exchange exerts a lot of power over our operations and results. They
 determine a lot of the logic of the `Client`, taking care of things like deduplication, caching, and
 sending requests to our API.
 
@@ -179,7 +179,7 @@ As a user, if we're using the one framework bindings that we've seen in [the "Ba
 section](./basics/README.md), we may never see these streams in action or may never use them even,
 since the bindings internally use them for us. But if we [use the `Client`
 directly](./basics/core.md#one-off-queries-and-mutations) or write exchanges then we'll see streams
-and wil have to deal with their API.
+and will have to deal with their API.
 
 ### The Wonka library
 


### PR DESCRIPTION
## Summary

I was reading through the documentation, familiarizing myself with `urql`, and caught a few small typos along the way. Figured I'd send them along to help improve the already-awesome docs! 😄 

## Set of changes

- Small typos across the MD files used to generate the docs site.
- No breaking changes. Furthermore, no changes to functionality of any of the actual `urql` packages.