### PR TITLE
(docs) Add Vite-specific installation instructions

### DIFF
--- a/docs/basics/svelte.md
+++ b/docs/basics/svelte.md
@@ -31,6 +31,17 @@ all `@urql/svelte` packages will define a range of compatible versions of `graph
 for breaking changes in the future however, in which case your package manager may warn you about
 `graphql` being out of the defined peer dependency range.
 
+Note: if using Vite as your bundler, you might stumble upon the error `Function called outside component initialization`, which will prevent the page from loading. To fix it, you must add `@urql/svelte` to Vite's configuration property [`optimizeDeps.exclude`](https://vitejs.dev/config/#dep-optimization-options):
+
+```js
+{
+  optimizeDeps: {
+    exclude: ['@urql/svelte'],
+  }
+  // other properties
+}
+```
+
 ### Setting up the `Client`
 
 The `@urql/svelte` package exports a method called `createClient` which we can use to create


### PR DESCRIPTION
## Summary

When using either this or other GraphQL clients together with Vite it's common to encounter this error:

```
Uncaught Error: Function called outside component initialization
    at get_current_component (index.mjs:649)
    at setContext (index.mjs:679)
    at setClient (context.ts:11)
```

The fix is simple, as seen in the changes, but in spite of that there exist very few resources that provide a concrete solution to it. Many threads are open on both StackOverflow and Github on this issue, so I believe specifying the solution in the docs will help a lot of developers in the long run.
