### PR TITLE
(chore) - remove closure-compiler

### DIFF
--- a/.changeset/curvy-bobcats-fry.md
+++ b/.changeset/curvy-bobcats-fry.md
@@ -14,7 +14,6 @@
 'next-urql': patch
 '@urql/preact': patch
 'urql': patch
-'urql-docs': patch
 '@urql/storybook-addon': patch
 '@urql/svelte': patch
 '@urql/vue': patch

--- a/.changeset/curvy-bobcats-fry.md
+++ b/.changeset/curvy-bobcats-fry.md
@@ -1,0 +1,23 @@
+---
+'@urql/exchange-auth': patch
+'@urql/exchange-execute': patch
+'@urql/exchange-graphcache': patch
+'@urql/exchange-multipart-fetch': patch
+'@urql/exchange-persisted-fetch': patch
+'@urql/exchange-populate': patch
+'@urql/exchange-refocus': patch
+'@urql/exchange-request-policy': patch
+'@urql/exchange-retry': patch
+'@urql/exchange-suspense': patch
+'@urql/core': patch
+'@urql/introspection': patch
+'next-urql': patch
+'@urql/preact': patch
+'urql': patch
+'urql-docs': patch
+'@urql/storybook-addon': patch
+'@urql/svelte': patch
+'@urql/vue': patch
+---
+
+Remove closure-compiler from the build step

--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -1,6 +1,7 @@
 {
   "name": "urql-exchange-graphcache-default-storage",
   "private": true,
+  "version": "0.0.0",
   "main": "../dist/urql-exchange-graphcache-default-storage",
   "module": "../dist/urql-exchange-graphcache-default-storage.mjs",
   "types": "../dist/types/default-storage/index.d.ts",
@@ -15,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@urql/core": ">=1.16.0",
+    "@urql/core": ">=2.0.0",
     "wonka": "^4.0.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@types/jest": "^26.0.20",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "babel-plugin-closure-elimination": "^1.3.2",
     "babel-plugin-modular-graphql": "1.0.1",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "react-is": "^17.0.1"
   },
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "^0.26.0",
     "@babel/core": "^7.12.13",
     "@babel/plugin-transform-object-assign": "^7.12.13",
     "@babel/plugin-transform-react-jsx": "^7.12.13",

--- a/scripts/babel/transform-function-expressions.js
+++ b/scripts/babel/transform-function-expressions.js
@@ -1,0 +1,37 @@
+const plugin = ({ types: t }) => ({
+  visitor: {
+    FunctionExpression(path) {
+      if (
+        t.isVariableDeclarator(path.parent) &&
+        t.isProgram(path.parentPath.scope.block)
+      ) {
+        const expr = path.node;
+        const decl = path.parent;
+        const decls = path.parentPath.parent.declarations;
+        const parent = path.parentPath.parentPath.parent;
+
+        let replacement = t.functionDeclaration(
+          decl.id,
+          expr.params,
+          expr.body,
+          expr.generator,
+          expr.async,
+        );
+
+        if (t.isExportNamedDeclaration(parent)) {
+          replacement = t.exportNamedDeclaration(replacement);
+        }
+
+        path.parentPath.parentPath.insertBefore(replacement);
+
+        if (decls.length <= 1) {
+          path.parentPath.parentPath.remove();
+        } else {
+          path.remove();
+        }
+      }
+    }
+  }
+});
+
+export default plugin;

