### PR TITLE
(next) - fix issue with next where staleWhileRevalidate would loop

### DIFF
--- a/.changeset/six-walls-jump.md
+++ b/.changeset/six-walls-jump.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Fix issue where the `renderToString` pass would keep looping due to reexecuting operations on the server

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -55,7 +55,10 @@ export function withUrqlClient(
           ssr = ssrExchange({
             initialState: urqlServerState,
             isClient: true,
-            staleWhileRevalidate: options!.staleWhileRevalidate,
+            staleWhileRevalidate:
+              typeof window !== 'undefined'
+                ? options!.staleWhileRevalidate
+                : undefined,
           });
         } else if (!version) {
           ssr.restoreData(urqlServerState);


### PR DESCRIPTION
## Summary

Relates to https://github.com/FormidableLabs/urql/issues/1888

When next resolves `getStaticProps` we rely on the `props.urqlState` to be hydrated during the `renderToString` this ensures that we actually use the data from this call on the server. The issue presents itself when we are in a `renderToString` pass and the exchange opts to mark the result as `stale` and perform a `reexecute`.

## Set of changes

- avoid data being `reexecuted` due to `staleWhileRevalidate` on the server
