### PR TITLE
(core) - Prevent stale results from promisified sources

### DIFF
--- a/.changeset/smooth-hounds-battle.md
+++ b/.changeset/smooth-hounds-battle.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Prevent stale results from being emitted by promisified query sources, e.g. `client.query(...).toPromise()` yielding a partial result with `stale: true` set. Instead, `.toPromise()` will now filter out stale results.

--- a/packages/core/src/utils/streamUtils.ts
+++ b/packages/core/src/utils/streamUtils.ts
@@ -1,9 +1,17 @@
-import { Source, pipe, toPromise, take } from 'wonka';
+import { Source, pipe, toPromise, filter, take } from 'wonka';
+import { OperationResult, PromisifiedSource } from '../types';
 
-import { PromisifiedSource } from '../types';
+export function withPromise<T extends OperationResult>(
+  source$: Source<T>
+): PromisifiedSource<T> {
+  (source$ as PromisifiedSource<T>).toPromise = () => {
+    return pipe(
+      source$,
+      filter(result => !result.stale),
+      take(1),
+      toPromise
+    );
+  };
 
-export function withPromise<T>(source$: Source<T>): PromisifiedSource<T> {
-  (source$ as PromisifiedSource<T>).toPromise = () =>
-    pipe(source$, take(1), toPromise);
   return source$ as PromisifiedSource<T>;
 }


### PR DESCRIPTION
## Summary

Prevent stale results from being emitted by promisified query sources, e.g. `client.query(...).toPromise()` yielding a partial result with `stale: true` set. Instead, `.toPromise()` will now filter out stale results.

## Set of changes

- Add `OperationResult` limitation and `filter` operator to `withPromise`
