### PR TITLE
(core) - fix single-source behavior in integrations

### DIFF
--- a/.changeset/popular-mirrors-lick.md
+++ b/.changeset/popular-mirrors-lick.md
@@ -1,0 +1,8 @@
+---
+'@urql/core': patch
+---
+
+The [single-source behavior previously](https://github.com/FormidableLabs/urql/pull/1515) wasn't effective for implementations like React,
+where the issue presents itself when the state of an operation is first polled. This led to the operation being torn down erroneously.
+
+We now ensure that operations started at the same time still use a shared single-source.


### PR DESCRIPTION
## Summary

The [single-source behavior previously](https://github.com/FormidableLabs/urql/pull/1515) wasn't effective for implementations like React, where the issue presents itself when the state of an operation is first polled. This led to the operation being torn down erroneously.

Fix #1841

## Set of changes

- We now ensure that operations started at the same time still use a shared single-source.
