### PR TITLE
(graphcache) - Fix edge-case of erroring introspection on schema-awareness

### DIFF
--- a/.changeset/ten-pets-remain.md
+++ b/.changeset/ten-pets-remain.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix an edge-case for which an introspection query during runtime could fail when schema-awareness was enabled in Graphcache, since built-in types weren't recognised as existent.


### PR DESCRIPTION
Resolve https://github.com/dotansimha/graphql-code-generator/issues/5981

- Add missing test for formatted introspection query on introspected schema-aware store
- Add cases for built-in typenames to `ast/schemaPredicates`