### PR TITLE
(graphcache) - Remove hasNext from stale results

### DIFF
--- a/.changeset/swift-apples-flash.md
+++ b/.changeset/swift-apples-flash.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Remove `hasNext: true` flag from stale responses. This was erroneously added in debugging, but leads to stale responses being marked with `hasNext`, which means the `dedupExchange` will keep waiting for further network responses.

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -322,7 +322,6 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
               outcome === 'partial')
           ) {
             result.stale = true;
-            result.hasNext = true;
             if (!isBlockedByOptimisticUpdate(dependencies)) {
               client.reexecuteOperation(
                 toRequestPolicy(operation, 'network-only')


### PR DESCRIPTION
Resolves #1904

## Summary

We've forgotten to remove `hasNext: true` from debugging in Graphcache's `cacheExchange`, which causes each stale result to be marked with `hasNext: true`. This erroneously causes the `dedupExchange` to prevent further operations, although this wasn't intended.

## Set of changes

- Remove `result.hasNext = true` from `cacheExchange` generated stale results
