### PR TITLE
(core) - Fix stale on reexecute being skipped for cache-first

### DIFF
--- a/.changeset/fresh-moose-exist.md
+++ b/.changeset/fresh-moose-exist.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix accidental change in passive `stale: true`, where a `cache-first` operation issued by Graphcache wouldn't yield an affected query and update its result to reflect the loading state with `stale: true`. This is a regression from `v2.1.0` and mostly becomes unexpected when `cache.invalidate(...)` is used.

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -6,7 +6,9 @@ import {
   Source,
   delay,
   map,
+  never,
   pipe,
+  merge,
   subscribe,
   publish,
   filter,
@@ -869,11 +871,14 @@ describe('shared sources behavior', () => {
 
   it('does nothing when operation is a subscription has been emitted yet', () => {
     const exchange: Exchange = () => ops$ => {
-      return pipe(
-        ops$,
-        map(op => ({ data: 1, operation: op })),
-        take(1)
-      );
+      return merge([
+        pipe(
+          ops$,
+          map(op => ({ data: 1, operation: op })),
+          take(1)
+        ),
+        never,
+      ]);
     };
 
     const client = createClient({

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -215,14 +215,12 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
           // Mark a result as stale when a new operation is sent for it
           pipe(
             operations$,
-            filter(op => {
-              return (
+            filter(
+              op =>
                 op.kind === operation.kind &&
                 op.key === operation.key &&
-                (op.context.requestPolicy === 'network-only' ||
-                  op.context.requestPolicy === 'cache-and-network')
-              );
-            }),
+                op.context.requestPolicy !== 'cache-only'
+            ),
             take(1),
             map(() => ({ ...result, stale: true }))
           ),

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -206,7 +206,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         )
       ),
       switchMap(result => {
-        if (result.stale) {
+        if (operation.kind !== 'query' || result.stale) {
           return fromValue(result);
         }
 
@@ -217,7 +217,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
             operations$,
             filter(
               op =>
-                op.kind === operation.kind &&
+                op.kind === 'query' &&
                 op.key === operation.key &&
                 op.context.requestPolicy !== 'cache-only'
             ),


### PR DESCRIPTION
Resolve #1754

## Summary

This fixes an accidental change from `v2.1.0` onwards that prevented `stale: true` from being added onto reexecuting operations when those were using `cache-first`. We reverted this to instead always update the `stale` flag except for `cache-only` as it was before.
