### PR TITLE
(graphcache) - Improve internal typings for lists, scalars, and overall cleanliness

### DIFF
--- a/.changeset/bright-tools-taste.md
+++ b/.changeset/bright-tools-taste.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix up internal types in Graphcache to improve their accuracy for catching more edge cases in its implementation. This only affects you if you previously imported any type related to `ScalarObject` from Graphcache which now is a more opaque type. We've also adjusted the `NullArray` types to be potentially nested, since lists in GraphQL can be nested arbitarily, which we were covering but didn't reflect in our types.

--- a/exchanges/graphcache/src/extras/relayPagination.ts
+++ b/exchanges/graphcache/src/extras/relayPagination.ts
@@ -39,14 +39,14 @@ const concatEdges = (
 ) => {
   const ids = new Set<string>();
   for (let i = 0, l = leftEdges.length; i < l; i++) {
-    const edge = leftEdges[i];
+    const edge = leftEdges[i] as string | null;
     const node = cache.resolve(edge, 'node');
     if (typeof node === 'string') ids.add(node);
   }
 
   const newEdges = leftEdges.slice();
   for (let i = 0, l = rightEdges.length; i < l; i++) {
-    const edge = rightEdges[i];
+    const edge = rightEdges[i] as string | null;
     const node = cache.resolve(edge, 'node');
     if (typeof node === 'string' && !ids.has(node)) {
       ids.add(node);
@@ -163,7 +163,7 @@ const getPage = (
     });
 
     if (pageInfo.endCursor === null) {
-      const edge = edges[edges.length - 1];
+      const edge = edges[edges.length - 1] as string | null;
       if (edge) {
         const endCursor = cache.resolve(edge, 'cursor');
         pageInfo.endCursor = ensureKey(endCursor);
@@ -171,7 +171,7 @@ const getPage = (
     }
 
     if (pageInfo.startCursor === null) {
-      const edge = edges[0];
+      const edge = edges[0] as string | null;
       if (edge) {
         const startCursor = cache.resolve(edge, 'cursor');
         pageInfo.startCursor = ensureKey(startCursor);

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -1,5 +1,5 @@
 import * as InMemoryData from '../store/data';
-import { FieldArguments } from '../types';
+import { FieldArgs } from '../types';
 import { keyOfField } from '../store';
 
 interface PartialFieldInfo {
@@ -9,7 +9,7 @@ interface PartialFieldInfo {
 export const invalidateEntity = (
   entityKey: string,
   field?: string,
-  args?: FieldArguments
+  args?: FieldArgs
 ) => {
   const fields: PartialFieldInfo[] = field
     ? [{ fieldKey: keyOfField(field, args) }]

--- a/exchanges/graphcache/src/operations/invalidate.ts
+++ b/exchanges/graphcache/src/operations/invalidate.ts
@@ -1,5 +1,5 @@
 import * as InMemoryData from '../store/data';
-import { Variables } from '../types';
+import { FieldArguments } from '../types';
 import { keyOfField } from '../store';
 
 interface PartialFieldInfo {
@@ -9,7 +9,7 @@ interface PartialFieldInfo {
 export const invalidateEntity = (
   entityKey: string,
   field?: string,
-  args?: Variables | null
+  args?: FieldArguments
 ) => {
   const fields: PartialFieldInfo[] = field
     ? [{ fieldKey: keyOfField(field, args) }]

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -19,7 +19,6 @@ import {
   DataField,
   Link,
   OperationRequest,
-  NullArray,
   Dependencies,
 } from '../types';
 
@@ -153,8 +152,8 @@ const readRoot = (
 const readRootField = (
   ctx: Context,
   select: SelectionSet,
-  originalData: null | Data | NullArray<Data>
-): Data | NullArray<Data> | null => {
+  originalData: Link<Data>
+): Link<Data> => {
   if (Array.isArray(originalData)) {
     const newData = new Array(originalData.length);
     for (let i = 0, l = originalData.length; i < l; i++) {

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -338,7 +338,7 @@ const readSelection = (
 
       dataFieldValue = resolvers[fieldName](
         data,
-        fieldArgs || ({} as Data),
+        fieldArgs || ({} as Variables),
         store,
         ctx
       );

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -299,8 +299,13 @@ const updateRCForLink = (
   if (typeof link === 'string') {
     updateRCForEntity(gc, refCount, link, by);
   } else if (Array.isArray(link)) {
-    for (let i = 0, l = link.length; i < l; i++)
-      updateRCForLink(gc, refCount, link[i], by);
+    for (let i = 0, l = link.length; i < l; i++) {
+      if (Array.isArray(link[i])) {
+        updateRCForLink(gc, refCount, link[i], by);
+      } else if (link[i]) {
+        updateRCForEntity(gc, refCount, link[i] as string, by);
+      }
+    }
   }
 };
 

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -299,12 +299,8 @@ const updateRCForLink = (
   if (typeof link === 'string') {
     updateRCForEntity(gc, refCount, link, by);
   } else if (Array.isArray(link)) {
-    for (let i = 0, l = link.length; i < l; i++) {
-      const entityKey = link[i];
-      if (entityKey) {
-        updateRCForEntity(gc, refCount, entityKey, by);
-      }
-    }
+    for (let i = 0, l = link.length; i < l; i++)
+      updateRCForLink(gc, refCount, link[i], by);
   }
 };
 

--- a/exchanges/graphcache/src/store/keys.ts
+++ b/exchanges/graphcache/src/store/keys.ts
@@ -1,7 +1,7 @@
 import { stringifyVariables } from '@urql/core';
-import { FieldArguments, FieldInfo, KeyInfo } from '../types';
+import { FieldArgs, FieldInfo, KeyInfo } from '../types';
 
-export const keyOfField = (fieldName: string, args?: FieldArguments) =>
+export const keyOfField = (fieldName: string, args?: FieldArgs) =>
   args ? `${fieldName}(${stringifyVariables(args)})` : fieldName;
 
 export const joinKeys = (parentKey: string, key: string) =>

--- a/exchanges/graphcache/src/store/keys.ts
+++ b/exchanges/graphcache/src/store/keys.ts
@@ -1,7 +1,7 @@
 import { stringifyVariables } from '@urql/core';
-import { Variables, FieldInfo, KeyInfo } from '../types';
+import { FieldArguments, FieldInfo, KeyInfo } from '../types';
 
-export const keyOfField = (fieldName: string, args?: null | Variables) =>
+export const keyOfField = (fieldName: string, args?: FieldArguments) =>
   args ? `${fieldName}(${stringifyVariables(args)})` : fieldName;
 
 export const joinKeys = (parentKey: string, key: string) =>

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -7,12 +7,14 @@ import {
   ResolverConfig,
   DataField,
   Variables,
+  FieldArguments,
   Data,
   QueryInput,
   UpdatesConfig,
   UpdateResolver,
   OptimisticMutationConfig,
   KeyingConfig,
+  Entity,
 } from '../types';
 
 import { invariant } from '../helpers/help';
@@ -106,7 +108,7 @@ export class Store implements Cache {
 
   keyOfField = keyOfField;
 
-  keyOfEntity(data: Data | null | string) {
+  keyOfEntity(data: Entity) {
     // In resolvers and updaters we may have a specific parent
     // object available that can be used to skip to a specific parent
     // key directly without looking at its incomplete properties
@@ -129,11 +131,7 @@ export class Store implements Cache {
     return key ? `${data.__typename}:${key}` : null;
   }
 
-  resolve(
-    entity: Data | string | null,
-    field: string,
-    args?: Variables
-  ): DataField {
+  resolve(entity: Entity, field: string, args?: FieldArguments): DataField {
     const fieldKey = keyOfField(field, args);
     const entityKey = this.keyOfEntity(entity);
     if (!entityKey) return null;
@@ -145,11 +143,7 @@ export class Store implements Cache {
 
   resolveFieldByKey = this.resolve;
 
-  invalidate(
-    entity: Data | string | null,
-    field?: string,
-    args?: Variables | null
-  ) {
+  invalidate(entity: Entity, field?: string, args?: FieldArguments) {
     const entityKey = this.keyOfEntity(entity);
 
     invariant(
@@ -166,7 +160,7 @@ export class Store implements Cache {
     invalidateEntity(entityKey, field, args);
   }
 
-  inspectFields(entity: Data | string | null): FieldInfo[] {
+  inspectFields(entity: Entity): FieldInfo[] {
     const entityKey = this.keyOfEntity(entity);
     return entityKey ? InMemoryData.inspectFields(entityKey) : [];
   }

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -7,7 +7,7 @@ import {
   ResolverConfig,
   DataField,
   Variables,
-  FieldArguments,
+  FieldArgs,
   Data,
   QueryInput,
   UpdatesConfig,
@@ -131,7 +131,7 @@ export class Store implements Cache {
     return key ? `${data.__typename}:${key}` : null;
   }
 
-  resolve(entity: Entity, field: string, args?: FieldArguments): DataField {
+  resolve(entity: Entity, field: string, args?: FieldArgs): DataField {
     const fieldKey = keyOfField(field, args);
     const entityKey = this.keyOfEntity(entity);
     if (!entityKey) return null;
@@ -143,7 +143,7 @@ export class Store implements Cache {
 
   resolveFieldByKey = this.resolve;
 
-  invalidate(entity: Entity, field?: string, args?: FieldArguments) {
+  invalidate(entity: Entity, field?: string, args?: FieldArgs) {
     const entityKey = this.keyOfEntity(entity);
 
     invariant(

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -23,8 +23,8 @@ export interface SystemFields {
   id?: string | number | null;
 }
 
-export type EntityField = undefined | Scalar | Scalar[];
-export type DataField = Scalar | Data | NullArray<Data | Scalar>;
+export type EntityField = undefined | Scalar | NullArray<Scalar>;
+export type DataField = Scalar | Data | NullArray<Scalar> | NullArray<Data>;
 
 export interface DataFields {
   [fieldName: string]: DataField;

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -36,9 +36,10 @@ export interface Variables {
 }
 
 export type Data = SystemFields & DataFields;
+export type Entity = null | Data | string;
 export type Link<Key = string> = null | Key | NullArray<Key>;
-export type ResolvedLink = Link<Data>;
 export type Connection = [Variables, string];
+export type FieldArguments = Variables | null | undefined;
 
 export interface FieldInfo {
   fieldKey: string;
@@ -78,33 +79,22 @@ export interface QueryInput<T = Data, V = Variables> {
 
 export interface Cache {
   /** keyOfEntity() returns the key for an entity or null if it's unkeyable */
-  keyOfEntity(data: Data | null | string): string | null;
+  keyOfEntity(entity: Entity): string | null;
 
   /** keyOfField() returns the key for a field */
-  keyOfField(
-    fieldName: string,
-    args?: Variables | null | undefined
-  ): string | null;
+  keyOfField(fieldName: string, args?: FieldArguments): string | null;
 
   /** resolve() retrieves the value (or link) of a field on any entity, given a partial/keyable entity or an entity key */
-  resolve(
-    entity: Data | string | null,
-    fieldName: string,
-    args?: Variables
-  ): DataField;
+  resolve(entity: Entity, fieldName: string, args?: FieldArguments): DataField;
 
   /** @deprecated use resolve() instead */
-  resolveFieldByKey(entity: Data | string | null, fieldKey: string): DataField;
+  resolveFieldByKey(entity: Entity, fieldKey: string): DataField;
 
   /** inspectFields() retrieves all known fields for a given entity */
-  inspectFields(entity: Data | string | null): FieldInfo[];
+  inspectFields(entity: Entity): FieldInfo[];
 
   /** invalidate() invalidates an entity or a specific field of an entity */
-  invalidate(
-    entity: Data | string | null,
-    fieldName?: string,
-    args?: Variables
-  ): void;
+  invalidate(entity: Entity, fieldName?: string, args?: FieldArguments): void;
 
   /** updateQuery() can be used to update the data of a given query using an updater function */
   updateQuery<T = Data, V = Variables>(
@@ -172,7 +162,7 @@ export type OptimisticMutationResolver = (
   vars: Variables,
   cache: Cache,
   info: ResolveInfo
-) => null | Data | NullArray<Data>;
+) => Link<Data>;
 
 export interface OptimisticMutationConfig {
   [mutationFieldName: string]: OptimisticMutationResolver;

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -39,7 +39,7 @@ export type Data = SystemFields & DataFields;
 export type Entity = null | Data | string;
 export type Link<Key = string> = null | Key | NullArray<Key>;
 export type Connection = [Variables, string];
-export type FieldArguments = Variables | null | undefined;
+export type FieldArgs = Variables | null | undefined;
 
 export interface FieldInfo {
   fieldKey: string;
@@ -82,10 +82,10 @@ export interface Cache {
   keyOfEntity(entity: Entity): string | null;
 
   /** keyOfField() returns the key for a field */
-  keyOfField(fieldName: string, args?: FieldArguments): string | null;
+  keyOfField(fieldName: string, args?: FieldArgs): string | null;
 
   /** resolve() retrieves the value (or link) of a field on any entity, given a partial/keyable entity or an entity key */
-  resolve(entity: Entity, fieldName: string, args?: FieldArguments): DataField;
+  resolve(entity: Entity, fieldName: string, args?: FieldArgs): DataField;
 
   /** @deprecated use resolve() instead */
   resolveFieldByKey(entity: Entity, fieldKey: string): DataField;
@@ -94,7 +94,7 @@ export interface Cache {
   inspectFields(entity: Entity): FieldInfo[];
 
   /** invalidate() invalidates an entity or a specific field of an entity */
-  invalidate(entity: Entity, fieldName?: string, args?: FieldArguments): void;
+  invalidate(entity: Entity, fieldName?: string, args?: FieldArgs): void;
 
   /** updateQuery() can be used to update the data of a given query using an updater function */
   updateQuery<T = Data, V = Variables>(

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -2,7 +2,7 @@ import { TypedDocumentNode } from '@urql/core';
 import { GraphQLError, DocumentNode, FragmentDefinitionNode } from 'graphql';
 
 // Helper types
-export type NullArray<T> = Array<null | T>;
+export type NullArray<T> = Array<null | T | NullArray<T>>;
 
 export interface Fragments {
   [fragmentName: string]: void | FragmentDefinitionNode;
@@ -12,8 +12,7 @@ export interface Fragments {
 export type Primitive = null | number | boolean | string;
 
 export interface ScalarObject {
-  __typename?: never;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export type Scalar = Primitive | ScalarObject;
@@ -25,7 +24,7 @@ export interface SystemFields {
 }
 
 export type EntityField = undefined | Scalar | Scalar[];
-export type DataField = Scalar | Scalar[] | Data | NullArray<Data>;
+export type DataField = Scalar | Data | NullArray<Data | Scalar>;
 
 export interface DataFields {
   [fieldName: string]: DataField;


### PR DESCRIPTION
This is a supporting PR for #1551 and #901 and some commits were lifted from other branches into this new PR.

## Summary

Some types in Graphcache weren't accurate enough, especially when using them as extensions for generated types, for conveying the intent of some methods on `Store` / `Cache`, and lastly when typing some scalar and link fields.

Mainly interesting is that `FieldArgs` is a new type that was generalisable, because it was used in this form quite frequently. It's simply `undefined | null | Variables`, a common input for a field's arguments.

The other adjustment that's notable is that `NullArray` can now be nested in on itself, because lists in GraphQL can be nested arbitrarily often. (There was actually one case where Graphcache wasn't handling this well in reference counting)

And lastly, the `ScalarObject` type previously forbid the `__typename` field although a scalar should technically be entirely opaque to us. So we've swapped this out with a type that reflects each field's value type as `unknown`

`7.15kB => 7.16kB minzipped`

## Set of changes

- Add `FieldArgs` type to `store.ts`
- Update reference counting to handle nested lists for links
- Add `Entity` type as a generic entity reference (either as a key or partial entity)
- Update `NullArray` to be recursive
