### PR TITLE
docs: fixed mutation test example which doesn't pass the test

### DIFF
--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -88,7 +88,7 @@ it('triggers a mutation', () => {
   wrapper.find('button').simulate('click');
 
   expect(mockClient.executeMutation).toBeCalledTimes(1);
-  expect(mockClient.executeMutation).toBeCalledWith(expect.objectContaining({ variables }));
+  expect(mockClient.executeMutation).toBeCalledWith(expect.objectContaining({ variables }), {});
 });
 ```
 


### PR DESCRIPTION
related #868 

## Summary

In the docs, testing mutation example instructs `expect(mockClient.executeMutation).toBeCalledWith(expect.objectContaining({ variables }))`
 but it won't pass the test because the second argument of executeMutation is missing.
This PR adds the second argument to the example in order to avoid confusion.