### PR TITLE
Implemented a global context for useMutation hook

### DIFF
--- a/.changeset/wise-days-doubt.md
+++ b/.changeset/wise-days-doubt.md
@@ -1,0 +1,8 @@
+---
+'@urql/preact': minor
+'urql': minor
+'@urql/vue': minor
+'urql-docs': minor
+---
+
+Added a second param to useMutation hook

--- a/docs/api/urql.md
+++ b/docs/api/urql.md
@@ -14,7 +14,7 @@ Accepts a single required options object as an input with the following properti
 | `query`         | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.                       |
 | `variables`     | `?object`                | The variables to be used with the GraphQL request.                                                       |
 | `requestPolicy` | `?RequestPolicy`         | An optional [request policy](./core.md#requestpolicy) that should be used specifying the cache strategy. |
-| `pause`         | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/react-preact.md#pausing-usequery).              |
+| `pause`         | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/react-preact.md#pausing-usequery).         |
 | `context`       | `?object`                | Holds the contextual information for the query.                                                          |
 
 This hook returns a tuple of the shape `[result, executeQuery]`.
@@ -30,13 +30,13 @@ This hook returns a tuple of the shape `[result, executeQuery]`.
 
 ## useMutation
 
-Accepts a single `query` argument of type `string | DocumentNode` and returns a tuple of the shape
+Accepts a `query` argument of type `string | DocumentNode` and a `globalContext` argument of type `Partial<OperationContext>` and returns a tuple of the shape
 `[result, executeMutation]`.
 
 - The `result` is an object with the shape of an [`OperationResult`](./core.md#operationresult) with
   an added `fetching: boolean` property, indicating whether the mutation is being executed.
 - The `executeMutation` function accepts variables and optionally
-  [`Partial<OperationContext>`](./core.md#operationcontext) and may be used to start executing a
+  [`Partial<OperationContext>`](./core.md#operationcontext) (it overwrites the global context param passed when initializing `useMutation`) and may be used to start executing a
   mutation. It returns a `Promise` resolving to an [`OperationResult`](./core.md#operationresult).
 
 [Read more about how to use the `useMutation` API on the "Mutations"
@@ -46,12 +46,12 @@ page.](../basics/react-preact.md#mutations)
 
 Accepts a single required options object as an input with the following properties:
 
-| Prop                                                 | Type                     | Description                                                                        |
-| ---------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------- |
-| `query`                                              | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode. |
-| `variables`                                          | `?object`                | The variables to be used with the GraphQL request.                                 |
-| `pause`                                              | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/react-preact.md#pausing-usequery). |
-| `context`                                            | `?object`                | Holds the contextual information for the query.                                    |
+| Prop        | Type                     | Description                                                                                      |
+| ----------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `query`     | `string \| DocumentNode` | The query to be executed. Accepts as a plain string query or GraphQL DocumentNode.               |
+| `variables` | `?object`                | The variables to be used with the GraphQL request.                                               |
+| `pause`     | `?boolean`               | A boolean flag instructing [execution to be paused](../basics/react-preact.md#pausing-usequery). |
+| `context`   | `?object`                | Holds the contextual information for the query.                                                  |
 
 The hook optionally accepts a second argument, which may be a handler function with a type signature
 of:

--- a/packages/preact-urql/src/hooks/useMutation.ts
+++ b/packages/preact-urql/src/hooks/useMutation.ts
@@ -32,7 +32,8 @@ export type UseMutationResponse<Data = any, Variables = object> = [
 ];
 
 export function useMutation<Data = any, Variables = object>(
-  query: DocumentNode | TypedDocumentNode<Data, Variables> | string
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+  globalMutationContext?: Partial<OperationContext>
 ): UseMutationResponse<Data, Variables> {
   const isMounted = useRef(true);
   const client = useClient();
@@ -45,10 +46,16 @@ export function useMutation<Data = any, Variables = object>(
     (variables?: Variables, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
 
+      let mutationContext = globalMutationContext || {};
+
+      if (context) {
+        mutationContext = context;
+      }
+
       return pipe(
         client.executeMutation<Data, Variables>(
           createRequest<Data, Variables>(query, variables),
-          context || {}
+          mutationContext
         ),
         toPromise
       ).then(result => {
@@ -66,7 +73,7 @@ export function useMutation<Data = any, Variables = object>(
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [client, query, setState]
+    [client, query, setState, globalMutationContext]
   );
 
   useEffect(() => {

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -32,7 +32,8 @@ export type UseMutationResponse<Data = any, Variables = object> = [
 ];
 
 export function useMutation<Data = any, Variables = object>(
-  query: DocumentNode | TypedDocumentNode<Data, Variables> | string
+  query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
+  globalMutationContext?: Partial<OperationContext>
 ): UseMutationResponse<Data, Variables> {
   const isMounted = useRef(true);
   const client = useClient();
@@ -45,10 +46,16 @@ export function useMutation<Data = any, Variables = object>(
     (variables?: Variables, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
 
+      let mutationContext = globalMutationContext || {};
+
+      if (context) {
+        mutationContext = context;
+      }
+
       return pipe(
         client.executeMutation<Data, Variables>(
           createRequest<Data, Variables>(query, variables),
-          context || {}
+          mutationContext
         ),
         toPromise
       ).then(result => {
@@ -66,7 +73,7 @@ export function useMutation<Data = any, Variables = object>(
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [client, query, setState]
+    [client, query, setState, globalMutationContext]
   );
 
   useEffect(() => {

--- a/packages/vue-urql/src/useClientHandle.ts
+++ b/packages/vue-urql/src/useClientHandle.ts
@@ -1,5 +1,5 @@
 import { DocumentNode } from 'graphql';
-import { Client, TypedDocumentNode } from '@urql/core';
+import { Client, TypedDocumentNode, OperationContext } from '@urql/core';
 import {
   WatchStopHandle,
   getCurrentInstance,
@@ -33,7 +33,8 @@ export interface ClientHandle {
   ): UseSubscriptionResponse<T, R, V>;
 
   useMutation<T = any, V = any>(
-    query: TypedDocumentNode<T, V> | DocumentNode | string
+    query: TypedDocumentNode<T, V> | DocumentNode | string,
+    globalMutationContext?: Partial<OperationContext>
   ): UseMutationResponse<T, V>;
 }
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

When using `useQuery` it is possible to pass a context in `useQuery` call. While with `useMutation` the context can be passed at some point later, when invoking `executeMutation` function. With this PR there's a possibility to pass a kind of "global context" to `useMutation` hook that helps to avoid adding the contextual information with every call of `executeMutation` function.

## Set of changes

- [x] added a second param of `globalContext`, type `Partial<OperationContext>`,
- [x] updated tests 

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
