### PR TITLE
(next) - hydrate cache correctly when using getStaticProps

### DIFF
--- a/.changeset/large-parents-talk.md
+++ b/.changeset/large-parents-talk.md
@@ -2,4 +2,9 @@
 'next-urql': patch
 ---
 
-Provide urqlState coming from pageProps
+Ensure `urqlState` is hydrated onto the client when a user opts out of `ssr` and uses the `getServerSideProps` or `getStaticProps` on a page-level.
+
+Examples:
+
+- [getStaticProps](https://codesandbox.io/s/urql-get-static-props-dmjch?file=/pages/index.js)
+- [getServerSideProps](https://codesandbox.io/s/urql-get-static-props-forked-xfbrs?file=/pages/index.js)

--- a/.changeset/large-parents-talk.md
+++ b/.changeset/large-parents-talk.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Provide urqlState coming from pageProps

--- a/.changeset/large-parents-talk.md
+++ b/.changeset/large-parents-talk.md
@@ -2,7 +2,7 @@
 'next-urql': patch
 ---
 
-Ensure `urqlState` is hydrated onto the client when a user opts out of `ssr` and uses the `getServerSideProps` or `getStaticProps` on a page-level.
+Ensure `urqlState` is hydrated onto the client when a user opts out of `ssr` and uses the `getServerSideProps` or `getStaticProps` on a page-level and `withUrqlClient` is wrapped on an `_app` level.
 
 Examples:
 

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -35,10 +35,10 @@ export function withUrqlClient(
     const shouldEnableSuspense = Boolean(
       (AppOrPage.getInitialProps || options!.ssr) && !options!.neverSuspend
     );
-
-    const WithUrql = ({ urqlClient, urqlState, ...rest }: WithUrqlProps) => {
+    const WithUrql = ({ pageProps, urqlClient, urqlState, ...rest }: WithUrqlProps) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const forceUpdate = useState(0);
+      const urqlServerState = pageProps.urqlState || urqlState;
 
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const client = React.useMemo(() => {
@@ -47,7 +47,7 @@ export function withUrqlClient(
         }
 
         if (!ssr || typeof window === 'undefined')
-          ssr = ssrExchange({ initialState: urqlState });
+          ssr = ssrExchange({ initialState: urqlServerState });
 
         const clientConfig = getClientConfig(ssr);
         if (!clientConfig.exchanges) {
@@ -63,7 +63,7 @@ export function withUrqlClient(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return initUrqlClient(clientConfig, shouldEnableSuspense)!;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, [urqlClient, urqlState, forceUpdate[0]]);
+      }, [urqlClient, urqlServerState, forceUpdate[0]]);
 
       const resetUrqlClient = () => {
         resetClient();
@@ -76,6 +76,7 @@ export function withUrqlClient(
         { value: client },
         createElement(AppOrPage, {
           ...rest,
+          pageProps,
           urqlClient: client,
           resetUrqlClient,
         })

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -38,7 +38,7 @@ export function withUrqlClient(
     const WithUrql = ({ pageProps, urqlClient, urqlState, ...rest }: WithUrqlProps) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const forceUpdate = useState(0);
-      const urqlServerState = pageProps.urqlState || urqlState;
+      const urqlServerState = (pageProps && pageProps.urqlState) || urqlState;
 
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const client = React.useMemo(() => {
@@ -46,8 +46,10 @@ export function withUrqlClient(
           return urqlClient;
         }
 
-        if (!ssr || typeof window === 'undefined')
-          ssr = ssrExchange({ initialState: urqlServerState });
+        if (!ssr || typeof window === 'undefined') {
+          // We want to force the cache to hydrate, we do this by setting the isClient flag to true
+          ssr = ssrExchange({ initialState: urqlServerState, isClient: true });
+        }
 
         const clientConfig = getClientConfig(ssr);
         if (!clientConfig.exchanges) {

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -35,7 +35,13 @@ export function withUrqlClient(
     const shouldEnableSuspense = Boolean(
       (AppOrPage.getInitialProps || options!.ssr) && !options!.neverSuspend
     );
-    const WithUrql = ({ pageProps, urqlClient, urqlState, ...rest }: WithUrqlProps) => {
+
+    const WithUrql = ({
+      pageProps,
+      urqlClient,
+      urqlState,
+      ...rest
+    }: WithUrqlProps) => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const forceUpdate = useState(0);
       const urqlServerState = (pageProps && pageProps.urqlState) || urqlState;


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/urql/issues/1481

## Summary

When we're not using `getInitialProps`, the one from `withUrqlClient` and opt to use static-prerendering we still have to hydrate the cache.

Examples: 
- [getStaticProps](https://codesandbox.io/s/urql-get-static-props-dmjch?file=/pages/index.js)
- [getServerSideProps](https://codesandbox.io/s/urql-get-static-props-forked-xfbrs?file=/pages/index.js)
- [getInitialProps](https://codesandbox.io/s/urql-get-static-props-forked-y1cv7?file=/package.json)

Might need to start the [GraphQL endpoint](https://codesandbox.io/s/urql-issue-template-server-0ufyz?file=/index.js) to try them

## Set of changes

- use `pageProps` to hydrate the cache when possible

