### PR TITLE
(graphcache) - only allow for one onOnline listener at a given time

### DIFF
--- a/.changeset/strong-turkeys-approve.md
+++ b/.changeset/strong-turkeys-approve.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Cleanup the previous `onOnline` event-listener when called again

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -34,6 +34,8 @@ export interface DefaultStorage extends StorageAdapter {
 export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
   if (!opts) opts = {};
 
+  let callback: (() => void) | undefined;
+
   const DB_NAME = opts.idbName || 'graphcache-v4';
   const ENTRIES_STORE_NAME = 'entries';
   const METADATA_STORE_NAME = 'metadata';
@@ -195,9 +197,17 @@ export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
     },
 
     onOnline(cb: () => void) {
-      window.addEventListener('online', () => {
-        cb();
-      });
+      if (callback) {
+        window.removeEventListener('online', callback);
+        callback = undefined;
+      }
+
+      window.addEventListener(
+        'online',
+        (callback = () => {
+          cb();
+        })
+      );
     },
   };
 };


### PR DESCRIPTION
## Summary

When we reset the urql-client a few time the `offlineExchange` will call `onOnline` again, however the `default-storage` instance stays the same as it's globally defined most of the time (in our examples, ...), this holds a reference to the currently defined callback and removes the event-listener when we call `onOnline` again.

Resolves https://github.com/FormidableLabs/urql/issues/1876

## Set of changes

- remove event-listener on repeated `onOnline` calls
