### PR TITLE
[@urql/vue] Allow client to be passed to useQuery, useMutation and useSubscription

### DIFF
--- a/.changeset/nine-wolves-suffer.md
+++ b/.changeset/nine-wolves-suffer.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': minor
+---
+
+Allow client to be passed to useQuery, useMutation and useSubscription

--- a/docs/api/vue.md
+++ b/docs/api/vue.md
@@ -16,8 +16,9 @@ Accepts a single required options object as an input with the following properti
 | `requestPolicy` | `?RequestPolicy`         | An optional [request policy](./core.md#requestpolicy) that should be used specifying the cache strategy. |
 | `pause`         | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/vue.md#pausing-usequery).                  |
 | `context`       | `?object`                | Holds the contextual information for the query.                                                          |
+| `client`        | `?Urql.Client`           | Client to use. If not provided will use client provided in parent component with `provideClient()`.      |
 
-Each of these inputs may also be [reactive](https://v3.vuejs.org/api/refs-api.html) (e.g. a `ref`)
+Each of these inputs (except `client`) may also be [reactive](https://v3.vuejs.org/api/refs-api.html) (e.g. a `ref`)
 and are allowed to change over time which will issue a new query.
 
 This function returns an object with the shape of an [`OperationResult`](./core.md#operationresult)
@@ -46,7 +47,7 @@ once a result from the API is available.
 
 ## useMutation
 
-Accepts a single `query` argument of type `string | DocumentNode` and returns a result object with
+Accepts a `query` argument of type `string | DocumentNode` and an optional `client` argument of type `Urql.Client`, returns a result object with
 the shape of an [`OperationResult`](./core.md#operationresult) with an added `fetching` property.
 
 All of the properties on this result object are also marked as
@@ -64,12 +65,13 @@ page.](../basics/vue.md#mutations)
 
 Accepts a single required options object as an input with the following properties:
 
-| Prop        | Type                     | Description                                                                             |
-| ----------- | ------------------------ | --------------------------------------------------------------------------------------- |
-| `query`     | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.      |
-| `variables` | `?object`                | The variables to be used with the GraphQL request.                                      |
-| `pause`     | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/vue.md#pausing-usequery). |
-| `context`   | `?object`                | Holds the contextual information for the subscription.                                  |
+| Prop        | Type                     | Description                                                                                         |
+| ----------- | ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `query`     | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.                  |
+| `variables` | `?object`                | The variables to be used with the GraphQL request.                                                  |
+| `pause`     | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/vue.md#pausing-usequery).             |
+| `context`   | `?object`                | Holds the contextual information for the subscription.                                              |
+| `client`    | `?Urql.Client`           | Client to use. If not provided will use client provided in parent component with `provideClient()`. |
 
 Each of these inputs may also be [reactive](https://v3.vuejs.org/api/refs-api.html) (e.g. a `ref`)
 and are allowed to change over time which will issue a new query.

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -31,7 +31,7 @@ export function useMutation<T = any, V = any>(
   query: TypedDocumentNode<T, V> | DocumentNode | string,
   client?: Client
 ): UseMutationResponse<T, V> {
-  const _client = client || useClient();
+  const _client = client || useClient(); // eslint-disable-line react-hooks/rules-of-hooks
 
   const data: Ref<T | undefined> = ref();
   const stale: Ref<boolean> = ref(false);

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -31,7 +31,7 @@ export function useMutation<T = any, V = any>(
   query: TypedDocumentNode<T, V> | DocumentNode | string,
   client?: Client
 ): UseMutationResponse<T, V> {
-  let _client = client ?? useClient();
+  const _client = client || useClient();
 
   const data: Ref<T | undefined> = ref();
   const stale: Ref<boolean> = ref(false);

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -7,6 +7,7 @@ import {
   Operation,
   OperationContext,
   OperationResult,
+  Client,
 } from '@urql/core';
 
 import { useClient } from './useClient';
@@ -27,9 +28,10 @@ export interface UseMutationState<T, V> {
 export type UseMutationResponse<T, V> = UseMutationState<T, V>;
 
 export function useMutation<T = any, V = any>(
-  query: TypedDocumentNode<T, V> | DocumentNode | string
+  query: TypedDocumentNode<T, V> | DocumentNode | string,
+  client?: Client
 ): UseMutationResponse<T, V> {
-  const client = useClient();
+  let _client = client ?? useClient();
 
   const data: Ref<T | undefined> = ref();
   const stale: Ref<boolean> = ref(false);
@@ -50,7 +52,7 @@ export function useMutation<T = any, V = any>(
       context?: Partial<OperationContext>
     ): Promise<OperationResult<T, V>> {
       fetching.value = true;
-      return client
+      return _client
         .mutation(query, variables as any, context)
         .toPromise()
         .then((res: OperationResult) => {

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -92,7 +92,7 @@ export function useQuery<T = any, V = object>(
   _args: UseQueryArgs<T, V>
 ): UseQueryResponse<T, V> {
   const args = reactive(_args);
-  const client = _args.client || useClient();
+  const client = _args.client || useClient(); // eslint-disable-line react-hooks/rules-of-hooks
 
   const data: Ref<T | undefined> = ref();
   const stale: Ref<boolean> = ref(false);

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -28,6 +28,7 @@ import {
   Operation,
   createRequest,
   GraphQLRequest,
+  Client,
 } from '@urql/core';
 
 import { useClient } from './useClient';
@@ -40,6 +41,7 @@ export interface UseQueryArgs<T = any, V = object> {
   requestPolicy?: MaybeRef<RequestPolicy>;
   context?: MaybeRef<Partial<OperationContext>>;
   pause?: MaybeRef<boolean>;
+  client?: Client;
 }
 
 export type QueryPartialState<T = any, V = object> = Partial<
@@ -90,7 +92,7 @@ export function useQuery<T = any, V = object>(
   _args: UseQueryArgs<T, V>
 ): UseQueryResponse<T, V> {
   const args = reactive(_args);
-  const client = useClient();
+  const client = _args.client ?? useClient();
 
   const data: Ref<T | undefined> = ref();
   const stale: Ref<boolean> = ref(false);

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -92,7 +92,7 @@ export function useQuery<T = any, V = object>(
   _args: UseQueryArgs<T, V>
 ): UseQueryResponse<T, V> {
   const args = reactive(_args);
-  const client = _args.client ?? useClient();
+  const client = _args.client || useClient();
 
   const data: Ref<T | undefined> = ref();
   const stale: Ref<boolean> = ref(false);

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -55,7 +55,7 @@ export function useSubscription<T = any, R = T, V = object>(
   handler?: MaybeRef<SubscriptionHandler<T, R>>
 ): UseSubscriptionResponse<T, R, V> {
   const args = reactive(_args);
-  const client = _args.client || useClient();
+  const client = _args.client || useClient(); // eslint-disable-line react-hooks/rules-of-hooks
 
   const data: Ref<R | undefined> = ref();
   const stale: Ref<boolean> = ref(false);

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -22,7 +22,7 @@ export interface UseSubscriptionArgs<T = any, V = object> {
   variables?: MaybeRef<V>;
   pause?: MaybeRef<boolean>;
   context?: MaybeRef<Partial<OperationContext>>;
-  client?: Client
+  client?: Client;
 }
 
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
@@ -55,7 +55,7 @@ export function useSubscription<T = any, R = T, V = object>(
   handler?: MaybeRef<SubscriptionHandler<T, R>>
 ): UseSubscriptionResponse<T, R, V> {
   const args = reactive(_args);
-  const client = _args.client ?? useClient();
+  const client = _args.client || useClient();
 
   const data: Ref<R | undefined> = ref();
   const stale: Ref<boolean> = ref(false);

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -10,6 +10,7 @@ import {
   Operation,
   createRequest,
   GraphQLRequest,
+  Client,
 } from '@urql/core';
 
 import { useClient } from './useClient';
@@ -21,6 +22,7 @@ export interface UseSubscriptionArgs<T = any, V = object> {
   variables?: MaybeRef<V>;
   pause?: MaybeRef<boolean>;
   context?: MaybeRef<Partial<OperationContext>>;
+  client?: Client
 }
 
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
@@ -53,7 +55,7 @@ export function useSubscription<T = any, R = T, V = object>(
   handler?: MaybeRef<SubscriptionHandler<T, R>>
 ): UseSubscriptionResponse<T, R, V> {
   const args = reactive(_args);
-  const client = useClient();
+  const client = _args.client ?? useClient();
 
   const data: Ref<R | undefined> = ref();
   const stale: Ref<boolean> = ref(false);


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

Resolves  #1445

## Summary

<!-- What's the motivation of this change? What does it solve? -->

With Vue 3 you can use a an `async setup` function as also [described in the docs](https://formidable.com/open-source/urql/docs/basics/vue/#vue-suspense). This allows you to `await` promise-returning functions such as `useQuery`. There is one downside, however. Vue's dependency injection mechanism `inject` / `provide` does not work after an `await` in an `async setup` function.

Because `useQuery`, `useMutation` and `useSubscription` all call `useClient`, which in turn calls `inject`, that means it's not possible to, for example:

  - Have an `async setup` function where you `await` two queries, with the result of one query being used as an input to the second query.
  - Call `useMutation` after having `await`ing an `useQuery` call. This can often make a lot of sense. The whole idea of the Composition API is to [group code for related logic together](https://v3.vuejs.org/guide/composition-api-introduction.html). But not being able to call `useMutation` in a place where it makes sense breaks this idea.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

The solution to the problem above is to allow passing of a `client` to `useQuery`, `useMutation` and `useSubscription`. The default behavior is unchanged so this is a fully backward-compatible change. But users of `async setup` will be able to use `useClient` at the top of their `async setup` and pass that client explicitly to all calls to `useQuery`, `useMutation` and `useSubscription`.
