### PR TITLE
(graphcache) - allow null for subscription- & mutationType

### DIFF
--- a/.changeset/slow-doors-sparkle.md
+++ b/.changeset/slow-doors-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Allow for the schema subscription and mutationType to be null

--- a/exchanges/graphcache/src/ast/schema.ts
+++ b/exchanges/graphcache/src/ast/schema.ts
@@ -35,8 +35,8 @@ export interface SchemaIntrospector {
 
 export interface PartialIntrospectionSchema {
   queryType: { name: string; kind?: any };
-  mutationType?: { name: string; kind?: any };
-  subscriptionType?: { name: string; kind?: any };
+  mutationType?: { name: string; kind?: any } | null;
+  subscriptionType?: { name: string; kind?: any } | null;
   types?: IntrospectionSchema['types'];
 }
 


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/urql/issues/1506

## Set of changes

- allow null for subscription- & mutationType in the introspectionSchema
