### PR TITLE
Fixed: Type mismatch between GraphCacheConfig and CacheExchange

### DIFF
--- a/.changeset/quiet-pants-refuse.md
+++ b/.changeset/quiet-pants-refuse.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Fixed typing of OptimisticMutationResolver.

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -190,7 +190,7 @@ export type UpdatesConfig = {
 
 export type OptimisticMutationResolver<
   Args = Variables,
-  Result = Link<Data>
+  Result = Link<Data> | Scalar
 > = {
   bivarianceHack(vars: Args, cache: Cache, info: ResolveInfo): Result;
 }['bivarianceHack'];


### PR DESCRIPTION
## Summary

This PR fixes type mismatch which happens when pass generated GraphCacheConfig to CacheExchange and you have mutations that returns scalar type.

fixes #1766 

## Set of changes

* fixed type definition of OptimisticMutationResolver
