### PR TITLE
(docs) Improve retryIf function in example

### DIFF
--- a/docs/advanced/retry-operations.md
+++ b/docs/advanced/retry-operations.md
@@ -79,7 +79,7 @@ const client = createClient({
     cacheExchange,
     retryExchange({
       retryIf: error => {
-        return Boolean(error && (error.graphQLErrors.length > 0 || error.networkError));
+        return !!(error.graphQLErrors.length > 0 || error.networkError);
       },
     }),
     fetchExchange,

--- a/docs/advanced/retry-operations.md
+++ b/docs/advanced/retry-operations.md
@@ -79,9 +79,7 @@ const client = createClient({
     cacheExchange,
     retryExchange({
       retryIf: error => {
-        if ((error && error.graphQLErrors.length > 0) || error.networkError) {
-          return true;
-        }
+        return Boolean(error && (error.graphQLErrors.length > 0 || error.networkError));
       },
     }),
     fetchExchange,


### PR DESCRIPTION
## Summary

In the docs, the existing retryIf condition could fail if error is not defined. That's why I wanted to check error is defined before checking for graphQLErrors or networkError
