### PR TITLE
Added a section about setting up custom headers

### DIFF
--- a/docs/api/urql.md
+++ b/docs/api/urql.md
@@ -153,7 +153,10 @@ Sometimes, it's required to send custom headers with your query/mutation. In suc
 import React from 'react';
 
 const SomeComponent = (): JSX.Element => {
-  const [{ data, error, fetching }] = useQuery({ query: YourQuery, context: { fetchOptions: { headers: { 'x-custom-header': 'some-value' } } });
+  const context = React.useMemo(() => ({
+    fetchOptions: { headers: { 'x-custom-header': 'some-value' } }
+  }), [])
+  const [{ data, error, fetching }] = useQuery({ query: YourQuery, context });
   
   return <div>{fetching ? 'Loading ...' : 'Data loaded'}</div>;
 }

--- a/docs/api/urql.md
+++ b/docs/api/urql.md
@@ -149,7 +149,7 @@ above, and should thus be preferred over manually using `useContext` with `urql`
 
 Sometimes, it's required to send custom headers with your query/mutation. In such case you should send them via `context` property of `useQuery`/`useMutation` params object:
 
-```
+```tsx
 import React from 'react';
 
 const SomeComponent = (): JSX.Element => {

--- a/docs/api/urql.md
+++ b/docs/api/urql.md
@@ -144,3 +144,36 @@ const useClient = () => React.useContext(Context);
 
 However, this hook is also responsible for outputting the default client warning that's mentioned
 above, and should thus be preferred over manually using `useContext` with `urql`'s `Context`.
+
+### Setting up custom headers for a query/mutations
+
+Sometimes, it's required to send custom headers with your query/mutation. In such case you should send them via `context` property of `useQuery`/`useMutation` params object:
+
+```
+import React from 'react';
+
+const SomeComponent = (): JSX.Element => {
+  const [{ data, error, fetching }] = useQuery({ query: YourQuery, context: { fetchOptions: { headers: { 'x-custom-header': 'some-value' } } });
+  
+  return <div>{fetching ? 'Loading ...' : 'Data loaded'}</div>;
+}
+```
+
+However you have to make an additional addition to such, as passing the `context` object will cause an infinite loop of re-rendering. In such case, you should memoize the `context` value in order to avoid re-renderings.
+
+```
+import React, { useMemo } from 'react';
+
+const SomeComponent = (): JSX.Element => {
+  const context = useMemo(() => {
+    return {
+      fetchOptions: { headers: { 'x-custom-header': 'some-value' } }
+    };
+  }, []);
+  const [{ data, error, fetching }] = useQuery({ query: YourQuery, context} });
+  
+  return <div>{fetching ? 'Loading ...' : 'Data loaded'}</div>;
+}
+```
+
+That way, you'll be able to pass custom headers to your queries/mutations everytime it's needed.

--- a/docs/api/urql.md
+++ b/docs/api/urql.md
@@ -164,7 +164,7 @@ const SomeComponent = (): JSX.Element => {
 
 However you have to make an additional addition to such, as passing the `context` object will cause an infinite loop of re-rendering. In such case, you should memoize the `context` value in order to avoid re-renderings.
 
-```
+```tsx
 import React, { useMemo } from 'react';
 
 const SomeComponent = (): JSX.Element => {


### PR DESCRIPTION
Added a section about setting up custom headers in useQuery/useMutation hooks.

<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

I was looking for information on how to set up custom headers when using `useQuery` and `useMutation` hooks in React applications. I was not able to find it in the existing docs.

## Set of changes

- [x] updated the React usage docs.
