### PR TITLE
(core) - error for invalid operation passed to query/mutation/subscription

### DIFF
--- a/.changeset/weak-doors-cheer.md
+++ b/.changeset/weak-doors-cheer.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Warn for invalid operation passed to query/subscription/mutation

--- a/.changeset/weak-doors-cheer.md
+++ b/.changeset/weak-doors-cheer.md
@@ -1,5 +1,5 @@
 ---
-'@urql/core': minor
+'@urql/core': patch
 ---
 
 Warn for invalid operation passed to query/subscription/mutation

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -213,7 +213,7 @@ describe('executeQuery', () => {
       expect(true).toBeFalsy();
     } catch (e) {
       expect(e.message).toMatchInlineSnapshot(
-        `"Expected operation of type query but found mutation"`
+        `"Expected operation of type \"query\" but found \"mutation\""`
       );
     }
   });

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -52,6 +52,30 @@ const query = {
   variables: { example: 1234 },
 };
 
+const mutation = {
+  key: 1,
+  query: gql`
+    mutation {
+      todos {
+        id
+      }
+    }
+  `,
+  variables: { example: 1234 },
+};
+
+const subscription = {
+  key: 1,
+  query: gql`
+    subscription {
+      todos {
+        id
+      }
+    }
+  `,
+  variables: { example: 1234 },
+};
+
 let receivedOps: Operation[] = [];
 let client = createClient({ url: '1234' });
 const receiveMock = jest.fn((s: Source<Operation>) =>
@@ -119,21 +143,17 @@ describe('promisified methods', () => {
   });
 
   it('mutation', () => {
-    const mutationResult = client
-      .mutation(
-        gql`
-          {
-            todos {
-              id
-            }
-          }
-        `,
-        { example: 1234 }
-      )
-      .toPromise();
+    const mut = gql`
+      mutation {
+        todos {
+          id
+        }
+      }
+    `;
+    const mutationResult = client.mutation(mut, { example: 1234 }).toPromise();
 
     const received = receivedOps[0];
-    expect(print(received.query)).toEqual(print(query.query));
+    expect(print(received.query)).toEqual(print(mut));
     expect(received.key).toBeDefined();
     expect(received.variables).toEqual({ example: 1234 });
     expect(received.kind).toEqual('mutation');
@@ -242,17 +262,17 @@ describe('executeQuery', () => {
 describe('executeMutation', () => {
   it('passes query string exchange', async () => {
     pipe(
-      client.executeMutation(query),
+      client.executeMutation(mutation),
       subscribe(x => x)
     );
 
     const receivedQuery = receivedOps[0].query;
-    expect(print(receivedQuery)).toBe(print(query.query));
+    expect(print(receivedQuery)).toBe(print(mutation.query));
   });
 
   it('passes variables type to exchange', () => {
     pipe(
-      client.executeMutation(query),
+      client.executeMutation(mutation),
       subscribe(x => x)
     );
 
@@ -261,7 +281,7 @@ describe('executeMutation', () => {
 
   it('passes kind type to exchange', () => {
     pipe(
-      client.executeMutation(query),
+      client.executeMutation(mutation),
       subscribe(x => x)
     );
 
@@ -270,7 +290,7 @@ describe('executeMutation', () => {
 
   it('passes url (from context) to exchange', () => {
     pipe(
-      client.executeMutation(query),
+      client.executeMutation(mutation),
       subscribe(x => x)
     );
 
@@ -281,26 +301,26 @@ describe('executeMutation', () => {
 describe('executeSubscription', () => {
   it('passes query string exchange', async () => {
     pipe(
-      client.executeSubscription(query),
+      client.executeSubscription(subscription),
       subscribe(x => x)
     );
 
     const receivedQuery = receivedOps[0].query;
-    expect(print(receivedQuery)).toBe(print(query.query));
+    expect(print(receivedQuery)).toBe(print(subscription.query));
   });
 
   it('passes variables type to exchange', () => {
     pipe(
-      client.executeSubscription(query),
+      client.executeSubscription(subscription),
       subscribe(x => x)
     );
 
-    expect(receivedOps[0]).toHaveProperty('variables', query.variables);
+    expect(receivedOps[0]).toHaveProperty('variables', subscription.variables);
   });
 
   it('passes kind type to exchange', () => {
     pipe(
-      client.executeSubscription(query),
+      client.executeSubscription(subscription),
       subscribe(x => x)
     );
 

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -213,7 +213,7 @@ describe('executeQuery', () => {
       expect(true).toBeFalsy();
     } catch (e) {
       expect(e.message).toMatchInlineSnapshot(
-        `"Expected operation of type \"query\" but found \"mutation\""`
+        `"Expected operation of type \\"query\\" but found \\"mutation\\""`
       );
     }
   });

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -207,6 +207,17 @@ describe('executeQuery', () => {
     expect(print(receivedQuery)).toBe(print(query.query));
   });
 
+  it('should throw when passing in a mutation', () => {
+    try {
+      client.executeQuery(mutation);
+      expect(true).toBeFalsy();
+    } catch (e) {
+      expect(e.message).toMatchInlineSnapshot(
+        `"Expected operation of type query but found mutation"`
+      );
+    }
+  });
+
   it('passes variables type to exchange', () => {
     pipe(
       client.executeQuery(query),

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -290,6 +290,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
 
     createRequestOperation(kind, request, opts) {
       if (
+        kind !== 'teardown' &&
         !request.query.definitions.some(
           x => x.kind === Kind.OPERATION_DEFINITION && x.operation === kind
         ) &&

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -22,7 +22,7 @@ import {
 } from 'wonka';
 
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { DocumentNode } from 'graphql';
+import { DocumentNode, Kind } from 'graphql';
 
 import { composeExchanges, defaultExchanges } from './exchanges';
 import { fallbackExchange } from './exchanges/fallback';
@@ -289,6 +289,24 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     },
 
     createRequestOperation(kind, request, opts) {
+      if (
+        !request.query.definitions.some(
+          x => x.kind === Kind.OPERATION_DEFINITION && x.operation === kind
+        ) &&
+        process.env.NODE_ENV !== 'production'
+      ) {
+        for (let i = 0; i < request.query.definitions.length; i++) {
+          const definition = request.query.definitions[i];
+          if (
+            definition.kind === Kind.OPERATION_DEFINITION &&
+            definition.operation !== kind
+          ) {
+            throw new Error(
+              `Expected operation of type ${kind} but found ${definition.operation}`
+            );
+          }
+        }
+      }
       return makeOperation(kind, request, client.createOperationContext(opts));
     },
 

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -98,3 +98,15 @@ export const getOperationName = (query: DocumentNode): string | undefined => {
     }
   }
 };
+
+/**
+ * Finds the operation-type
+ */
+export const getOperationType = (query: DocumentNode): string | undefined => {
+  for (let i = 0, l = query.definitions.length; i < l; i++) {
+    const node = query.definitions[i];
+    if (node.kind === Kind.OPERATION_DEFINITION) {
+      return node.operation;
+    }
+  }
+};


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/urql/issues/1827

## Summary

Errors out when an invalid operation-node is passed into our client-methods


## Set of changes

 - throw an error when passing in the wrong operation-type to the urql-client