### PR TITLE
(graphcache) - Add cache.link method for writing links

### DIFF
--- a/.changeset/moody-mice-arrive.md
+++ b/.changeset/moody-mice-arrive.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Add `cache.link(...)` method to Graphcache. This method may be used in updaters to update links in the cache. It is hence the writing-equivalent of `cache.resolve()`, which previously didn't have any equivalent as such, which meant that only `cache.updateQuery` or `cache.writeFragment` could be used, even to update simple relations.

--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -371,6 +371,39 @@ cache.readQuery({
 [Read more about using `readQuery` on the ["Local Resolvers"
 page.](../graphcache/local-resolvers.md#reading-a-query)
 
+### link
+
+Corresponding to [`cache.resolve`](#resolve), the `cache.link` method allows
+links in the cache to be updated. While the `cache.resolve` method reads both
+records and links from the cache, the `cache.link` method will only ever write
+links as fragments (See [`cache.writeFragment`](#writefragment) below) are more
+suitable for updating scalar data in the cache.
+
+The arguments for `cache.link` are identical to [`cache.resolve`](#resolve) and
+the field's arguments are optional. However, the last argument must always be
+a link, meaning `null`, an entity key, a keyable entity, or a list of these.
+
+In other words, `cache.link` accepts an entity to write to as its first argument,
+with the same arguments as `cache.keyOfEntity`. It then accepts one or two arguments
+that are passed to `cache.keyOfField` to get the targeted field key. And lastly,
+you may pass a list or a single entity (or an entity key).
+
+```js
+// Link Query.todo field to a todo item
+cache.link({ __typename: 'Query' }, 'todo', { __typename: 'Todo', id: 1 });
+
+// You may also pass arguments instead:
+cache.link({ __typename: 'Query' }, 'todo', { id: 1 }, { __typename: 'Todo', id: 1 });
+
+// Or use entity keys instead of the entities themselves:
+cache.link('Query', 'todo', cache.keyOfEntity({ __typename: 'Todo', id: 1 }));
+```
+
+The method may [output a
+warning](../graphcache/errors.md#12-cant-generate-a-key-for-writefragment-or-link) when any of the
+entities were passed as objects but aren't keyable, which is useful when a scalar or a non-keyable
+object have been passed to `cache.link` accidentally.
+
 ### writeFragment
 
 Corresponding to [`cache.readFragment`](#readfragments), the `cache.writeFragment` method allows

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -171,19 +171,20 @@ is maybe empty or does not contain fragments.
 When you're calling a fragment method, please ensure that you're only passing fragments
 in your GraphQL document. The first fragment will be used to start writing data.
 
-## (12) Can't generate a key for writeFragment(...)
+## (12) Can't generate a key for writeFragment(...) or link(...)
 
-> Can't generate a key for writeFragment(...) data.
+> Can't generate a key for writeFragment(...) [or link(...) data.
 > You have to pass an `id` or `_id` field or create a custom `keys` config for `???`.
 
-You probably have called `cache.writeFragment` with data that the cache can't generate a
-key for.
+You probably have called `cache.writeFragment` or `cache.link` with data that the cache
+can't generate a key for.
 
 This may either happen because you're missing the `id` or `_id` field or some other
 fields for your custom `keys` config.
 
 Please make sure that you include enough properties on your data so that `writeFragment`
-can generate a key.
+or `cache.link` can generate a key. On `cache.link` the entities must either be
+an existing entity key, or a keyable entity.
 
 ## (13) Invalid undefined
 
@@ -196,8 +197,8 @@ know the part of your result that did contain `undefined`.
 
 ## (14) Couldn't find \_\_typename when writing.
 
-> Couldn't find **typename when writing.
-> If you're writing to the cache manually have to pass a `**typename` property on each entity in your data.
+> Couldn't find `__typename` when writing.
+> If you're writing to the cache manually have to pass a `__typename` property on each entity in your data.
 
 You probably have called `cache.writeFragment` or `cache.updateQuery` with data that is missing a
 `__typename` field for an entity where your document contains a selection set. The cache won't be

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -18,8 +18,17 @@ import {
 import { warn, pushDebugNode, popDebugNode } from '../helpers/help';
 import { hasField } from '../store/data';
 import { Store, keyOfField } from '../store';
-import { Fragments, Variables, DataField, NullArray, Data } from '../types';
 import { getFieldArguments, shouldInclude, isInterfaceOfType } from '../ast';
+
+import {
+  Fragments,
+  Variables,
+  DataField,
+  NullArray,
+  Link,
+  Entity,
+  Data,
+} from '../types';
 
 export interface Context {
   store: Store;
@@ -204,3 +213,27 @@ export const makeSelectionIterator = (
 
 export const ensureData = (x: DataField): Data | NullArray<Data> | null =>
   x === undefined ? null : (x as Data | NullArray<Data>);
+
+export const ensureLink = (store: Store, ref: Link<Entity>): Link => {
+  if (ref == null) {
+    return ref;
+  } else if (Array.isArray(ref)) {
+    const link = new Array(ref.length);
+    for (let i = 0, l = link.length; i < l; i++)
+      link[i] = ensureLink(store, ref[i]);
+    return link;
+  }
+
+  const link = store.keyOfEntity(ref);
+  if (!link && ref && typeof ref === 'object') {
+    warn(
+      "Can't generate a key for link(...) item." +
+        '\nYou have to pass an `id` or `_id` field or create a custom `keys` config for `' +
+        ref.__typename +
+        '`.',
+      12
+    );
+  }
+
+  return link;
+};

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -19,7 +19,7 @@ import {
 } from '../types';
 
 import { invariant } from '../helpers/help';
-import { contextRef } from '../operations/shared';
+import { contextRef, ensureLink } from '../operations/shared';
 import { read, readFragment } from '../operations/query';
 import { writeFragment, startWrite } from '../operations/write';
 import { invalidateEntity } from '../operations/invalidate';
@@ -224,17 +224,13 @@ export class Store implements Cache {
     const link = (maybeLink !== undefined
       ? maybeLink
       : argsOrLink) as Link<Entity>;
-
-    const entityKey = this.keyOfEntity(entity);
-    if (!entityKey) return;
-
-    InMemoryData.writeLink(
-      entityKey,
-      keyOfField(field, args),
-      // FIXME: Needs to handle nested lists, unknown entities (?), scalars, etc (see writeField in operations/write)
-      Array.isArray(link)
-        ? link.map(entity => this.keyOfEntity(entity as any))
-        : this.keyOfEntity(link)
-    );
+    const entityKey = ensureLink(this, entity);
+    if (typeof entityKey === 'string') {
+      InMemoryData.writeLink(
+        entityKey,
+        keyOfField(field, args),
+        ensureLink(this, link)
+      );
+    }
   }
 }

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -117,6 +117,16 @@ export interface Cache {
     data: T,
     variables?: V
   ): void;
+
+  /** link() can be used to update a given entity field to link to another entity or entities */
+  link(
+    entity: Entity,
+    field: string,
+    args: FieldArgs,
+    link: Link<Entity>
+  ): void;
+  /** link() can be used to update a given entity field to link to another entity or entities */
+  link(entity: Entity, field: string, value: Link<Entity>): void;
 }
 
 type ResolverResult =


### PR DESCRIPTION
## Summary

This allows the user to pass in a rootKey or entity from which we'll derive the rootKey for instance Query or { __typename:'Todo', id: 1 }, secondly we accept a field, this can be for instance author which will be applied to the rootKey. As a thirth argument we accept the entity or entities to be written as keys to the rootKey.field, for example { __typename: 'Author', id: 1 } and as a last argument we accept fieldArguments, these will be applied to the fieldKey and will help with fields that have their own arguments for instance: Todo:1.authors({ first: 10 }).

Resolves: #1485

## Set of changes

- Adds `cache.link` to graphCache to be used in updaters
