### PR TITLE
(docs) - missing import/dependency in Next.js example

### DIFF
--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -185,9 +185,9 @@ To set up `next-urql`, first we'll install `next-urql` with `react-is` and `urql
 peer dependencies:
 
 ```sh
-yarn add next-urql react-is urql
+yarn add next-urql react-is urql graphql
 # or
-npm install --save next-urql react-is urql
+npm install --save next-urql react-is urql graphql
 ```
 
 The peer dependency on `react-is` is inherited from `react-ssr-prepass` requiring it.
@@ -204,6 +204,7 @@ Optimization"](https://nextjs.org/docs/advanced-features/automatic-static-optimi
 // pages/index.js
 import React from 'react';
 import Head from 'next/head';
+import { useQuery } from "urql";
 import { withUrqlClient } from 'next-urql';
 
 const Index = () => {


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Adds in a missing import and dependency to Next.js examples, improving the 'get started' experience

## Set of changes

- Adds `graphql` to dependency list for Next.js (app errors without this)
- Adds `useQuery` import from `urql` to Next.js example