### PR TITLE
(introspection) - Add options to include more schema info to minifyIntrospectionQuery

### DIFF
--- a/.changeset/lovely-hounds-tap.md
+++ b/.changeset/lovely-hounds-tap.md
@@ -1,0 +1,5 @@
+---
+'@urql/introspection': minor
+---
+
+Add `includeScalars` option to `@urql/introspection`'s `minifyIntrospectionQuery`

--- a/.changeset/lovely-hounds-tap.md
+++ b/.changeset/lovely-hounds-tap.md
@@ -2,4 +2,6 @@
 '@urql/introspection': minor
 ---
 
-Add `includeScalars` option to `@urql/introspection`'s `minifyIntrospectionQuery`
+Add options to `@urql/introspection`'s `minifyIntrospectionQuery` allowing the inclusion of more
+information into the minified schema as needed, namely `includeScalars`, `includeEnums`,
+`includeInputs`, and `includeDirectives`.

--- a/packages/introspection/src/minifyIntrospectionQuery.ts
+++ b/packages/introspection/src/minifyIntrospectionQuery.ts
@@ -49,7 +49,7 @@ const mapType = (fromType: any): IntrospectionTypeRef => {
 };
 
 const minifyIntrospectionType = (
-  type: IntrospectionType,
+  type: IntrospectionType
 ): IntrospectionType => {
   switch (type.kind) {
     case 'SCALAR':
@@ -62,9 +62,12 @@ const minifyIntrospectionType = (
       return {
         kind: 'ENUM',
         name: type.name,
-        enumValues: type.enumValues.map(value => ({
-          name: value.name,
-        }) as any)
+        enumValues: type.enumValues.map(
+          value =>
+            ({
+              name: value.name,
+            } as any)
+        ),
       };
 
     case 'INPUT_OBJECT': {
@@ -72,12 +75,13 @@ const minifyIntrospectionType = (
         kind: 'INPUT_OBJECT',
         name: type.name,
         inputFields: type.inputFields.map(
-          field => ({
-            name: field.name,
-            type: mapType(field.type),
-            defaultValue: field.defaultValue || undefined,
-          }) as IntrospectionInputValue
-        )
+          field =>
+            ({
+              name: field.name,
+              type: mapType(field.type),
+              defaultValue: field.defaultValue || undefined,
+            } as IntrospectionInputValue)
+        ),
       };
     }
 
@@ -210,11 +214,14 @@ export const minifyIntrospectionQuery = (
     name: directive.name,
     isRepeatable: directive.isRepeatable ? true : undefined,
     locations: directive.locations,
-    args: directive.args.map(arg => ({
-      name: arg.name,
-      type: mapType(arg.type),
-      defaultValue: arg.defaultValue || undefined,
-    }) as IntrospectionInputValue),
+    args: directive.args.map(
+      arg =>
+        ({
+          name: arg.name,
+          type: mapType(arg.type),
+          defaultValue: arg.defaultValue || undefined,
+        } as IntrospectionInputValue)
+    ),
   }));
 
   if (!_includeScalars || !_includeEnums || !_includeInputs || _hasAnyType) {
@@ -227,9 +234,7 @@ export const minifyIntrospectionQuery = (
       mutationType,
       subscriptionType,
       types: minifiedTypes,
-      directives: opts.includeDirectives
-        ? minifiedDirectives
-        : [],
+      directives: opts.includeDirectives ? minifiedDirectives : [],
     },
   };
 };

--- a/packages/introspection/src/minifyIntrospectionQuery.ts
+++ b/packages/introspection/src/minifyIntrospectionQuery.ts
@@ -4,7 +4,8 @@ import {
   IntrospectionTypeRef,
 } from 'graphql';
 
-let _includeScalars: boolean = false;
+let _includeScalars = false;
+let _hasAnyType = false;
 
 const anyType: IntrospectionTypeRef = {
   kind: 'SCALAR',
@@ -21,10 +22,12 @@ const mapType = (fromType: any): IntrospectionTypeRef => {
       };
 
     case 'SCALAR':
+      _hasAnyType = _hasAnyType || _includeScalars;
       return _includeScalars ? fromType : anyType;
 
     case 'INPUT_OBJECT':
     case 'ENUM':
+      _hasAnyType = true;
       return anyType;
 
     case 'OBJECT':
@@ -138,6 +141,7 @@ export const minifyIntrospectionQuery = (
     throw new TypeError('Expected to receive an IntrospectionQuery.');
   }
 
+  _hasAnyType = false;
   _includeScalars = !!opts.includeScalars;
 
   const {
@@ -167,7 +171,7 @@ export const minifyIntrospectionQuery = (
     })
     .map(minifyIntrospectionType);
 
-  if (_includeScalars) {
+  if (!_includeScalars || _hasAnyType) {
     minifiedTypes.push({ kind: 'SCALAR', name: anyType.name });
   }
 

--- a/packages/introspection/src/minifyIntrospectionQuery.ts
+++ b/packages/introspection/src/minifyIntrospectionQuery.ts
@@ -210,7 +210,7 @@ export const minifyIntrospectionQuery = (
     })
     .map(minifyIntrospectionType);
 
-  const minifiedDirectives = directives.map(directive => ({
+  const minifiedDirectives = (directives || []).map(directive => ({
     name: directive.name,
     isRepeatable: directive.isRepeatable ? true : undefined,
     locations: directive.locations,


### PR DESCRIPTION
Resolve: #1577

## Summary

Some other tools may want to use the schema for other purposes, which has the prerequisite of more information having to be included in the schema; namely, the `customScalarsExchange` (a third-party one) requires scalar information to map any kind of scalar values in a result.

It's also imagineable that other information is needed so this PR adds options to now allow the inclusion of all schema information separately, which is still excluded by default.