### PR TITLE
(core) - mark query.__key as non-enumerable

### DIFF
--- a/.changeset/rude-pumpkins-yawn.md
+++ b/.changeset/rude-pumpkins-yawn.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix mark `query.__key` as non-enumerable so `formatDocument` does not restore previous invocations when cloning the gql-ast.

--- a/packages/core/src/utils/typenames.test.ts
+++ b/packages/core/src/utils/typenames.test.ts
@@ -49,6 +49,15 @@ describe('formatTypeNames', () => {
     expect(expectedKey).toBe(actualKey);
   });
 
+  it('does not preserve the referential integrity with a cloned object', () => {
+    const doc = parse(`{ id todos { id } }`);
+    const formattedDoc = formatDocument(doc);
+    expect(formattedDoc).not.toBe(doc);
+    const query = { ...formattedDoc };
+    const reformattedDoc = formatDocument(query);
+    expect(reformattedDoc).not.toBe(doc);
+  });
+
   it('preserves custom properties', () => {
     const doc = parse(`{ todos { id } }`) as any;
     doc.documentId = '123';

--- a/packages/core/src/utils/typenames.ts
+++ b/packages/core/src/utils/typenames.ts
@@ -76,8 +76,16 @@ export const formatDocument = <T extends DocumentNode>(node: T): T => {
       Field: formatNode,
       InlineFragment: formatNode,
     }) as KeyedDocumentNode;
+
     // Ensure that the hash of the resulting document won't suddenly change
-    result.__key = query.__key;
+    // we are marking __key as non-enumerable so when external exchanges use visit
+    // to manipulate a document we won't restore the previous query due to the __key
+    // property.
+    Object.defineProperty(result, '__key', {
+      value: query.__key,
+      enumerable: false,
+    });
+
     formattedDocs.set(query.__key, result);
   }
 


### PR DESCRIPTION
## Summary

When a plugin manipulates `operation.query` with for instance removing a directive, changing the selectionSet, ... we would restore the original query with subsequent invocations of `formatDocument`. By marking `query.__key` as non-enumerable we prevent this, this does assume that the consuming exchange uses `visit` or any other cloning traversal mechanism to manipulate the query.

## Set of changes

- mark `query.__key` as non-enumerable
