### PR TITLE
(svelte) - Fix typings for subscription's differing results

### DIFF
--- a/.changeset/loud-ghosts-sparkle.md
+++ b/.changeset/loud-ghosts-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': patch
+---
+
+Improve `OperationStore` and `subscription` types to allow for result types of `data` that differ from the original `Data` type, which may be picked up from `TypedDocumentNode`.

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -13,8 +13,8 @@ type Updater<T> = (value: T) => T;
  * This Svelte store wraps both a `GraphQLRequest` and an `OperationResult`.
  * It can be used to update the query and read the subsequent result back.
  */
-export interface OperationStore<Data = any, Vars = any>
-  extends Readable<OperationStore<Data, Vars>> {
+export interface OperationStore<Data = any, Vars = any, Result = Data>
+  extends Readable<OperationStore<Data, Vars, Result>> {
   // Input properties
   query: DocumentNode | TypedDocumentNode<Data, Vars> | string;
   variables: Vars | null;
@@ -22,19 +22,19 @@ export interface OperationStore<Data = any, Vars = any>
   // Output properties
   readonly stale: boolean;
   readonly fetching: boolean;
-  readonly data: Data | undefined;
+  readonly data: Result | undefined;
   readonly error: CombinedError | undefined;
   readonly extensions: Record<string, any> | undefined;
   // Writable properties
-  set(value: Partial<OperationStore<Data, Vars>>): void;
-  update(updater: Updater<Partial<OperationStore<Data, Vars>>>): void;
+  set(value: Partial<OperationStore<Data, Vars, Result>>): void;
+  update(updater: Updater<Partial<OperationStore<Data, Vars, Result>>>): void;
 }
 
-export function operationStore<Data = any, Vars = object>(
+export function operationStore<Data = any, Vars = object, Result = Data>(
   query: string | DocumentNode | TypedDocumentNode<Data, Vars>,
   variables?: Vars | null,
   context?: Partial<OperationContext & { pause: boolean }>
-): OperationStore<Data, Vars> {
+): OperationStore<Data, Vars, Result> {
   const internal = {
     query,
     variables: variables || null,
@@ -47,7 +47,7 @@ export function operationStore<Data = any, Vars = object>(
     data: undefined,
     error: undefined,
     extensions: undefined,
-  } as OperationStore<Data, Vars>;
+  } as OperationStore<Data, Vars, Result>;
 
   const svelteStore = writable(state);
   let _internalUpdate = false;

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -41,7 +41,9 @@ const baseState = {
   extensions: undefined,
 };
 
-function toSource<Data, Variables>(store: OperationStore<Data, Variables>) {
+function toSource<Data, Variables, Result>(
+  store: OperationStore<Data, Variables, Result>
+) {
   return make<SourceRequest<Data, Variables>>(observer => {
     let $request: void | GraphQLRequest<Data, Variables>;
     let $contextKey: void | string;
@@ -111,9 +113,9 @@ export function query<Data = any, Variables = object>(
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 
 export function subscription<Data = any, Result = Data, Variables = object>(
-  store: OperationStore<Result, Variables>,
+  store: OperationStore<Data, Variables, Result>,
   handler?: SubscriptionHandler<Data, Result>
-): OperationStore<Result, Variables> {
+): OperationStore<Data, Variables, Result> {
   const client = getClient();
   const subscription = pipe(
     toSource(store),
@@ -182,7 +184,6 @@ export function mutation<Data = any, Variables = object>(
 
     _markStoreUpdate(update);
     store.set(update);
-
     return client
       .mutation(store.query, store.variables as any, store.context)
       .toPromise()


### PR DESCRIPTION
Resolves #1716

## Summary

Improve `OperationStore` and `subscription` types to allow for result types of `data` that differ from the original `Data` type, which may be picked up from `TypedDocumentNode`.

## Set of changes

- Add a `Result = Data` generic to `OperationStore`
- Fix generic usage on `subscription` to assign new `Result` type to store
