### PR TITLE
(core) - Rename "Basics" > "Core" page for discoverability

### DIFF
--- a/docs/basics/core.md
+++ b/docs/basics/core.md
@@ -1,9 +1,9 @@
 ---
-title: Core Usage
+title: Core / Node.js
 order: 3
 ---
 
-# Core
+# Core and Node.js Usage
 
 The `@urql/core` package contains `urql`'s `Client`, some common utilities, and some default
 _Exchanges_. These are the shared, default parts of `urql` that we will be using no matter which


### PR DESCRIPTION
I noticed that a lot of folks are having trouble finding "Node.js" as a keyword in the menu or via the search, so I think we should rename the "Core" page to account for that.