### PR TITLE
(request-policy) - Fix requestPolicyExchange usage with persisted caching

### DIFF
--- a/.changeset/sweet-beers-brush.md
+++ b/.changeset/sweet-beers-brush.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-request-policy': patch
+---
+
+Do not set the TTL unless cache outcome is "miss". Previously we set the TTL on cache "miss" if it was the first time an operation returned a result, now the TTL is only set on cache miss results. This allows the request policy exchange to work when using persisted caching.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /.vscode
 **/node_modules
 *.log

--- a/exchanges/request-policy/src/requestPolicyExchange.ts
+++ b/exchanges/request-policy/src/requestPolicyExchange.ts
@@ -45,10 +45,7 @@ export const requestPolicyExchange = (options: Options): Exchange => ({
 
   const processIncomingResults = (result: OperationResult): void => {
     const meta = result.operation.context.meta;
-    const isMiss =
-      !operations.has(result.operation.key) ||
-      !meta ||
-      meta.cacheOutcome === 'miss';
+    const isMiss = !meta || meta.cacheOutcome === 'miss';
     if (isMiss) {
       operations.set(result.operation.key, new Date().getTime());
     }


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

Resolves https://github.com/FormidableLabs/urql/issues/1644

## Set of changes

Do not set the TTL unless cache outcome is "miss". If the first result to come through the requestPolicyExchange was a cache-hit then the ttl was set initially based on this cache hit and no network request was made. This happens when using
persisted caching with the graphcache exchange since the very first result could be a cache hit.
