### PR TITLE
(core) - Fix concurrent operations not respecting request policies

### DIFF
--- a/.changeset/new-dingos-clean.md
+++ b/.changeset/new-dingos-clean.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix a regression in `@urql/core@2.1.1` that prevented concurrent operations from being dispatched with differing request policies, which for instance prevented the explicit `executeQuery` calls on bindings to fail.

--- a/packages/core/src/utils/streamUtils.ts
+++ b/packages/core/src/utils/streamUtils.ts
@@ -1,66 +1,9 @@
-import {
-  Operator,
-  Source,
-  pipe,
-  toPromise,
-  take,
-  share,
-  onPush,
-  onStart,
-  onEnd,
-  subscribe,
-  make,
-} from 'wonka';
+import { Source, pipe, toPromise, take } from 'wonka';
 
-import { OperationResult, PromisifiedSource } from '../types';
+import { PromisifiedSource } from '../types';
 
 export function withPromise<T>(source$: Source<T>): PromisifiedSource<T> {
   (source$ as PromisifiedSource<T>).toPromise = () =>
     pipe(source$, take(1), toPromise);
   return source$ as PromisifiedSource<T>;
-}
-
-export type ReplayMode = 'pre' | 'post';
-
-export function replayOnStart<T extends OperationResult>(
-  mode: ReplayMode,
-  start: () => void
-): Operator<T, T> {
-  return source$ => {
-    let replay: T | void;
-
-    const shared$ = pipe(
-      source$,
-      onEnd(() => {
-        replay = undefined;
-      }),
-      onPush(value => {
-        replay = value;
-      }),
-      share
-    );
-
-    return make<T>(observer => {
-      const prevReplay = replay;
-
-      return pipe(
-        shared$,
-        onEnd(observer.complete),
-        onStart(() => {
-          if (mode === 'pre') {
-            start();
-          }
-
-          if (prevReplay !== undefined && prevReplay === replay) {
-            observer.next(
-              mode === 'pre' ? { ...prevReplay, stale: true } : prevReplay
-            );
-          } else if (mode === 'post') {
-            start();
-          }
-        }),
-        subscribe(observer.next)
-      ).unsubscribe;
-    });
-  };
 }


### PR DESCRIPTION
Resolves #1621

## Summary

We discovered a slight regression in `@urql/core@2.1.0` that caused reexecuting an operation to not be possible under the usual circumstances anymore. The reason for this was that the `replayOnStart` utility was effective but we'd share the entire source too eagerly. Since this source was shared, no new operation would be created for future concurrent runs which makes changing the `requestPolicy` of an operation, e.g. for the `executeQuery` function in bindings, impossible.

Instead, I've now moved the implementation back to `Client` and cleaned it up a little, which should make it easier for us to predict how it'll behave. Sources aren't completely shared anymore and instead (which was the same in a prior implementation) we only share the result source and store that internally. The `OperationResult` stream and `onStart` behaviour isn't shared any longer.
