### PR TITLE
(core) - Add staleWhileRevalidate option to ssrExchange

### DIFF
--- a/.changeset/new-horses-bow.md
+++ b/.changeset/new-horses-bow.md
@@ -1,0 +1,5 @@
+---
+'next-urql': minor
+---
+
+Add new `staleWhileRevalidate` option from the `ssrExchange` addition to `withUrqlClient`'s options. This is useful when Next.js is used in static site generation (SSG) mode.

--- a/.changeset/spicy-poems-rule.md
+++ b/.changeset/spicy-poems-rule.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Add a `staleWhileRevalidate` option to the `ssrExchange`, which allows the client to immediately refetch a new result on hydration, which may be used for cached / stale SSR or SSG pages. This is different from using `cache-and-network` by default (which isn't recommended) as the `ssrExchange` typically acts like a "replacement fetch request".

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -280,11 +280,13 @@ The `ssrExchange` as [described on the "Server-side Rendering"
 page.](../advanced/server-side-rendering.md).
 It's of type `Options => Exchange`.
 
-It accepts two inputs, `initialState` which is completely
+It accepts three inputs, `initialState` which is completely
 optional and populates the server-side rendered data with
-a rehydrated cache, and `isClient` which can be set to
+a rehydrated cache, `isClient` which can be set to
 `true` or `false` to tell the `ssrExchange` whether to
-write to (server-side) or read from (client-side) the cache.
+write to (server-side) or read from (client-side) the cache, and
+`staleWhileRevalidate` which will treat rehydrated data as stale
+and refetch up-to-date data by reexecuring the operation using a `network-only` requests policy.
 
 By default, `isClient` defaults to `true` when the `Client.suspense`
 mode is disabled and to `false` when the `Client.suspense` mode

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -155,7 +155,7 @@ export const cacheExchange: Exchange = ({ forward, client, dispatchDebug }) => {
 };
 
 // Reexecutes a given operation with the default requestPolicy
-const reexecuteOperation = (client: Client, operation: Operation) => {
+export const reexecuteOperation = (client: Client, operation: Operation) => {
   return client.reexecuteOperation(
     makeOperation(operation.kind, operation, {
       ...operation.context,

--- a/packages/next-urql/src/types.ts
+++ b/packages/next-urql/src/types.ts
@@ -54,4 +54,5 @@ export interface SSRExchange extends Exchange {
 export interface WithUrqlClientOptions {
   ssr?: boolean;
   neverSuspend?: boolean;
+  staleWhileRevalidate?: boolean;
 }

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -52,7 +52,11 @@ export function withUrqlClient(
 
         if (!ssr || typeof window === 'undefined') {
           // We want to force the cache to hydrate, we do this by setting the isClient flag to true
-          ssr = ssrExchange({ initialState: urqlServerState, isClient: true });
+          ssr = ssrExchange({
+            initialState: urqlServerState,
+            isClient: true,
+            staleWhileRevalidate: options!.staleWhileRevalidate,
+          });
         } else if (!version) {
           ssr.restoreData(urqlServerState);
         }


### PR DESCRIPTION
Resolve #1846

## Summary

This adds a `staleWhileRevalidate` option to both the `ssrExchange` and `next-urql`'s `withUrqlClient`, which allows the `ssrExchange` to mark a result as stale while it forcefully refetches a new server result. This is similar but different to `cache-and-network` as we wouldn't recommend changing the request policy on every operation by default, which would also be ineffective as the `ssrExchange` "imitates" full network results.

## Set of changes

- Add `staleWhileRevalidate` to `ssrExchange` in `@urql/core`
- Add `staleWhileRevalidate` to `withUrqlClient` in `next-urql`
