### PR TITLE
(vue) - Simplify useQuery implementation

### DIFF
--- a/.changeset/strange-windows-repair.md
+++ b/.changeset/strange-windows-repair.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Refactor `useQuery` implementation to utilise the single-source implementation of `@urql/core@2.1.0`. This should improve the stability of promisified `useQuery()` calls and prevent operations from not being issued in some edge cases.

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -82,7 +82,7 @@ export function callUseQuery<T = any, V = object>(
     createRequest<T, V>(args.query, args.variables as V) as any
   );
 
-  const source: Ref<Source<OperationResult> | null> = ref(null as any);
+  const source: Ref<Source<OperationResult> | undefined> = ref();
 
   stops.push(
     watchEffect(() => {
@@ -100,7 +100,7 @@ export function callUseQuery<T = any, V = object>(
             requestPolicy: args.requestPolicy,
             ...args.context,
           })
-        : null;
+        : undefined;
     }, watchOptions)
   );
 

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -4,16 +4,7 @@ import { DocumentNode } from 'graphql';
 
 import { WatchStopHandle, Ref, ref, watchEffect, reactive, isRef } from 'vue';
 
-import {
-  Source,
-  map,
-  pipe,
-  take,
-  subscribe,
-  onEnd,
-  onStart,
-  toPromise,
-} from 'wonka';
+import { Source, map, pipe, take, subscribe, onEnd, toPromise } from 'wonka';
 
 import {
   Client,
@@ -142,13 +133,12 @@ export function callUseQuery<T = any, V = object>(
     watchEffect(
       onInvalidate => {
         if (source.value) {
+          fetching.value = true;
+          stale.value = false;
+
           onInvalidate(
             pipe(
               source.value,
-              onStart(() => {
-                fetching.value = true;
-                stale.value = false;
-              }),
               onEnd(() => {
                 fetching.value = false;
                 stale.value = false;
@@ -163,6 +153,9 @@ export function callUseQuery<T = any, V = object>(
               })
             ).unsubscribe
           );
+        } else {
+          fetching.value = false;
+          stale.value = false;
         }
       },
       {

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import { DocumentNode } from 'graphql';
-import { Source, pipe, subscribe, share, onEnd } from 'wonka';
+import { Source, pipe, subscribe, onEnd } from 'wonka';
 
 import { WatchStopHandle, Ref, ref, watchEffect, reactive, isRef } from 'vue';
 
@@ -98,16 +98,9 @@ export function callUseSubscription<T = any, R = T, V = object>(
 
   stops.push(
     watchEffect(() => {
-      if (!isPaused.value) {
-        source.value = pipe(
-          client.executeSubscription<T, V>(request.value, {
-            ...args.context,
-          }),
-          share
-        );
-      } else {
-        source.value = undefined;
-      }
+      source.value = !isPaused.value
+        ? client.executeSubscription<T, V>(request.value, { ...args.context })
+        : undefined;
     }, watchOptions)
   );
 
@@ -154,13 +147,10 @@ export function callUseSubscription<T = any, R = T, V = object>(
     executeSubscription(
       opts?: Partial<OperationContext>
     ): UseSubscriptionState<T, R, V> {
-      source.value = pipe(
-        client.executeSubscription<T, V>(request.value, {
-          ...args.context,
-          ...opts,
-        }),
-        share
-      );
+      source.value = client.executeSubscription<T, V>(request.value, {
+        ...args.context,
+        ...opts,
+      });
 
       return state;
     },


### PR DESCRIPTION
Resolve #1429 

Refactor `useQuery` implementation to utilise the single-source implementation of `@urql/core@2.1.0`. This should improve the stability of promisified `useQuery()` calls and prevent operations from not being issued in some edge cases.