### PR TITLE
(core) - Fix ssrExchange.restoreData adding invalidated results

### DIFF
--- a/.changeset/cuddly-readers-walk.md
+++ b/.changeset/cuddly-readers-walk.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Prevent `ssrExchange().restoreData()` from adding results to the exchange that have already been invalidated. This may happen when `restoreData()` is called repeatedly, e.g. per page. When a prior run has already invalidated an SSR result then the result is 'migrated' to the user's `cacheExchange`, which means that `restoreData()` should never attempt to re-add it again.

--- a/packages/core/src/exchanges/ssr.test.ts
+++ b/packages/core/src/exchanges/ssr.test.ts
@@ -134,7 +134,7 @@ it('caches complex GraphQLErrors in query results correctly', () => {
   publish(exchange);
   next(queryOperation);
 
-  const error = ssr.extractData()[queryOperation.key].error;
+  const error = ssr.extractData()[queryOperation.key]!.error;
 
   expect(error).toHaveProperty('graphQLErrors.0.message', 'Oh no!');
   expect(error).toHaveProperty('graphQLErrors.0.path', ['Query']);
@@ -176,7 +176,7 @@ it('deletes cached results in non-suspense environments', async () => {
 
   await Promise.resolve();
 
-  expect(ssr.extractData()[queryOperation.key]).toBe(null);
+  expect(Object.keys(ssr.extractData()).length).toBe(0);
   expect(onPush).toHaveBeenCalledWith(queryResponse);
 
   // NOTE: The operation should not be duplicated
@@ -202,12 +202,12 @@ it('never allows restoration of invalidated results', async () => {
 
   await Promise.resolve();
 
-  expect(ssr.extractData()[queryOperation.key]).toBe(null);
+  expect(Object.keys(ssr.extractData()).length).toBe(0);
   expect(onPush).toHaveBeenCalledTimes(1);
   expect(output).not.toHaveBeenCalled();
 
   ssr.restoreData(initialState);
-  expect(ssr.extractData()[queryOperation.key]).toBe(null);
+  expect(Object.keys(ssr.extractData()).length).toBe(0);
 
   next(queryOperation);
   expect(onPush).toHaveBeenCalledTimes(2);

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -12,7 +12,7 @@ export interface SerializedResult {
 }
 
 export interface SSRData {
-  [key: string]: SerializedResult | null;
+  [key: string]: SerializedResult;
 }
 
 export interface SSRExchangeParams {
@@ -91,7 +91,7 @@ const deserializeResult = (
 
 /** The ssrExchange can be created to capture data during SSR and also to rehydrate it on the client */
 export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
-  const data: SSRData = {};
+  const data: Record<string, SerializedResult | null> = {};
 
   // On the client-side, we delete results from the cache as they're resolved
   // this is delayed so that concurrent queries don't delete each other's data
@@ -170,7 +170,11 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
     }
   };
 
-  ssr.extractData = () => Object.assign({}, data);
+  ssr.extractData = () => {
+    const result: SSRData = {};
+    for (const key in data) if (data[key] != null) result[key] = data[key]!;
+    return result;
+  };
 
   if (params && params.initialState) {
     ssr.restoreData(params.initialState);


### PR DESCRIPTION
Related #1775 
Resolve #1771

## Summary

Prevent `ssrExchange().restoreData()` from adding results to the exchange that have already been invalidated. This may happen when `restoreData()` is called repeatedly, e.g. per page. When a prior run has already invalidated an SSR result then the result is 'migrated' to the user's `cacheExchange`, which means that `restoreData()` should never attempt to re-add it again.

## Set of changes

- Invalidate results in `ssrExchange` with `null` rather than `delete`
- Use `null` entries to prevent overwriting invalidated results
