### PR TITLE
(next) - Prevent restoring SSR data when client has been reset

### DIFF
--- a/.changeset/spicy-impalas-repair.md
+++ b/.changeset/spicy-impalas-repair.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Fix `resetUrqlClient` not resetting the SSR cache itself and instead restoring data when all data related to this `Client` and session should've been deleted.

--- a/packages/next-urql/package.json
+++ b/packages/next-urql/package.json
@@ -25,6 +25,7 @@
     "test": "jest",
     "clean": "rimraf dist",
     "check": "tsc --noEmit",
+    "lint": "eslint --ext=js,jsx,ts,tsx .",
     "build": "rollup -c ../../scripts/rollup/config.js",
     "prepare": "node ../../scripts/prepare/index.js",
     "prepublishOnly": "run-s clean build"

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -1,4 +1,4 @@
-import React, { createElement, useState } from 'react';
+import { createElement, useCallback, useReducer, useMemo } from 'react';
 import ssrPrepass from 'react-ssr-prepass';
 
 import {
@@ -42,20 +42,18 @@ export function withUrqlClient(
       urqlState,
       ...rest
     }: WithUrqlProps) => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const forceUpdate = useState(0);
+      const [version, forceUpdate] = useReducer(prev => prev + 1, 0);
       const urqlServerState = (pageProps && pageProps.urqlState) || urqlState;
 
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const client = React.useMemo(() => {
-        if (urqlClient && forceUpdate[0] === 0) {
+      const client = useMemo(() => {
+        if (urqlClient && !version) {
           return urqlClient;
         }
 
         if (!ssr || typeof window === 'undefined') {
           // We want to force the cache to hydrate, we do this by setting the isClient flag to true
           ssr = ssrExchange({ initialState: urqlServerState, isClient: true });
-        } else if (forceUpdate[0] === 0) {
+        } else if (!version) {
           ssr.restoreData(urqlServerState);
         }
 
@@ -70,16 +68,14 @@ export function withUrqlClient(
           ];
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return initUrqlClient(clientConfig, shouldEnableSuspense)!;
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, [urqlClient, urqlServerState, forceUpdate[0]]);
+      }, [urqlClient, urqlServerState, version]);
 
-      const resetUrqlClient = () => {
+      const resetUrqlClient = useCallback(() => {
         resetClient();
         ssr = ssrExchange({ initialState: undefined });
-        forceUpdate[1](forceUpdate[0] + 1);
-      };
+        forceUpdate();
+      }, []);
 
       return createElement(
         Provider,

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -48,14 +48,14 @@ export function withUrqlClient(
 
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const client = React.useMemo(() => {
-        if (urqlClient) {
+        if (urqlClient && forceUpdate[0] === 0) {
           return urqlClient;
         }
 
         if (!ssr || typeof window === 'undefined') {
           // We want to force the cache to hydrate, we do this by setting the isClient flag to true
           ssr = ssrExchange({ initialState: urqlServerState, isClient: true });
-        } else if (ssr && typeof window !== 'undefined') {
+        } else if (forceUpdate[0] === 0) {
           ssr.restoreData(urqlServerState);
         }
 


### PR DESCRIPTION
  Resolves #1714 

This aims to fix two things
1. When we first visit a page and later do `resetUrqlClient`. We do end up using a new client because `urqlClient` prop was set to null. But due to `ssr.restoreData(urqlServerState)` Results are fetched from old ssr cache and network isn't called.
2. When we navigate to a new page (client side rendered) `urqlClient` prop is not null and that is the client we use. Now if you call `resetUrqlClient`, we don't get a `new client` because of existing `urqlClient` prop value. `if (urqlClient) return  urqlClient`

