### PR TITLE
(graphcache) - make list items non-nullable without schema-awareness

### DIFF
--- a/.changeset/great-scissors-boil.md
+++ b/.changeset/great-scissors-boil.md
@@ -2,4 +2,4 @@
 '@urql/exchange-graphcache': patch
 ---
 
-list-items are never nullable when we aren't using schema-awareness, this would otherwise lead to scenario's where we don't refetch partial results. Formerly we made the assumption that a list-item was nullable when we weren't provided with a schema, this meant that if we'd provide `[undefined, 'entity:x']` from a resolver we wouldn't fetch the result but we'd return it.
+Fix list items being returned as `null` even for non-nullable lists, when the entities are missing in the cache. This could happen when a resolver was added returning entities or their keys. This behaviour is now (correctly) only applied to partial results with schema awareness.

--- a/.changeset/great-scissors-boil.md
+++ b/.changeset/great-scissors-boil.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+list-items are never nullable when we aren't using schema-awareness, this would otherwise lead to scenario's where we don't refetch partial results. Formerly we made the assumption that a list-item was nullable when we weren't provided with a schema, this meant that if we'd provide `[undefined, 'entity:x']` from a resolver we wouldn't fetch the result but we'd return it.

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -447,8 +447,9 @@ const resolveResolverResult = (
     const { store } = ctx;
     // Check whether values of the list may be null; for resolvers we assume
     // that they can be, since it's user-provided data
-    const _isListNullable =
-      store.schema ? isListNullable(store.schema, typename, fieldName) : false;
+    const _isListNullable = store.schema
+      ? isListNullable(store.schema, typename, fieldName)
+      : false;
     const data = new Array(result.length);
     for (let i = 0, l = result.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value
@@ -509,8 +510,9 @@ const resolveLink = (
 ): DataField | undefined => {
   if (Array.isArray(link)) {
     const { store } = ctx;
-    const _isListNullable =
-      store.schema ? isListNullable(store.schema, typename, fieldName) : false;
+    const _isListNullable = store.schema
+      ? isListNullable(store.schema, typename, fieldName)
+      : false;
     const newLink = new Array(link.length);
     for (let i = 0, l = link.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -448,7 +448,7 @@ const resolveResolverResult = (
     // Check whether values of the list may be null; for resolvers we assume
     // that they can be, since it's user-provided data
     const _isListNullable =
-      !store.schema || isListNullable(store.schema, typename, fieldName);
+      store.schema ? isListNullable(store.schema, typename, fieldName) : false;
     const data = new Array(result.length);
     for (let i = 0, l = result.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value
@@ -510,7 +510,7 @@ const resolveLink = (
   if (Array.isArray(link)) {
     const { store } = ctx;
     const _isListNullable =
-      store.schema && isListNullable(store.schema, typename, fieldName);
+      store.schema ? isListNullable(store.schema, typename, fieldName) : false;
     const newLink = new Array(link.length);
     for (let i = 0, l = link.length; i < l; i++) {
       // Add the current index to the walked path before reading the field's value


### PR DESCRIPTION
list-items are never nullable when we aren't using schema-awareness, this would otherwise lead to scenario's where we don't refetch partial results

Fixes: https://github.com/FormidableLabs/urql/issues/1546

## Summary

Formerly we made the assumption that a list-item was nullable when we weren't provided with a schema, this meant that if we'd provide `[undefined, 'entity:x']` from a resolver we wouldn't fetch the result but we'd return it.

## Set of changes

- Lists are non-nullable without schema-awareness
