### PR TITLE
expose ExecuteExchangeArgs

### DIFF
--- a/.changeset/sour-goats-agree.md
+++ b/.changeset/sour-goats-agree.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-execute': patch
+---
+
+Expose `ExecuteExchangeArgs` interface

--- a/exchanges/execute/src/execute.ts
+++ b/exchanges/execute/src/execute.ts
@@ -24,7 +24,7 @@ import {
   getOperationName,
 } from '@urql/core';
 
-interface ExecuteExchangeArgs {
+export interface ExecuteExchangeArgs {
   schema: GraphQLSchema;
   rootValue?: any;
   context?: ((op: Operation) => void) | any;

--- a/exchanges/execute/src/index.ts
+++ b/exchanges/execute/src/index.ts
@@ -1,1 +1,1 @@
-export { executeExchange } from './execute';
+export { executeExchange, ExecuteExchangeArgs } from './execute';


### PR DESCRIPTION
## Summary

This PR exposes ExecuteExchangeArgs from execute-exchange which would be useful when you wrap executeExchange in your function and pass the configuration args accordingly (e.g. testing).

## Set of changes
* export ExecuteExchangeArgs
