### PR TITLE
(docs) - Polled queries are no longer supported

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -43,7 +43,7 @@ All features are marked to indicate the following:
 | Devtools                                   | ✅                                  | ✅                                            | ✅                             |
 | Subscriptions                              | ✅                                  | ✅                                            | ✅                             |
 | Client-side Rehydration                    | ✅                                  | ✅                                            | ✅                             |
-| Polled Queries                             | ✅                                  | ✅                                            | ✅                             |
+| Polled Queries                             | 🛑                                  | ✅                                            | ✅                             |
 | Lazy Queries                               | ✅                                  | ✅                                            | ✅                             |
 | Stale while Revalidate / Cache and Network | ✅                                  | ✅                                            | ✅                             |
 | Focus Refetching                           | ✅ `@urql/exchange-refocus`         | 🛑                                            | 🛑                             |


### PR DESCRIPTION
I saw that polling is supported in the docs, but couldn't find anything when searching for it. Then I found out the feature was actually [removed](https://github.com/FormidableLabs/urql/pull/1374).

I think the docs should be updated to reflect this change.

In case you want to include snippets in the individual docs of how to do polling, the Vue equivalent of @kitten's React snippet would be:


```js
let { data, fetching, executeQuery } = useQuery(...);

const id = setInterval(() => {
  if (!fetching)
    executeQuery({ requestPolicy: 'network-only' });
}, 1000);

onBeforeUnmount(() => {
  clearInterval(id);
});
```

I am happy to add the React and Vue snippets for polling, however, someone else would have to chip in for svelte since I'm not familiar with it.

