### PR TITLE
(exchange-persisted-fetch) - Make indirect eval call to optimize for minifiers

### DIFF
--- a/.changeset/silent-carpets-judge.md
+++ b/.changeset/silent-carpets-judge.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted-fetch': patch
+---
+
+Optimize for minification by avoiding direct eval call.

--- a/exchanges/persisted-fetch/src/sha256.ts
+++ b/exchanges/persisted-fetch/src/sha256.ts
@@ -30,18 +30,14 @@ const sha256Browser = (bytes: Uint8Array): Promise<Uint8Array> => {
   });
 };
 
-const nodeCrypto =
-  typeof window === 'undefined'
-    ? (() => {
-        try {
-          // Call eval indirectly to guarantee no side-effects in module scope
-          // (optimization for minifiers)
-          return (0, eval)("r => r('crypto')")(require);
-        } catch (e) {
-          return null;
-        }
-      })()
-    : null;
+let nodeCrypto;
+if (typeof window === 'undefined') {
+  try {
+    // Indirect eval/require to guarantee no side-effects in module scope
+    // (optimization for minifiers)
+    nodeCrypto = new Function('require', 'return require("crypto")')(require);
+  } catch (e) {}
+}
 
 export const hash = async (query: string): Promise<string> => {
   if (

--- a/exchanges/persisted-fetch/src/sha256.ts
+++ b/exchanges/persisted-fetch/src/sha256.ts
@@ -31,7 +31,17 @@ const sha256Browser = (bytes: Uint8Array): Promise<Uint8Array> => {
 };
 
 const nodeCrypto =
-  typeof window === 'undefined' ? eval("require('crypto')") : null;
+  typeof window === 'undefined'
+    ? (() => {
+        try {
+          // Call eval indirectly to guarantee no side-effects in module scope
+          // (optimization for minifiers)
+          return (0, eval)("r => r('crypto')")(require);
+        } catch (e) {
+          return null;
+        }
+      })()
+    : null;
 
 export const hash = async (query: string): Promise<string> => {
   if (


### PR DESCRIPTION
## Summary

The `@urql/exchange-persisted-fetch` package is not currently being minified to the fullest extent and even throws warnings in some minifiers/bundlers, such as esbuild, because it contains a direct call to `eval()`.

Every minifier (including terser, which is being used to generate minified bundles of urql libraries) avoids mangling names when there is a direct `eval` call in scope. Because a direct call to eval gives the code being evaluated access to the scope from which it was called, there's no way for the minifier to know what side-effects that evaluted code has, so it avoids making optimizations.

By changing it to an indirect eval, we get smaller outputs, even though more boilerplate was added to the code:

* `urql-exchange-persisted-fetch.min.js` shrinks from `3299b` to <strike>`2802b`</strike> `2792b`
* `urql-exchange-persisted-fetch.min.mjs` shrinks from `3281b` to <strike>`2828b`</strike> `2818b`

This PR also resolves #875 which I believe was erroneously closed.

## Set of changes

* Replaced direct `eval()` call in `exchanges/persisted-fetch/src/sha256.ts` with an indirect call, guarded against errors with a try/catch.

## Side-note

This is probably not the _ideal_ fix. I question whether an `eval` here is even appropriate as a means of avoiding including `crypto` in a client-side bundle.

It would probably be better to generate separate builds for node and browser environments, where a direct call to `require('crypto')` gets tree-shaken out of the `browser` build.