### PR TITLE
(core) - prevent mangling embedded strings in queries

### DIFF
--- a/.changeset/giant-jobs-cross.md
+++ b/.changeset/giant-jobs-cross.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix prevent mangling embedded strings in queries sent using the `GET` method.

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -40,9 +40,7 @@ export const makeFetchURL = (
   if (body.query) {
     search.push(
       'query=' +
-        encodeURIComponent(
-          body.query.replace(/([\s,]|#[^\n\r]+)+/g, ' ').trim()
-        )
+        encodeURIComponent(body.query.replace(/#[^\n\r]+/g, ' ').trim())
     );
   }
 


### PR DESCRIPTION
## Summary

Fix prevent mangling embedded strings in queries sent using the `GET` method.

## Set of changes

- Alter the regex so it only removes comments
