### PR TITLE
(graphcache) extend Primitive type to include Date

### DIFF
--- a/.changeset/green-carpets-enjoy.md
+++ b/.changeset/green-carpets-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Graphcache Primitive type now includes Date

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -10,7 +10,7 @@ export interface Fragments {
 }
 
 // Scalar types are not entities as part of response data
-export type Primitive = null | number | boolean | string;
+export type Primitive = null | number | boolean | string | Date;
 
 export interface ScalarObject {
   constructor?: Function;


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Return type for local resolvers could include a `Date`, which is even in the [documentation](https://formidable.com/open-source/urql/docs/graphcache/local-resolvers/) for local resolvers. This PR extends the `Primitive` type so that this is supported.


## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

Graphcache's `Primitive` type now includes `Date` in the union.
