### PR TITLE
(core) - Make DocumentNode serialization idempotent

### DIFF
--- a/.changeset/fair-beds-happen.md
+++ b/.changeset/fair-beds-happen.md
@@ -2,4 +2,4 @@
 '@urql/core': patch
 ---
 
-Make DocumentNode serialization idempotent, closes #1508
+Fix inconsistency in generating keys for `DocumentNode`s, especially when using GraphQL Code Generator, which could cause SSR serialization to fail.

--- a/.changeset/fair-beds-happen.md
+++ b/.changeset/fair-beds-happen.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Make DocumentNode serialization idempotent, closes #1508

--- a/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
+++ b/exchanges/multipart-fetch/src/__snapshots__/multipartFetchExchange.test.ts.snap
@@ -16,7 +16,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -140,9 +140,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -185,7 +186,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -309,9 +310,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -356,7 +358,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -480,9 +482,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -529,7 +532,7 @@ Object {
     "key": 3,
     "kind": "mutation",
     "query": Object {
-      "__key": 3781860981,
+      "__key": 4034972436,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -627,9 +630,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 102,
+        "end": 125,
         "source": Object {
-          "body": "mutation uploadProfilePicture($picture: File) { uploadProfilePicture(picture: $picture) { location } }",
+          "body": "# uploadProfilePicture
+mutation uploadProfilePicture($picture: File) { uploadProfilePicture(picture: $picture) { location } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -678,7 +682,7 @@ Object {
     "key": 3,
     "kind": "mutation",
     "query": Object {
-      "__key": 1193185401,
+      "__key": 2033658603,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -780,9 +784,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 108,
+        "end": 132,
         "source": Object {
-          "body": "mutation uploadProfilePictures($pictures: [File]) { uploadProfilePicture(pictures: $pictures) { location } }",
+          "body": "# uploadProfilePictures
+mutation uploadProfilePictures($pictures: [File]) { uploadProfilePicture(pictures: $pictures) { location } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,

--- a/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/fetch.test.ts.snap
@@ -16,7 +16,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -140,9 +140,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -185,7 +186,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -309,9 +310,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -356,7 +358,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -480,9 +482,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,

--- a/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
+++ b/packages/core/src/exchanges/__snapshots__/subscription.test.ts.snap
@@ -16,7 +16,7 @@ Object {
     "key": 4,
     "kind": "subscription",
     "query": Object {
-      "__key": 2616620656,
+      "__key": 2088253569,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -114,9 +114,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 74,
+        "end": 92,
         "source": Object {
-          "body": "subscription subscribeToUser($user: String) { user(user: $user) { name } }",
+          "body": "# subscribeToUser
+subscription subscribeToUser($user: String) { user(user: $user) { name } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,

--- a/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
+++ b/packages/core/src/internal/__snapshots__/fetchSource.test.ts.snap
@@ -16,7 +16,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -140,9 +140,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -175,7 +176,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -299,9 +300,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -334,7 +336,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -458,9 +460,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -497,7 +500,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -621,9 +624,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,
@@ -676,7 +680,7 @@ Object {
     "key": 2,
     "kind": "query",
     "query": Object {
-      "__key": 3044551916,
+      "__key": 3521976120,
       "definitions": Array [
         Object {
           "directives": Array [],
@@ -800,9 +804,10 @@ Object {
       ],
       "kind": "Document",
       "loc": Object {
-        "end": 76,
+        "end": 86,
         "source": Object {
-          "body": "query getUser($name: String) { user(name: $name) { id firstName lastName } }",
+          "body": "# getUser
+query getUser($name: String) { user(name: $name) { id firstName lastName } }",
           "locationOffset": Object {
             "column": 1,
             "line": 1,

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -32,10 +32,12 @@ export const stringifyDocument = (
     .trim();
 
   if (typeof node !== 'string') {
-    if (node.loc) {
-      const operationName = 'definitions' in node && getOperationName(node);
-      if (operationName) str = `# ${operationName}\n${str}`;
-    } else {
+    const operationName = 'definitions' in node && getOperationName(node);
+    if (operationName) {
+      str = `# ${operationName}\n${str}`;
+    }
+
+    if (!node.loc) {
       (node as WritableLocation).loc = {
         start: 0,
         end: str.length,


### PR DESCRIPTION
## Summary

Fixes #1508

## Set of changes

This makes DocumentNode serialization idempotent.
In other words, this makes it so we get the same serial representation (and therefore hash key) for a DocumentNode each time it is computed.
