### PR TITLE
(auth) - expose AuthConfig type

### DIFF
--- a/.changeset/spicy-suits-tease.md
+++ b/.changeset/spicy-suits-tease.md
@@ -2,4 +2,4 @@
 '@urql/exchange-auth': patch
 ---
 
-Expose `AuthContext` type, by [@arempe93](https://github.com/arempe93) (See [#1828](https://github.com/FormidableLabs/urql/pull/1828))
+Expose `AuthContext` type

--- a/.changeset/spicy-suits-tease.md
+++ b/.changeset/spicy-suits-tease.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-auth': patch
+---
+
+Expose `AuthContext` type, by [@arempe93](https://github.com/arempe93) (See [#1828](https://github.com/FormidableLabs/urql/pull/1828))

--- a/exchanges/auth/src/index.ts
+++ b/exchanges/auth/src/index.ts
@@ -1,1 +1,1 @@
-export { authExchange } from './authExchange';
+export { authExchange, AuthConfig } from './authExchange';


### PR DESCRIPTION
## Summary

Exposes the `AuthConfig<T>` type in the auth exchange package. This would be useful for doing something like:

```ts
const baseAuthConfig: AuthConfig<MyAuthContext> = { ... }
```

Currently `AuthConfig` cannot properly be derived at all because it is generic.

```ts
type AuthConfig = Parameters<typeof authExchange>[0] // => AuthConfig<unknown>
```

## Set of changes

 - re-export `AuthConfig<T>` from `authExchange.ts`
