### PR TITLE
(graphcache) - loosen type constraint on the graphCache generic

### DIFF
--- a/.changeset/swift-pumas-tie.md
+++ b/.changeset/swift-pumas-tie.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Loosen the typing constraint on the cacheExchange generic

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -30,7 +30,7 @@ import { makeDict, isDictEmpty } from './helpers/dict';
 import { addCacheOutcome, toRequestPolicy } from './helpers/operation';
 import { filterVariables, getMainOperation } from './ast';
 import { Store, noopDataState, hydrateData, reserveLayer } from './store';
-import { Dependencies, CacheExchangeOpts } from './types';
+import { Dependencies, GenericCacheExchangeOpts } from './types';
 
 type OperationResultWithMeta = OperationResult & {
   outcome: CacheOutcome;
@@ -42,7 +42,7 @@ type OperationMap = Map<number, Operation>;
 type OptimisticDependencies = Map<number, Dependencies>;
 type DependentOperations = Record<string, number[]>;
 
-export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
+export const cacheExchange = <C extends Partial<GenericCacheExchangeOpts>>(
   opts?: C
 ): Exchange => ({ forward, client, dispatchDebug }) => {
   const store = new Store<C>(opts);

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -24,7 +24,7 @@ import {
   SerializedRequest,
   OptimisticMutationConfig,
   Variables,
-  CacheExchangeOpts,
+  GenericCacheExchangeOpts,
 } from './types';
 
 import { makeDict } from './helpers/dict';
@@ -66,7 +66,7 @@ const isOfflineError = (error: undefined | CombinedError) =>
       error.networkError.message
     ));
 
-export const offlineExchange = <C extends Partial<CacheExchangeOpts>>(
+export const offlineExchange = <C extends Partial<GenericCacheExchangeOpts>>(
   opts: C
 ): Exchange => input => {
   const { storage } = opts;

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -15,6 +15,7 @@ import {
   OptimisticMutationConfig,
   KeyingConfig,
   Entity,
+  GenericCacheExchangeOpts,
   CacheExchangeOpts,
 } from '../types';
 
@@ -38,7 +39,7 @@ import {
 type RootField = 'query' | 'mutation' | 'subscription';
 
 export class Store<
-  C extends Partial<CacheExchangeOpts> = Partial<CacheExchangeOpts>
+  C extends Partial<GenericCacheExchangeOpts> = Partial<CacheExchangeOpts>
 > implements Cache {
   data: InMemoryData.InMemoryData;
 

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -146,6 +146,29 @@ export type CacheExchangeOpts = {
   storage?: StorageAdapter;
 };
 
+type GenericUpdateResolver<
+  ParentData extends any = DataFields,
+  Args = Variables
+> = (parent: ParentData, args: Args, cache: Cache, info: ResolveInfo) => void;
+
+interface GenericUpdatesConfig {
+  Mutation: {
+    [fieldName: string]: GenericUpdateResolver;
+  };
+  Subscription: {
+    [fieldName: string]: GenericUpdateResolver;
+  };
+}
+
+export type GenericCacheExchangeOpts = {
+  updates?: Partial<GenericUpdatesConfig>;
+  resolvers?: ResolverConfig;
+  optimistic?: OptimisticMutationConfig;
+  keys?: KeyingConfig;
+  schema?: IntrospectionData;
+  storage?: StorageAdapter;
+};
+
 // Cache resolvers are user-defined to overwrite an entity field result
 export type Resolver<
   ParentData = DataFields,

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -146,6 +146,23 @@ export type CacheExchangeOpts = {
   storage?: StorageAdapter;
 };
 
+/**
+ * The following part is meant to support the generic type-generated part of graphcache,
+ * we want to make the extends loose but the default type still has to work as DataFields.
+ * You can recognize these by the "generic" prefix.
+ */
+type GenericResolver<
+  ParentData extends any = DataFields,
+  Args = Variables,
+  Result = ResolverResult
+> = (parent: ParentData, args: Args, cache: Cache, info: ResolveInfo) => Result;
+
+interface GenericResolverConfig {
+  [typeName: string]: {
+    [fieldName: string]: GenericResolver;
+  };
+}
+
 type GenericUpdateResolver<
   ParentData extends any = DataFields,
   Args = Variables
@@ -162,7 +179,7 @@ interface GenericUpdatesConfig {
 
 export type GenericCacheExchangeOpts = {
   updates?: Partial<GenericUpdatesConfig>;
-  resolvers?: ResolverConfig;
+  resolvers?: GenericResolverConfig;
   optimistic?: OptimisticMutationConfig;
   keys?: KeyingConfig;
   schema?: IntrospectionData;


### PR DESCRIPTION
## Summary

When using the types like https://github.com/FormidableLabs/urql/discussions/1654 we run into an issue with the typings of our current `updateResolver`, this because `[key: string]` is seen and TS expects `__typename`. A similar fix has been put into place for the `resolversconfig`

[Playground](https://www.typescriptlang.org/play?#code/PTAEAkFMBsAdIE6gC4E94GcBQkAesB7BZFdSUAOQFdpoBBBBAQ1QB4AVAPlAF5QHmbAHY1ooAD6h2EyqIEsOnTgG4sOfERIBLIckQAzJgGNyAMWYBzALaRdGUAG8soUAG19lm7opMbALlAMZAQdCwBdAIA3Ai0AE1UAXzUQUABlIyZoJiQ0TFBs8iECEltkLTLIeyZ7WGySAn1QBErCIQxyWKZkJnVCYlJ4UAAFEKtyrUjyPhFaGRErACNEGQWCAmhIJiEZIJChC1VezVAdPQRDEzSMrIQAeQWAK0gjEicXIwI24KoXogB+AKmKhCF5aT6qFyuADWkFQAV2oQi+SEqESajwfRIuXI6Uy2V4w1G40mMlxN3uTxehwxx1OBmMONQQUgVlMWhgsXsb1AAH0edihL5IPDgqEIby4gDAqL9nMqItlpIZtBxSdYlKEbKlfKlkhtbQ0Ud+tjQABRXTlVBsjkE4GxSD6HSQWKk674yTUWjyNhk7IqI1YsigAAiXSY1ugLr4vr1IbDMk99EYChj3A9cmTbFD3X9NONQezTAJqSZelZ7Mj9gAZHHuhHOdSNPnBoX6-Y+NzobCRXtwgFWxX4lgkgGBuQAKqwTp6ABKlXWkwQrCGBV0hdAeD0Qk5yNQBIHHIw3D4AApnKBas1dAEV1fkIWADRYACUvG40TihxNdCMJlgyAASSESJykgFdUGgAgmCjRxzziHsxXPPkBSFAIAHIgJAvQ0MNfRgVBT4UEqZBFBPXAAgcUAqCnLpEACSdp0gOcMAXRBFFABJXwcEc9CCVgfz-QDgNA8DIOgzgT25ajGIQAIT0vUpXx4bgFN0AA6ZCyEFGxh2fQ4Pi+KiaLOejjKY+doEXAl5NXZAlO4blVOQYc1CAA)

## Set of changes

- When using a generic extend  `updateResolver`  & `Resolver` `Parent` from `any` and default to `DataFields`