### PR TITLE
(core) - Refactor Client to hide some impl details and reduce size

### DIFF
--- a/.changeset/plenty-frogs-remember.md
+++ b/.changeset/plenty-frogs-remember.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Refactor `Client` to hide some implementation details and to reduce size.

--- a/packages/core/src/__snapshots__/client.test.ts.snap
+++ b/packages/core/src/__snapshots__/client.test.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`createClient passes snapshot 1`] = `
-Object {
+Client {
+  "constructor": [Function],
   "createOperationContext": [Function],
   "createRequestOperation": [Function],
   "executeMutation": [Function],
@@ -12,6 +13,7 @@ Object {
   "fetchOptions": undefined,
   "maskTypename": false,
   "mutation": [Function],
+  "operations$": [Function],
   "preferGetMethod": false,
   "query": [Function],
   "readQuery": [Function],

--- a/packages/core/src/__snapshots__/client.test.ts.snap
+++ b/packages/core/src/__snapshots__/client.test.ts.snap
@@ -8,6 +8,7 @@ Client {
   "dispatchOperation": [Function],
   "executeMutation": [Function],
   "executeQuery": [Function],
+  "executeRequestOperation": [Function],
   "executeSubscription": [Function],
   "fetch": undefined,
   "fetchOptions": undefined,

--- a/packages/core/src/__snapshots__/client.test.ts.snap
+++ b/packages/core/src/__snapshots__/client.test.ts.snap
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`createClient passes snapshot 1`] = `
-Client {
-  "activeOperations": Map {},
+Object {
   "createOperationContext": [Function],
   "createRequestOperation": [Function],
-  "dispatchOperation": [Function],
   "executeMutation": [Function],
   "executeQuery": [Function],
   "executeRequestOperation": [Function],
@@ -13,13 +11,14 @@ Client {
   "fetch": undefined,
   "fetchOptions": undefined,
   "maskTypename": false,
-  "operations$": [Function],
+  "mutation": [Function],
   "preferGetMethod": false,
-  "queue": Array [],
+  "query": [Function],
+  "readQuery": [Function],
   "reexecuteOperation": [Function],
   "requestPolicy": "cache-first",
-  "results$": [Function],
   "subscribeToDebugTarget": [Function],
+  "subscription": [Function],
   "suspense": false,
   "url": "https://hostname.com",
 }

--- a/packages/core/src/__snapshots__/client.test.ts.snap
+++ b/packages/core/src/__snapshots__/client.test.ts.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createClient passes snapshot 1`] = `
+exports[`createClient / Client passes snapshot 1`] = `
 Client {
-  "constructor": [Function],
   "createOperationContext": [Function],
   "createRequestOperation": [Function],
   "executeMutation": [Function],

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -21,18 +21,20 @@ import {
 import { gql } from './gql';
 import { Exchange, Operation, OperationResult } from './types';
 import { makeOperation } from './utils';
-import { createClient } from './client';
+import { Client, createClient } from './client';
 import { queryOperation, subscriptionOperation } from './test-utils';
 
 const url = 'https://hostname.com';
 
-describe('createClient', () => {
-  it('passes snapshot', () => {
-    const c = createClient({
-      url,
-    });
+describe('createClient / Client', () => {
+  it('creates an instance of Client', () => {
+    expect(createClient({ url }) instanceof Client).toBeTruthy();
+    expect(new Client({ url }) instanceof Client).toBeTruthy();
+  });
 
-    expect(c).toMatchSnapshot();
+  it('passes snapshot', () => {
+    const client = createClient({ url });
+    expect(client).toMatchSnapshot();
   });
 });
 

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -8,9 +8,12 @@ import {
   map,
   pipe,
   subscribe,
+  publish,
   filter,
+  share,
   toArray,
   toPromise,
+  onPush,
   tap,
   take,
 } from 'wonka';
@@ -344,19 +347,16 @@ describe('queuing behavior', () => {
       exchanges: [exchange],
     });
 
-    pipe(
-      client.results$,
-      subscribe(result => {
-        output.push(result);
-      })
-    );
-
-    const results = pipe(
+    const shared = pipe(
       client.executeRequestOperation(queryOperation),
-      toArray
+      onPush(result => output.push(result)),
+      share
     );
 
-    expect(output.length).toBe(4);
+    const results = pipe(shared, toArray);
+    pipe(shared, publish);
+
+    expect(output.length).toBe(8);
     expect(results.length).toBe(2);
 
     expect(output[0]).toHaveProperty('key', queryOperation.key);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -71,6 +71,8 @@ export interface ClientOptions {
 export interface Client {
   new (options: ClientOptions): Client;
 
+  operations$: Source<Operation>;
+
   /** Start an operation from an exchange */
   reexecuteOperation: (operation: Operation) => void;
   /** Event target for monitoring, e.g. for @urql/devtools */
@@ -140,7 +142,7 @@ export interface Client {
   ): Source<OperationResult<Data, Variables>>;
 }
 
-export const Client = (function FauxClass(opts: ClientOptions) {
+export const Client = (function Client(opts: ClientOptions) {
   if (process.env.NODE_ENV !== 'production' && !opts.url) {
     throw new Error('You are creating an urql-client without a url.');
   }
@@ -255,6 +257,8 @@ export const Client = (function FauxClass(opts: ClientOptions) {
     requestPolicy: opts.requestPolicy || 'cache-first',
     preferGetMethod: !!opts.preferGetMethod,
     maskTypename: !!opts.maskTypename,
+
+    operations$,
 
     reexecuteOperation(operation: Operation) {
       // Reexecute operation only if any subscribers are still subscribed to the
@@ -411,7 +415,8 @@ export const Client = (function FauxClass(opts: ClientOptions) {
   // cancellations cascading up from components
   pipe(results$, publish);
 
+  client.constructor = Client;
   return client;
-} as any) as Client;
+} as unknown) as Client;
 
 export const createClient = (Client as any) as (opts: ClientOptions) => Client;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -143,6 +143,7 @@ export interface Client {
 }
 
 export const Client: new (opts: ClientOptions) => Client = function Client(
+  this: Client | {},
   opts: ClientOptions
 ) {
   if (process.env.NODE_ENV !== 'production' && !opts.url) {
@@ -251,7 +252,9 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     return source;
   };
 
-  const client = {
+  const instance: Client =
+    this instanceof Client ? this : Object.create(Client.prototype);
+  const client: Client = Object.assign(instance, {
     url: opts.url,
     fetchOptions: opts.fetchOptions,
     fetch: opts.fetch,
@@ -385,7 +388,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         client.executeMutation(createRequest(query, variables), context)
       );
     },
-  } as Client;
+  } as Client);
 
   let dispatchDebug: ExchangeInput['dispatchDebug'] = noop;
   if (process.env.NODE_ENV !== 'production') {
@@ -417,7 +420,6 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
   // cancellations cascading up from components
   pipe(results$, publish);
 
-  client.constructor = Client;
   return client;
 } as any;
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -142,7 +142,9 @@ export interface Client {
   ): Source<OperationResult<Data, Variables>>;
 }
 
-export const Client = (function Client(opts: ClientOptions) {
+export const Client: new (opts: ClientOptions) => Client = function Client(
+  opts: ClientOptions
+) {
   if (process.env.NODE_ENV !== 'production' && !opts.url) {
     throw new Error('You are creating an urql-client without a url.');
   }
@@ -417,6 +419,6 @@ export const Client = (function Client(opts: ClientOptions) {
 
   client.constructor = Client;
   return client;
-} as unknown) as Client;
+} as any;
 
 export const createClient = (Client as any) as (opts: ClientOptions) => Client;

--- a/packages/next-urql/src/__tests__/with-urql-client.spec.ts
+++ b/packages/next-urql/src/__tests__/with-urql-client.spec.ts
@@ -43,7 +43,6 @@ describe('withUrqlClient', () => {
       const tree = shallow(h(Component));
       const app = tree.find(MockApp);
 
-      expect(app.props().urqlClient).toBeInstanceOf(Client);
       expect(app.props().urqlClient.url).toBe('http://localhost:3000');
       expect(spyInitUrqlClient).toHaveBeenCalledTimes(1);
       expect(spyInitUrqlClient.mock.calls[0][0].exchanges).toHaveLength(4);
@@ -58,7 +57,6 @@ describe('withUrqlClient', () => {
       const tree = shallow(h(Component, props));
       const app = tree.find(MockApp);
 
-      expect(app.props().urqlClient).toBeInstanceOf(Client);
       expect(app.props().urqlClient.url).toEqual('http://localhost:3000');
     });
   });

--- a/scripts/eslint/preset.js
+++ b/scripts/eslint/preset.js
@@ -16,6 +16,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-misused-new': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/array-type': 'off',
     'import/no-internal-modules': 'off',


### PR DESCRIPTION
- Create an `interface Client` type with all internals hidden
- Convert `Client` to an ES5 factory/constructor pattern
- Ensure that `Client` can both be called with or without `new` (types remain the same)
- Hide internals in factory function using scoped closure variables as needed

`3.68kB minzipped` to `3.59kB minzipped`