--- a/scripts/babel/transform-function-expressions.js
+++ b/scripts/babel/transform-function-expressions.js
@@ -1,37 +1,95 @@
-const plugin = ({ types: t }) => ({
-  visitor: {
-    FunctionExpression(path) {
-      if (
-        t.isVariableDeclarator(path.parent) &&
-        t.isProgram(path.parentPath.scope.block)
+/** Babel plugin for cleaning up arrow function transpilation, which turns function expressions assigned to variable decalators into function declarations when it's safe to do so. */
+const functionExpressionCleanup = ({ types: t }) => {
+  /** Checks whether this block has only safe conditions up until the given node. */
+  const isSafeUntil = (block, until) => {
+    let body = [];
+    if (t.isIfStatement(block)) {
+      body = block.consequent;
+      if (block.alternate && !isSafeUntil(block.alternate, until)) {
+        return false;
+      }
+    } else if (t.isBlockStatement(block)) {
+      body = block.body;
+    }
+
+    for (let i = 0, l = body.length; i < l; i++) {
+      let node = body[i];
+      if (t.isIfStatement(node)) {
+        // An if statement is safe if it also is safe throughout
+        if (!isSafeUntil(node, until)) return false;
+      } else if (
+        !t.isVariableDeclaration(node) &&
+        !t.isFunctionDeclaration(node) &&
+        !(t.isExpressionStatement(node) && t.isAssignmentExpression(node.expression))
       ) {
-        const expr = path.node;
-        const decl = path.parent;
-        const decls = path.parentPath.parent.declarations;
-        const parent = path.parentPath.parentPath.parent;
+        // only variable declarations and function declarations are safe
+        // assignments are fine too, since we're later checking the binding for "constantViolations"
+        return false;
+      } else if (node === until) {
+        return true;
+      }
+    }
 
-        let replacement = t.functionDeclaration(
-          decl.id,
-          expr.params,
-          expr.body,
-          expr.generator,
-          expr.async,
-        );
+    return true;
+  };
 
-        if (t.isExportNamedDeclaration(parent)) {
-          replacement = t.exportNamedDeclaration(replacement);
+  return {
+    visitor: {
+      FunctionExpression(path) {
+        if (!t.isVariableDeclarator(path.parent)) {
+          // Must be on a variable declarator
+          return;
         }
 
-        path.parentPath.parentPath.insertBefore(replacement);
+        if (
+          t.isFunctionDeclaration(path.parentPath.scope.block) ||
+          t.isFunctionExpression(path.parentPath.scope.block)
+        ) {
+          // When the function expression is nested inside another function, it may be safe
+          // to turn this into a declaration, if it's only preceded by variable declarations
+          // and assignments (potentially even nested in if-statements)
+          if (!isSafeUntil(path.parentPath.scope.block.body, path.parentPath.parent))
+            return;
+        } else if (!t.isProgram(path.parentPath.scope.block)) {
+          return;
+        }
 
-        if (decls.length <= 1) {
+        const binding = path.scope.getBinding(path.parent.id.name);
+
+        if (
+          (binding.constantViolations && binding.constantViolations.length) ||
+          binding.referencePaths.some(path =>
+            !t.isCallExpression(path.parentPath.node) &&
+            !t.isProgram(path.parentPath.node))
+        ) {
+          // The declaration must not be reassigned and it must only be referenced as plain calls
+          return;
+        }
+
+        const fn = t.functionDeclaration(
+          path.parent.id,
+          path.node.params,
+          path.node.body,
+          path.node.generator,
+          path.node.async,
+        );
+
+        // We insert after other variable declarators to not rely on hoisting and for readability
+        path.parentPath.parentPath.insertAfter(
+          // If the variabe is exported then the function declaration must also be exported.
+          t.isExportNamedDeclaration(path.parentPath.parentPath.parent)
+            ? t.exportNamedDeclaration(fn)
+            : fn
+        );
+
+        if (path.parentPath.parent.declarations.length <= 1) {
           path.parentPath.parentPath.remove();
         } else {
           path.remove();
         }
       }
     }
-  }
-});
+  };
+};
 
-export default plugin;
+export default functionExpressionCleanup;

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -14,6 +14,7 @@ const input = settings.sources.reduce((acc, source) => {
       baseContents: {
         name: source.name,
         private: true,
+        version: '0.0.0',
         main: join(rel, dirname(source.main), basename(source.main, '.js')),
         module: join(rel, source.module),
         types: join(rel, source.types),

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -74,7 +74,6 @@ export const makePlugins = () => [
       babelPluginTransformDebugTarget,
       babelPluginTransformPipe,
       babelPluginTransformInvariant,
-      'babel-plugin-closure-elimination',
       '@babel/plugin-transform-object-assign',
       settings.hasReact && ['@babel/plugin-transform-react-jsx', {
         pragma: 'React.createElement',

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -11,6 +11,7 @@ import visualizer from 'rollup-plugin-visualizer';
 import { terser } from 'rollup-plugin-terser';
 
 import cleanup from './cleanup-plugin.js'
+import babelPluginTransformFunctionExpressions from '../babel/transform-function-expressions';
 import babelPluginTransformPipe from '../babel/transform-pipe';
 import babelPluginTransformInvariant from '../babel/transform-invariant-warning';
 import babelPluginTransformDebugTarget from '../babel/transform-debug-target';
@@ -74,6 +75,7 @@ export const makePlugins = () => [
       babelPluginTransformDebugTarget,
       babelPluginTransformPipe,
       babelPluginTransformInvariant,
+      babelPluginTransformFunctionExpressions,
       '@babel/plugin-transform-object-assign',
       settings.hasReact && ['@babel/plugin-transform-react-jsx', {
         pragma: 'React.createElement',

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -118,9 +118,6 @@ const terserPretty = terser({
   keep_fnames: true,
   ie8: false,
   compress: {
-    // We need to hoist vars for process.env.NODE_ENV if-clauses for Metro:
-    hoist_vars: true,
-    hoist_funs: true,
     pure_getters: true,
     toplevel: true,
     booleans_as_integers: false,
@@ -133,7 +130,10 @@ const terserPretty = terser({
     conditionals: false,
     join_vars: false
   },
-  mangle: false,
+  mangle: {
+    module: true,
+    keep_fnames: true,
+  },
   output: {
     beautify: true,
     braces: true,
@@ -150,6 +150,9 @@ const terserMinified = terser({
     keep_infinity: true,
     pure_getters: true,
     passes: 10
+  },
+  mangle: {
+    module: true,
   },
   output: {
     comments: false

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -7,7 +7,6 @@ import sucrase from '@rollup/plugin-sucrase';
 import buble from '@rollup/plugin-buble';
 import replace from '@rollup/plugin-replace';
 import babel from '@rollup/plugin-babel';
-import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import visualizer from 'rollup-plugin-visualizer';
 import { terser } from 'rollup-plugin-terser';
 
@@ -103,10 +102,6 @@ export const makeOutputPlugins = ({ isProduction, extension }) => {
   return [
     isProduction && replace({
       'process.env.NODE_ENV': JSON.stringify('production')
-    }),
-    !settings.mayReexport && compiler({
-      formatting: 'PRETTY_PRINT',
-      compilation_level: 'SIMPLE_OPTIMIZATIONS'
     }),
     cleanup({ extension }),
     isProduction ? terserMinified : terserPretty,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,11 +3539,6 @@ babel-plugin-apply-mdx-type-prop@1.6.22:
     "@babel/helper-plugin-utils" "7.10.4"
     "@mdx-js/util" "1.6.22"
 
-babel-plugin-closure-elimination@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-closure-elimination/-/babel-plugin-closure-elimination-1.3.2.tgz#2c9a90360bdf888fd3b3694391a745a70ce18c34"
-  integrity sha512-GJnezbVp5ejiwh74fXJPznsrrWHR9bTuJV20FhXivbgEtg1WyNG/9KaDyHEpfU7G9iB6Gy+F2UffYLZ7DJh+Jw==
-
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,27 +2,6 @@
 # yarn lockfile v1
 
 
-"@ampproject/remapping@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-0.2.0.tgz#07290a5c0f5eac8a4c33d38aa0d15a3416db432e"
-  integrity sha512-a4EztS9/GOVQjX5Ol+Iz33TFhaXvYBF7aB6D8+Qz0/SCIxOm3UNRhGZiwcCuJ8/Ifc6NCogp3S48kc5hFxRpUw==
-  dependencies:
-    "@jridgewell/resolve-uri" "1.0.0"
-    sourcemap-codec "1.4.8"
-
-"@ampproject/rollup-plugin-closure-compiler@^0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/rollup-plugin-closure-compiler/-/rollup-plugin-closure-compiler-0.26.0.tgz#69f8265e5fdbf3e26905eaaedc60cb5982bd6be0"
-  integrity sha512-wuHzGE6BDhDR0L7nUPlpQDPGiGnMw+b0B+cDPG0S5TatOmFNQva8KSNdBHan3L9RbvNyYXOXicuCrZtSoBfrBg==
-  dependencies:
-    "@ampproject/remapping" "0.2.0"
-    acorn "7.2.0"
-    acorn-walk "7.1.1"
-    estree-walker "2.0.1"
-    google-closure-compiler "20200517.0.0"
-    magic-string "0.25.7"
-    uuid "8.1.0"
-
 "@babel/cli@^7.5.5":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.12.13.tgz#ae2c6a75fa43f3db4bca0659799b0dfca3f5212b"
@@ -1602,11 +1581,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jridgewell/resolve-uri@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-1.0.0.tgz#3fdf5798f0b49e90155896f6291df186eac06c83"
-  integrity sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==
-
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@manypkg/find-root/-/find-root-1.1.0.tgz#a62d8ed1cd7e7d4c11d9d52a8397460b5d4ad29f"
@@ -2975,20 +2949,10 @@ acorn-jsx@^5.2.0, acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
-acorn-walk@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
-  integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
-
 acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
-
-acorn@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
-  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
 
 acorn@^6.4.1:
   version "6.4.2"
@@ -4558,7 +4522,7 @@ chalk@2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@2.4.2, chalk@2.x, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4860,11 +4824,6 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-clone-buffer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
-  integrity sha1-4+JbIHrE5wGvch4staFnksrD3Fg=
-
 clone-response@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
@@ -4872,29 +4831,10 @@ clone-response@1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clone-stats@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
-  integrity sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=
-
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
-
-clone@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
-cloneable-readable@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/cloneable-readable/-/cloneable-readable-1.1.3.tgz#120a00cb053bfb63a222e709f9683ea2e11d8cec"
-  integrity sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==
-  dependencies:
-    inherits "^2.0.1"
-    process-nextick-args "^2.0.0"
-    readable-stream "^2.3.5"
 
 co@^4.6.0:
   version "4.6.0"
@@ -6792,11 +6732,6 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
-estree-walker@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.1.tgz#f8e030fb21cefa183b44b7ad516b747434e7a3e0"
-  integrity sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
-
 estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
@@ -7900,47 +7835,6 @@ good-listener@^1.2.2:
   integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
   dependencies:
     delegate "^3.1.2"
-
-google-closure-compiler-java@^20200517.0.0:
-  version "20200517.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20200517.0.0.tgz#778370c22273c9085f4cf959ce063f8f112c02ac"
-  integrity sha512-JVZBiyyXwcYi6Yc3lO6dF2hMLJA4OzPm4/mgsem/tF1vk2HsWTnL3GTaBsPB2ENVZp0hoqsd4KgpPiG9ssNWxw==
-
-google-closure-compiler-js@^20200517.0.0:
-  version "20200517.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20200517.0.0.tgz#9cb0861f764073d1c4d3b7453b74073ccb1ecfb1"
-  integrity sha512-dz6dOUHx5nhdIqMRXacAYS8aJfLvw4IKxGg28Hq/zeeDPHlX3P3iBK20NgFDfT8zdushThymtMqChSy7C5eyfA==
-
-google-closure-compiler-linux@^20200517.0.0:
-  version "20200517.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-linux/-/google-closure-compiler-linux-20200517.0.0.tgz#2b9ecb634130060174aff5c52329a694ea4be68b"
-  integrity sha512-S5xPh6TtP+ESzZrmQLcDDqtZAsCVTbdI4VS98wQlN6IMZTd94nAnOCg9mrxQNAgop2t4sdsv/KuH0BGPUWEZ+w==
-
-google-closure-compiler-osx@^20200517.0.0:
-  version "20200517.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-osx/-/google-closure-compiler-osx-20200517.0.0.tgz#9394e9a2fd97e3729fc3bd2abcffff6aab2cfcaa"
-  integrity sha512-FWIcsKqLllLjdOBZd7azijVaObydgRd0obVNi63eUfC5MX6T4qxKumGCyor2UCNY6by2ESz+PlGqCFzFhZ6b2g==
-
-google-closure-compiler-windows@^20200517.0.0:
-  version "20200517.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-windows/-/google-closure-compiler-windows-20200517.0.0.tgz#c5cdde438c29458666a83358567b12072924ed6c"
-  integrity sha512-UXhjRGwS8deTkRla/riyVq3psscgMuw78lepEPtq5NgbumgJzY2+IQP9q+4MVOfJW58Rv0JUWKAFOnBBSZWcAQ==
-
-google-closure-compiler@20200517.0.0:
-  version "20200517.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20200517.0.0.tgz#6c47f99fc1be59bd4f9e23c5a8f2e66d64b54143"
-  integrity sha512-80W9zBS9Ajk1T5InWCfsoPohDmo5T1AAyw1rHh5+dgb/jPgwC65KhY+oJozTncf+/7tyQHJXozTARwhSlBUcMg==
-  dependencies:
-    chalk "2.x"
-    google-closure-compiler-java "^20200517.0.0"
-    google-closure-compiler-js "^20200517.0.0"
-    minimist "1.x"
-    vinyl "2.x"
-    vinyl-sourcemaps-apply "^0.2.0"
-  optionalDependencies:
-    google-closure-compiler-linux "^20200517.0.0"
-    google-closure-compiler-osx "^20200517.0.0"
-    google-closure-compiler-windows "^20200517.0.0"
 
 got@^8.3.1:
   version "8.3.2"
@@ -10307,7 +10201,7 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
-magic-string@0.25.7, magic-string@^0.25.0, magic-string@^0.25.7:
+magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -10712,7 +10606,7 @@ minimist@1.2.3:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
   integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
 
-minimist@1.x, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -12361,7 +12255,7 @@ prismjs@^1.21.0, prismjs@~1.23.0:
   optionalDependencies:
     clipboard "^2.0.0"
 
-process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
+process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
@@ -13514,11 +13408,6 @@ repeat-string@^1.5.4, repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-replace-ext@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.1.tgz#2d6d996d04a15855d967443631dd5f77825b016a"
-  integrity sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==
-
 request-promise-core@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
@@ -14354,7 +14243,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
-source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.6, source-map@^0.5.7:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -14369,7 +14258,7 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourcemap-codec@1.4.8, sourcemap-codec@^1.4.4:
+sourcemap-codec@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -15923,11 +15812,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
-  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
-
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -16011,25 +15895,6 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
-
-vinyl-sourcemaps-apply@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
-  integrity sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=
-  dependencies:
-    source-map "^0.5.1"
-
-vinyl@2.x:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.2.1.tgz#23cfb8bbab5ece3803aa2c0a1eb28af7cbba1974"
-  integrity sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==
-  dependencies:
-    clone "^2.1.1"
-    clone-buffer "^1.0.0"
-    clone-stats "^1.0.0"
-    cloneable-readable "^1.0.0"
-    remove-trailing-separator "^1.0.1"
-    replace-ext "^1.0.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
Fixes: https://github.com/FormidableLabs/urql/issues/1552

## Summary

The current rollup plugin isn't really maintained and we were seeing frequent issues with metro and bundles compiled by closure

## Set of changes

- remove `rollup-plugin-closure-compiler`
