### PR TITLE
(core/next) Only restore uncached operation data into ssr-cache

### DIFF
--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@urql/core": ">=2.0.0",
+    "@urql/core": ">=2.1.4",
     "wonka": "^4.0.14"
   }
 }

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -159,7 +159,16 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
     return merge([forwardedOps$, cachedOps$]);
   };
 
-  ssr.restoreData = (restore: SSRData) => Object.assign(data, restore);
+  ssr.restoreData = (restore: SSRData) => {
+    // Only restore data for uncached operations
+    const uncached = {};
+    Object.entries(restore).forEach(([key, value]) => {
+      if (false === key in data) {
+        uncached[key] = value;
+      }
+    });
+    return Object.assign(data, uncached);
+  };
   ssr.extractData = () => Object.assign({}, data);
 
   if (params && params.initialState) {


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary
<!-- What's the motivation of this change? What does it solve? -->

We are attempting to improve our nextjs SSG strategy. We recently figured out how to statically generate pages for public resources while allowing non-public resources to not result in a temporary 404 while being fetched on the client (see discussion https://github.com/FormidableLabs/urql/discussions/1771).

The final issue we are facing is that the statically generated data hydrates client cache, due to #1602. While this preferable for most pages, it is a problem for our resource listings, where the statically generated version only includes public data, which then updates locally when a user has access to additional resources.

As far as I can tell, what happens is that when the cache has been updated with resources visible to the user, and they navigate back to the listing page, the cache is overwritten with the statically generated data (and then updated again when the client query is fetched).

## Set of changes
<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

I've changed the `ssr.restoreData` function to only merge operations into the cache that have not been cached yet.

I'm not entirely sure if this should be fixed in the `ssrExchange` or I should be focusing on `next-urql`, please let me know your thoughts on how best to handle this.