### PR TITLE
(core) - update toPromise to exclude `hasNext` results

### DIFF
--- a/.changeset/thick-seals-wait.md
+++ b/.changeset/thick-seals-wait.md
@@ -1,0 +1,7 @@
+---
+"@urql/core": patch
+---
+
+Fix: update toPromise to exclude `hasNext` results. This change ensures that
+when we call toPromise() on a query we wont serve an incomplete result, the
+user will expect to receive a non-stale full-result when using toPromise()

--- a/packages/core/src/utils/streamUtils.ts
+++ b/packages/core/src/utils/streamUtils.ts
@@ -7,7 +7,7 @@ export function withPromise<T extends OperationResult>(
   (source$ as PromisifiedSource<T>).toPromise = () => {
     return pipe(
       source$,
-      filter(result => !result.stale),
+      filter(result => !result.stale && !result.hasNext),
       take(1),
       toPromise
     );


### PR DESCRIPTION
## Summary

This change ensures that when we call `toPromise()` on a query we wont serve an incomplete result, the user will expect to receive a non-stale full-result when using `toPromise()`

## Set of changes

- Account for `hasNext` in `toPromise`
