### PR TITLE
(react) - Fix pause + executeQuery issue in useQuery

### DIFF
--- a/.changeset/grumpy-dogs-allow.md
+++ b/.changeset/grumpy-dogs-allow.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Fix issue with `useQuery`'s `executeQuery` state updates, where some calls wouldn't trigger a source change and start a request when the hook was paused.


### PR DESCRIPTION
Fix #1698

Fix issue with `useQuery`'s `executeQuery` state updates, where some calls wouldn't trigger a source change and start a request when the hook was paused.

