### PR TITLE
(svelte) - Loosen subscription type further

### DIFF
--- a/.changeset/quick-shrimps-fetch.md
+++ b/.changeset/quick-shrimps-fetch.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': patch
+---
+
+Loosen `subscription(...)` type further to allow any `operationStore` input, regardless of the `Result` produced.

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -115,7 +115,7 @@ export function query<Data = any, Variables = object>(
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 
 export function subscription<Data = any, Result = Data, Variables = object>(
-  store: OperationStore<Data, Variables, Result>,
+  store: OperationStore<Data, Variables, any>,
   handler?: SubscriptionHandler<Data, Result>
 ): OperationStore<Data, Variables, Result> {
   const client = getClient();


### PR DESCRIPTION
Resolve #1716
Resolve #1750

There isn't a much cleaner way of inferring this. Either `operationStore` _needs_ to be explicitly typed with a `Result` generic, or the `subscription(...)` type needs to be looser and assign a more specific type to its return value. There isn't really an in-between solution.

As this is confusing to many, I'm thinking of just loosening the type.
