### PR TITLE
(graphcache) - add the ENTRIES_STORE_NAME to the clear transaction

### DIFF
--- a/.changeset/strange-elephants-add.md
+++ b/.changeset/strange-elephants-add.md
@@ -1,0 +1,5 @@
+---
+"@urql/exchange-graphcache": patch
+---
+
+Fix: add the `ENTRIES_STORE_NAME` to the clear transaction

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -98,7 +98,7 @@ export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
     clear() {
       return database$.then(database => {
         const transaction = database.transaction(
-          METADATA_STORE_NAME,
+          [METADATA_STORE_NAME, ENTRIES_STORE_NAME],
           'readwrite'
         );
         transaction.objectStore(METADATA_STORE_NAME).clear();


### PR DESCRIPTION
## Summary

We were clearing on `ENTRIES_STORE_NAME` without an active transaction. Fixes #1684 

## Set of changes

- add `ENTRIES_STORE_NAME` to `storage.clear()` transaction
