### PR TITLE
(core) - Fix Client hang on promisified sources

### DIFF
--- a/.changeset/empty-zoos-compete.md
+++ b/.changeset/empty-zoos-compete.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix a condition under which the `Client` would hang when a query is started and consumed with `toPromise()`

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -10,6 +10,7 @@ import {
   subscribe,
   filter,
   toArray,
+  toPromise,
   tap,
   take,
 } from 'wonka';
@@ -892,5 +893,31 @@ describe('shared sources behavior', () => {
       subscribe(resultTwo)
     );
     expect(resultTwo).toHaveBeenCalledTimes(0);
+  });
+
+  it('supports promisified sources', async () => {
+    const exchange: Exchange = () => ops$ => {
+      return pipe(
+        ops$,
+        map(op => ({ stale: true, data: 1, operation: op }))
+      );
+    };
+
+    const client = createClient({
+      url: 'test',
+      exchanges: [exchange],
+    });
+
+    const resultOne = await pipe(
+      client.executeRequestOperation(queryOperation),
+      take(1),
+      toPromise
+    );
+
+    expect(resultOne).toEqual({
+      data: 1,
+      operation: queryOperation,
+      stale: true,
+    });
   });
 });


### PR DESCRIPTION
Resolves #1633

## Summary

This will need further investigation and I'd like to find a nicer implementation for this behaviour (our test suite should guide us there).

The short story here is that it seems that the `toPromise` implementation in Wonka is a little flawed and doesn't quite operate correctly. In fact, it doesn't seem to work correctly as soon as a subject is added to the direct descendants of the source.

## Set of changes

- Replace subject in `client.executeRequestOperation` with `make` i.e. anonymous source
