### PR TITLE
(core) - Make Client more forgiving by sharing result sources that emit cached results

### DIFF
--- a/packages/core/src/__snapshots__/client.test.ts.snap
+++ b/packages/core/src/__snapshots__/client.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`createClient passes snapshot 1`] = `
 Client {
-  "activeOperations": Object {},
+  "activeOperations": Map {},
   "createOperationContext": [Function],
   "createRequestOperation": [Function],
   "dispatchOperation": [Function],

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -704,7 +704,7 @@ describe('shared sources behavior', () => {
       return pipe(
         ops$,
         map(op => ({ data: 1, operation: op })),
-        take(1),
+        take(1)
       );
     };
 
@@ -716,12 +716,16 @@ describe('shared sources behavior', () => {
     const resultOne = jest.fn();
     const resultTwo = jest.fn();
 
-    pipe(client.executeRequestOperation(subscriptionOperation), subscribe(resultOne));
+    pipe(
+      client.executeRequestOperation(subscriptionOperation),
+      subscribe(resultOne)
+    );
     expect(resultOne).toHaveBeenCalledTimes(1);
 
-    pipe(client.executeRequestOperation(subscriptionOperation), subscribe(resultTwo));
+    pipe(
+      client.executeRequestOperation(subscriptionOperation),
+      subscribe(resultTwo)
+    );
     expect(resultTwo).toHaveBeenCalledTimes(0);
   });
-
-
 });

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -11,7 +11,9 @@ import {
   filter,
   toArray,
   tap,
+  take,
 } from 'wonka';
+
 import { gql } from './gql';
 import { Exchange, Operation, OperationResult } from './types';
 import { makeOperation } from './utils';
@@ -505,5 +507,195 @@ describe('queuing behavior', () => {
     );
 
     unsubscribe();
+  });
+});
+
+describe('shared sources behavior', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('replays results from prior operation result as needed', async () => {
+    const exchange: Exchange = () => ops$ => {
+      let i = 0;
+      return pipe(
+        ops$,
+        map(op => ({
+          data: ++i,
+          operation: op,
+        })),
+        delay(1)
+      );
+    };
+
+    const client = createClient({
+      url: 'test',
+      exchanges: [exchange],
+    });
+
+    const resultOne = jest.fn();
+    const resultTwo = jest.fn();
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultOne));
+
+    expect(resultOne).toHaveBeenCalledTimes(0);
+
+    jest.advanceTimersByTime(1);
+
+    expect(resultOne).toHaveBeenCalledTimes(1);
+    expect(resultOne).toHaveBeenCalledWith({
+      data: 1,
+      operation: queryOperation,
+    });
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultTwo));
+
+    expect(resultTwo).toHaveBeenCalledWith({
+      data: 1,
+      stale: true,
+      operation: queryOperation,
+    });
+
+    jest.advanceTimersByTime(1);
+
+    expect(resultTwo).toHaveBeenCalledWith({
+      data: 2,
+      operation: queryOperation,
+    });
+  });
+
+  it('replayed results are not emitted on the shared source', () => {
+    const exchange: Exchange = () => ops$ => {
+      let i = 0;
+      return pipe(
+        ops$,
+        map(op => ({
+          data: ++i,
+          operation: op,
+        })),
+        take(1)
+      );
+    };
+
+    const client = createClient({
+      url: 'test',
+      exchanges: [exchange],
+    });
+
+    const resultOne = jest.fn();
+    const resultTwo = jest.fn();
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultOne));
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultTwo));
+
+    expect(resultOne).toHaveBeenCalledTimes(1);
+    expect(resultTwo).toHaveBeenCalledTimes(1);
+
+    expect(resultTwo).toHaveBeenCalledWith({
+      data: 1,
+      operation: queryOperation,
+      stale: true,
+    });
+  });
+
+  it('does nothing when no operation result has been emitted yet', () => {
+    const exchange: Exchange = () => ops$ => {
+      return pipe(
+        ops$,
+        map(op => ({ data: 1, operation: op })),
+        filter(() => false)
+      );
+    };
+
+    const client = createClient({
+      url: 'test',
+      exchanges: [exchange],
+    });
+
+    const resultOne = jest.fn();
+    const resultTwo = jest.fn();
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultOne));
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultTwo));
+
+    expect(resultOne).toHaveBeenCalledTimes(0);
+    expect(resultTwo).toHaveBeenCalledTimes(0);
+  });
+
+  it('skips replaying results when a result is emitted immediately', () => {
+    const exchange: Exchange = () => ops$ => {
+      let i = 0;
+      return pipe(
+        ops$,
+        map(op => ({ data: ++i, operation: op }))
+      );
+    };
+
+    const client = createClient({
+      url: 'test',
+      exchanges: [exchange],
+    });
+
+    const resultOne = jest.fn();
+    const resultTwo = jest.fn();
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultOne));
+
+    expect(resultOne).toHaveBeenCalledWith({
+      data: 1,
+      operation: queryOperation,
+    });
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultTwo));
+
+    expect(resultTwo).toHaveBeenCalledWith({
+      data: 2,
+      operation: queryOperation,
+    });
+
+    expect(resultOne).toHaveBeenCalledWith({
+      data: 2,
+      operation: queryOperation,
+    });
+  });
+
+  it('replays stale results as needed', () => {
+    const exchange: Exchange = () => ops$ => {
+      return pipe(
+        ops$,
+        map(op => ({ stale: true, data: 1, operation: op })),
+        take(1)
+      );
+    };
+
+    const client = createClient({
+      url: 'test',
+      exchanges: [exchange],
+    });
+
+    const resultOne = jest.fn();
+    const resultTwo = jest.fn();
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultOne));
+
+    expect(resultOne).toHaveBeenCalledWith({
+      data: 1,
+      operation: queryOperation,
+      stale: true,
+    });
+
+    pipe(client.executeRequestOperation(queryOperation), subscribe(resultTwo));
+
+    expect(resultTwo).toHaveBeenCalledWith({
+      data: 1,
+      operation: queryOperation,
+      stale: true,
+    });
   });
 });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -260,7 +260,7 @@ export class Client {
         this.dispatchOperation(
           makeOperation('teardown', operation, operation.context)
         );
-      }),
+      })
     );
 
     if (operation.kind === 'subscription') {
@@ -270,7 +270,7 @@ export class Client {
           this.activeOperations.set(operation.key, active!);
           this.dispatchOperation(operation);
         }),
-        share,
+        share
       );
     } else {
       active = pipe(
@@ -278,7 +278,7 @@ export class Client {
         replayOnStart(() => {
           this.activeOperations.set(operation.key, active!);
           this.dispatchOperation(operation);
-        }),
+        })
       );
     }
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -314,7 +314,7 @@ export class Client {
     let result: OperationResult<Data, Variables> | null = null;
 
     pipe(
-      this.executeQuery(createRequest(query, variables), context),
+      this.query(query, variables, context),
       subscribe(res => {
         result = res;
       })

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -4,6 +4,7 @@ import {
   filter,
   makeSubject,
   onEnd,
+  onPush,
   onStart,
   pipe,
   share,
@@ -66,10 +67,6 @@ export interface ClientOptions {
   maskTypename?: boolean;
 }
 
-interface ActiveOperations {
-  [operationKey: string]: number;
-}
-
 export const createClient = (opts: ClientOptions) => new Client(opts);
 
 /** The URQL application-wide client library. Each execute method starts a GraphQL request and returns a stream of results. */
@@ -93,7 +90,7 @@ export class Client {
   dispatchOperation: (operation?: Operation | void) => void;
   operations$: Source<Operation>;
   results$: Source<OperationResult>;
-  activeOperations = Object.create(null) as ActiveOperations;
+  activeOperations: Map<number, Source<OperationResult>> = new Map();
   queue: Operation[] = [];
 
   constructor(opts: ClientOptions) {
@@ -138,7 +135,7 @@ export class Client {
       // operation's exchange results
       if (
         operation.kind === 'mutation' ||
-        (this.activeOperations[operation.key] || 0) > 0
+        this.activeOperations.has(operation.key)
       ) {
         this.queue.push(operation);
         if (!isOperationBatchActive) {
@@ -197,100 +194,97 @@ export class Client {
       this.createOperationContext(opts)
     );
 
-  /** Counts up the active operation key and dispatches the operation */
-  private onOperationStart(operation: Operation) {
-    const { key } = operation;
-    this.activeOperations[key] = (this.activeOperations[key] || 0) + 1;
-    this.dispatchOperation(operation);
-  }
-
-  /** Deletes an active operation's result observable and sends a teardown signal through the exchange pipeline */
-  private onOperationEnd(operation: Operation) {
-    const { key } = operation;
-    const prevActive = this.activeOperations[key] || 0;
-    const newActive = (this.activeOperations[key] =
-      prevActive <= 0 ? 0 : prevActive - 1);
-    // Check whether this operation has now become inactive
-    if (newActive <= 0) {
-      // Delete all related queued up operations for the inactive one
-      for (let i = this.queue.length - 1; i >= 0; i--)
-        if (this.queue[i].key === operation.key) this.queue.splice(i, 1);
-      // Issue the cancellation teardown operation
-      this.dispatchOperation(
-        makeOperation('teardown', operation, operation.context)
-      );
-    }
-  }
-
   /** Executes an Operation by sending it through the exchange pipeline It returns an observable that emits all related exchange results and keeps track of this observable's subscribers. A teardown signal will be emitted when no subscribers are listening anymore. */
   executeRequestOperation<Data = any, Variables = object>(
     operation: Operation<Data, Variables>
   ): Source<OperationResult<Data, Variables>> {
-    let operationResults$ = pipe(
-      this.results$,
-      filter((res: OperationResult) => res.operation.key === operation.key)
-    ) as Source<OperationResult<Data, Variables>>;
+    let result$ = this.activeOperations.get(operation.key);
+    if (!result$) {
+      result$ = pipe(
+        this.results$,
+        filter((res: OperationResult) => res.operation.key === operation.key)
+      ) as Source<OperationResult<Data, Variables>>;
 
-    if (this.maskTypename) {
-      operationResults$ = pipe(
-        operationResults$,
-        map(res => {
-          res.data = maskTypename(res.data);
-          return res;
-        })
-      );
-    }
+      if (this.maskTypename) {
+        result$ = pipe(
+          result$,
+          map(res => ({ ...res, data: maskTypename(res.data) }))
+        );
+      }
 
-    if (operation.kind === 'mutation') {
       // A mutation is always limited to just a single result and is never shared
-      return pipe(
-        operationResults$,
-        onStart<OperationResult>(() => this.dispatchOperation(operation)),
+      if (operation.kind === 'mutation') {
+        return pipe(
+          result$,
+          onStart<OperationResult>(() => this.dispatchOperation(operation)),
+          take(1)
+        );
+      }
+
+      const teardown$ = pipe(
+        this.operations$,
+        filter(
+          (op: Operation) => op.kind === 'teardown' && op.key === operation.key
+        )
+      );
+
+      const refetch$ = pipe(
+        this.operations$,
+        filter(
+          (op: Operation) =>
+            op.kind === operation.kind &&
+            op.key === operation.key &&
+            op.context.requestPolicy !== 'cache-only'
+        ),
         take(1)
       );
+
+      let prevResult: OperationResult | undefined;
+
+      result$ = pipe(
+        merge([
+          pipe(
+            fromValue(null),
+            map(() => prevResult),
+            filter(Boolean)
+          ) as Source<OperationResult>,
+          result$,
+        ]),
+        takeUntil(teardown$),
+        switchMap(result => {
+          if (result.stale) return fromValue(result);
+          return merge([
+            fromValue(result),
+            pipe(
+              refetch$,
+              map(() => ({ ...result, stale: true }))
+            ),
+          ]);
+        }),
+        onEnd<OperationResult>(() => {
+          prevResult = undefined;
+          this.activeOperations.delete(operation.key);
+          for (let i = this.queue.length - 1; i >= 0; i--)
+            if (this.queue[i].key === operation.key) this.queue.splice(i, 1);
+          this.dispatchOperation(
+            makeOperation('teardown', operation, operation.context)
+          );
+        }),
+        onPush(result => {
+          prevResult = result;
+        }),
+        share
+      );
     }
 
-    const teardown$ = pipe(
-      this.operations$,
-      filter(
-        (op: Operation) => op.kind === 'teardown' && op.key === operation.key
-      )
-    );
-
-    const refetch$ = pipe(
-      this.operations$,
-      filter(
-        (op: Operation) =>
-          op.kind === operation.kind &&
-          op.key === operation.key &&
-          op.context.requestPolicy !== 'cache-only'
-      )
-    );
-
-    const result$ = pipe(
-      operationResults$,
-      takeUntil(teardown$),
-      switchMap(result => {
-        if (result.stale) return fromValue(result);
-
-        return merge([
-          fromValue(result),
-          pipe(
-            refetch$,
-            take(1),
-            map(() => ({ ...result, stale: true }))
-          ),
-        ]);
-      }),
+    return pipe(
+      result$,
       onStart<OperationResult>(() => {
-        this.onOperationStart(operation);
-      }),
-      onEnd<OperationResult>(() => {
-        this.onOperationEnd(operation);
+        const { key } = operation;
+        this.activeOperations.set(key, result$!);
+        this.dispatchOperation(operation);
       })
     );
-
-    return result$;
   }
 
   query<Data = any, Variables extends object = {}>(

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -238,7 +238,8 @@ export class Client {
           (op: Operation) =>
             op.kind === operation.kind &&
             op.key === operation.key &&
-            op.context.requestPolicy !== 'cache-only'
+            (op.context.requestPolicy === 'network-only' ||
+              op.context.requestPolicy === 'cache-and-network')
         ),
         take(1)
       );

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -4,7 +4,7 @@ export * from './result';
 export * from './typenames';
 export * from './stringifyVariables';
 export * from './maskTypename';
-export * from './withPromise';
+export * from './streamUtils';
 export * from './operation';
 
 export const noop = () => {

--- a/packages/core/src/utils/streamUtils.ts
+++ b/packages/core/src/utils/streamUtils.ts
@@ -1,0 +1,53 @@
+import {
+  Operator,
+  Source,
+  pipe,
+  toPromise,
+  take,
+  share,
+  onPush,
+  onStart,
+  onEnd,
+  subscribe,
+  make,
+} from 'wonka';
+
+import { OperationResult, PromisifiedSource } from '../types';
+
+export function withPromise<T>(source$: Source<T>): PromisifiedSource<T> {
+  (source$ as PromisifiedSource<T>).toPromise = () =>
+    pipe(source$, take(1), toPromise);
+  return source$ as PromisifiedSource<T>;
+}
+
+export function replayOnStart<T extends OperationResult>(start?: () => void): Operator<T, T> {
+  return source$ => {
+    let replay: T | void;
+
+    const shared$ = pipe(
+      source$,
+      onPush(value => {
+        replay = value;
+      }),
+      share,
+    );
+
+    return make<T>(observer => {
+      const prevReplay = replay;
+
+      const subscription = pipe(
+        shared$,
+        onEnd(observer.complete),
+        onStart(() => {
+          if (start)
+            start();
+          if (prevReplay !== undefined && prevReplay === replay)
+            observer.next({ ...prevReplay, stale: true });
+        }),
+        subscribe(observer.next)
+      );
+
+      return subscription.unsubscribe;
+    });
+  };
+}

--- a/packages/core/src/utils/streamUtils.ts
+++ b/packages/core/src/utils/streamUtils.ts
@@ -20,7 +20,9 @@ export function withPromise<T>(source$: Source<T>): PromisifiedSource<T> {
   return source$ as PromisifiedSource<T>;
 }
 
-export function replayOnStart<T extends OperationResult>(start?: () => void): Operator<T, T> {
+export function replayOnStart<T extends OperationResult>(
+  start?: () => void
+): Operator<T, T> {
   return source$ => {
     let replay: T | void;
 
@@ -29,7 +31,7 @@ export function replayOnStart<T extends OperationResult>(start?: () => void): Op
       onPush(value => {
         replay = value;
       }),
-      share,
+      share
     );
 
     return make<T>(observer => {
@@ -39,8 +41,7 @@ export function replayOnStart<T extends OperationResult>(start?: () => void): Op
         shared$,
         onEnd(observer.complete),
         onStart(() => {
-          if (start)
-            start();
+          if (start) start();
           if (prevReplay !== undefined && prevReplay === replay)
             observer.next({ ...prevReplay, stale: true });
         }),

--- a/packages/core/src/utils/withPromise.ts
+++ b/packages/core/src/utils/withPromise.ts
@@ -1,8 +1,0 @@
-import { Source, pipe, toPromise, take } from 'wonka';
-import { PromisifiedSource } from '../types';
-
-export function withPromise<T>(source$: Source<T>): PromisifiedSource<T> {
-  (source$ as PromisifiedSource<T>).toPromise = () =>
-    pipe(source$, take(1), toPromise);
-  return source$ as PromisifiedSource<T>;
-}


### PR DESCRIPTION
## Summary

At the risk of being called edgy, this proposed change layers a third cache on top of the `Client`. Apart from the usual exchange cache (default `cacheExchange` or Graphcache) and the React bindings' suspense/concurrent cache, this third cache is just a minor one to share results across all sources.

This change replaces the `Client`'s semaphore with a shared binary semaphore that only stores the result source for a given operation. Hence, an active operation now has a single source that it uses for all subscribers. Apart from the shared source on each subscription it will still emit a new operation. However, all sources for a single subscription now share an underlying source. This source ensures that all operations see the exact same result (which was only implicitly guaranteed before) and each new subscriber will receive the last previously known result if its operation doesn't immediately yield a first result.

This means that it'll be harder to trip up when layering a lot of logic with shared operations that have multiple concurrent subscribers and multiple concurrent uses of `cache-and-network` request policies.

## Set of changes

- Replace `activeOperations` type with a `Map<number, ActiveOperation>`
- Store a result source for each query/subscription source that's shared and cleans itself up
- Keep around an "active cached value" for each source that's the last known result
- Clear the `activeOperations` when it ends
- Use the "active cached value" to emit a first value for new subscribers when they start and don't receive a synchronous result immediately
- Ensure that each new subscriber issues a fresh operation

**The risk associated with this change right now is that the `requestPolicy` may be disregarded. We have to investigate whether a `network-only` operation for instance still shows the expected bindings behaviour. Although, this hasn't been doing what people thought anyway.**
