### PR TITLE
(vue) - unwrap the proxy variables before we send it to the urql-client

### DIFF
--- a/.changeset/dull-crabs-sit.md
+++ b/.changeset/dull-crabs-sit.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Unwrap the `variables` proxy before we send it into the client.

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -63,7 +63,7 @@ export function callUseMutation<T = any, V = any>(
 
       return pipe(
         client.executeMutation<T, V>(
-          createRequest<T, V>(query, variables),
+          createRequest<T, V>(query, JSON.parse(JSON.stringify(variables))),
           context || {}
         ),
         take(1),

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -15,6 +15,7 @@ import {
 } from '@urql/core';
 
 import { useClient } from './useClient';
+import { unwrapPossibleProxy } from './utils';
 
 export interface UseMutationState<T, V> {
   fetching: Ref<boolean>;
@@ -63,7 +64,7 @@ export function callUseMutation<T = any, V = any>(
 
       return pipe(
         client.executeMutation<T, V>(
-          createRequest<T, V>(query, JSON.parse(JSON.stringify(variables))),
+          createRequest<T, V>(query, unwrapPossibleProxy<V>(variables)),
           context || {}
         ),
         take(1),

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -79,14 +79,20 @@ export function callUseQuery<T = any, V = object>(
     : ref(!!_args.pause);
 
   const request: Ref<GraphQLRequest<T, V>> = ref(
-    createRequest<T, V>(args.query, args.variables as V) as any
+    createRequest<T, V>(
+      args.query,
+      JSON.parse(JSON.stringify(args.variables)) as V
+    ) as any
   );
 
   const source: Ref<Source<OperationResult> | undefined> = ref();
 
   stops.push(
     watchEffect(() => {
-      const newRequest = createRequest<T, V>(args.query, args.variables as any);
+      const newRequest = createRequest<T, V>(
+        args.query,
+        JSON.parse(JSON.stringify(args.variables)) as V
+      );
       if (request.value.key !== newRequest.key) {
         request.value = newRequest;
       }

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -19,6 +19,7 @@ import {
 } from '@urql/core';
 
 import { useClient } from './useClient';
+import { unwrapPossibleProxy } from './utils';
 
 type MaybeRef<T> = T | Ref<T>;
 
@@ -81,7 +82,7 @@ export function callUseQuery<T = any, V = object>(
   const request: Ref<GraphQLRequest<T, V>> = ref(
     createRequest<T, V>(
       args.query,
-      JSON.parse(JSON.stringify(args.variables)) as V
+      unwrapPossibleProxy<V>(args.variables as V)
     ) as any
   );
 
@@ -91,7 +92,7 @@ export function callUseQuery<T = any, V = object>(
     watchEffect(() => {
       const newRequest = createRequest<T, V>(
         args.query,
-        JSON.parse(JSON.stringify(args.variables)) as V
+        unwrapPossibleProxy<V>(args.variables as V)
       );
       if (request.value.key !== newRequest.key) {
         request.value = newRequest;

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -82,14 +82,20 @@ export function callUseSubscription<T = any, R = T, V = object>(
     : ref(!!_args.pause);
 
   const request: Ref<GraphQLRequest<T, V>> = ref(
-    createRequest<T, V>(args.query, args.variables as V) as any
+    createRequest<T, V>(
+      args.query,
+      JSON.parse(JSON.stringify(args.variables)) as V
+    ) as any
   );
 
   const source: Ref<Source<OperationResult<T, V>> | undefined> = ref();
 
   stops.push(
     watchEffect(() => {
-      const newRequest = createRequest<T, V>(args.query, args.variables as any);
+      const newRequest = createRequest<T, V>(
+        args.query,
+        JSON.parse(JSON.stringify(args.variables)) as V
+      );
       if (request.value.key !== newRequest.key) {
         request.value = newRequest;
       }

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -17,6 +17,7 @@ import {
 } from '@urql/core';
 
 import { useClient } from './useClient';
+import { unwrapPossibleProxy } from './utils';
 
 type MaybeRef<T> = T | Ref<T>;
 
@@ -84,7 +85,7 @@ export function callUseSubscription<T = any, R = T, V = object>(
   const request: Ref<GraphQLRequest<T, V>> = ref(
     createRequest<T, V>(
       args.query,
-      JSON.parse(JSON.stringify(args.variables)) as V
+      unwrapPossibleProxy<V>(args.variables as V)
     ) as any
   );
 
@@ -94,7 +95,7 @@ export function callUseSubscription<T = any, R = T, V = object>(
     watchEffect(() => {
       const newRequest = createRequest<T, V>(
         args.query,
-        JSON.parse(JSON.stringify(args.variables)) as V
+        unwrapPossibleProxy<V>(args.variables as V)
       );
       if (request.value.key !== newRequest.key) {
         request.value = newRequest;

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -1,0 +1,9 @@
+import { Ref } from 'vue';
+
+export function unwrapPossibleProxy<V>(
+  possibleProxy: V | Ref<V> | undefined
+): V {
+  return possibleProxy && typeof possibleProxy === 'object'
+    ? JSON.parse(JSON.stringify(possibleProxy))
+    : possibleProxy;
+}

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -1,9 +1,9 @@
-import { Ref } from 'vue';
+import { Ref, isRef } from 'vue';
 
 export function unwrapPossibleProxy<V>(
   possibleProxy: V | Ref<V> | undefined
-): V {
-  return possibleProxy && typeof possibleProxy === 'object'
-    ? JSON.parse(JSON.stringify(possibleProxy))
+): V | undefined {
+  return possibleProxy && isRef(possibleProxy)
+    ? possibleProxy.value
     : possibleProxy;
 }


### PR DESCRIPTION
Relates to https://github.com/FormidableLabs/urql/discussions/1809

## Summary

When we use `variables` in vue we'll pass it in as a `ref` which in `vue` is a proxy or proxy-like object, this means if we don't unwrap it we'll send this through the exchanges-chain which in this case caused issues in IndexedDB.

I'm wondering if there's more places where we could mutate/.... a variable that goes into the exchange-pipeline.

## Set of changes

- unwrap `variables` proxy-ref before sending it through to the client