### PR TITLE
(auth) - Allow mutate from the getAuth to accept a TypedDocumentNode

### DIFF
--- a/.changeset/weak-boxes-speak.md
+++ b/.changeset/weak-boxes-speak.md
@@ -2,4 +2,4 @@
 '@urql/exchange-auth': patch
 ---
 
-allow mutate to infer mutation Data and Variables by using TypedDocumentNode
+Allow `mutate` to infer the result's type when a `TypedDocumentNode` is passed via the usual generics, like `client.mutation` for instance.

--- a/.changeset/weak-boxes-speak.md
+++ b/.changeset/weak-boxes-speak.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-auth': patch
+---
+
+allow mutate to infer mutation Data and Variables by using TypedDocumentNode

--- a/exchanges/auth/src/authExchange.ts
+++ b/exchanges/auth/src/authExchange.ts
@@ -23,6 +23,7 @@ import {
   Exchange,
   createRequest,
   makeOperation,
+  TypedDocumentNode,
 } from '@urql/core';
 
 import { DocumentNode } from 'graphql';
@@ -48,7 +49,7 @@ export interface AuthConfig<T> {
     authState: T | null;
     /** The mutate() method may be used to send one-off mutations to the GraphQL API for the purpose of authentication. */
     mutate<Data = any, Variables extends object = {}>(
-      query: DocumentNode | string,
+      query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
       variables?: Variables,
       context?: Partial<OperationContext>
     ): Promise<OperationResult<Data>>;


### PR DESCRIPTION
First of all thanks a lot for this awesome GraphQL client 

## Summary

`useMutation` gives up the posiblity to infer Data/Variables if we pass a typed-document as you can see here [useMutation.ts#L35](https://github.com/FormidableLabs/urql/blob/main/packages/react-urql/src/hooks/useMutation.ts#L35), unlike mutate from auth-exchange which only accepts `DocumentNode` and not `TypedDocumentNode`


## Set of changes

### auth-exchange:
- allow `mutate` exposed by the `getAuth` to accept `TypedDocumentNode` to make type inference possible

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
