### PR TITLE
feat(svelte): allow to pass a client directly to `query`, ...

### DIFF
--- a/.changeset/mighty-plants-wonder.md
+++ b/.changeset/mighty-plants-wonder.md
@@ -1,0 +1,41 @@
+---
+'@urql/svelte': minor
+---
+
+Allow to pass a client directly to `query`, `subscription` and `mutation`.
+
+This change supports the use of the svelte bindings outside of a component.
+
+For example with @sveltejs/kit it is possible to use the [load](https://kit.svelte.dev/docs#loading) method to get data before the component is initialized:
+
+```html
+<script context="module">
+  import { get } from 'svelte/store';
+  import { operationStore, query } from '@urql/svelte';
+
+  export async function load({ context: { client } }) {
+    const todos = query(
+      operationStore(`
+      query {
+        todos {
+          id
+          title
+        }
+      }
+    `),
+      context.client
+    );
+
+    // Load the todos and make them available during initial rendering
+    await todos.toPromise();
+
+    return { props: { todos } };
+  }
+</script>
+
+<script>
+  export const todos
+
+  // No need to invoke query(result)
+</script>
+```

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -68,9 +68,9 @@ function toSource<Data, Variables>(store: OperationStore<Data, Variables>) {
 }
 
 export function query<Data = any, Variables = object>(
-  store: OperationStore<Data, Variables>
+  store: OperationStore<Data, Variables>,
+  client = getClient()
 ): OperationStore<Data, Variables> {
-  const client = getClient();
   const subscription = pipe(
     toSource(store),
     switchMap(request => {
@@ -112,9 +112,9 @@ export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 
 export function subscription<Data = any, Result = Data, Variables = object>(
   store: OperationStore<Result, Variables>,
-  handler?: SubscriptionHandler<Data, Result>
+  handler?: SubscriptionHandler<Data, Result>,
+  client = getClient()
 ): OperationStore<Result, Variables> {
-  const client = getClient();
   const subscription = pipe(
     toSource(store),
     switchMap(
@@ -164,10 +164,9 @@ interface GraphQLRequestInput<Data = any, Variables = object> {
 }
 
 export function mutation<Data = any, Variables = object>(
-  input: GraphQLRequestInput<Data, Variables> | OperationStore<Data, Variables>
+  input: GraphQLRequestInput<Data, Variables> | OperationStore<Data, Variables>,
+  client = getClient()
 ): ExecuteMutation<Data, Variables> {
-  const client = getClient();
-
   const store =
     typeof (input as any).subscribe !== 'function'
       ? operationStore<Data, Variables>(input.query, input.variables)


### PR DESCRIPTION
## Summary

This change supports the use of the svelte bindings outside of a component.

For example with @sveltejs/kit it is possible to use the [load](https://kit.svelte.dev/docs#loading) method to get data before the component is initialized:

```html
<script context="module">
  import { get } from 'svelte/store';
  import { operationStore, query } from '@urql/svelte';

  export async function load({ context: { client } }) {
    const todos = query(
      operationStore(`
      query {
        todos {
          id
          title
        }
      }
    `),
      context.client
    );

    // Load the todos and make them available during initial rendering
    await todos.toPromise();

    return { props: { todos } };
  }
</script>

<script>
  export const todos

  // No need to invoke query(result)
</script>
```

## Set of changes

`@urql/svelte`: adding `client` as last optional argument to `query`, `subscription` and `mutation` (not a breaking change – API compatible to previous versions)
