### PR TITLE
(docs) - Remove accidental bullet point

### DIFF
--- a/docs/graphcache/cache-updates.md
+++ b/docs/graphcache/cache-updates.md
@@ -68,7 +68,7 @@ arguments, which are the same as [the resolvers' arguments](./local-resolvers.md
 - `args`: The arguments that the field has been called with, which will be replaced with an empty
   object if the field hasn't been called with any arguments.
 - `cache`: The `cache` instance, which gives us access to methods allowing us to interact with the
-- local cache. Its full API can be found [in the API docs](../api/graphcache.md#cache). On this page
+  local cache. Its full API can be found [in the API docs](../api/graphcache.md#cache). On this page
   we use it frequently to read from and write to the cache.
 - `info`: This argument shouldn't be used frequently, but it contains running information about the
   traversal of the query document. It allows us to make resolvers reusable or to retrieve


### PR DESCRIPTION
## Summary
A possibly accidental bullet point in the docs seem to affect the readability.
It's a pretty minor inconvenience but I decided to make a PR anyways :) 
![image](https://user-images.githubusercontent.com/36479718/114292543-ce3ba580-9aac-11eb-894f-b4de147e88c5.png)

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes
Remove the bullet point.
<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
