### PR TITLE
Use uncompiled files in a Svelte project

### DIFF
--- a/packages/svelte-urql/package.json
+++ b/packages/svelte-urql/package.json
@@ -21,6 +21,7 @@
   ],
   "main": "dist/urql-svelte",
   "module": "dist/urql-svelte.mjs",
+  "svelte": "src/index.ts",
   "types": "dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {

--- a/packages/svelte-urql/src/context.ts
+++ b/packages/svelte-urql/src/context.ts
@@ -1,5 +1,8 @@
+import type { ClientOptions } from '@urql/core';
+
 import { setContext, getContext } from 'svelte';
-import { Client, ClientOptions } from '@urql/core';
+import { Client } from '@urql/core';
+
 import { _contextKey } from './internal';
 
 export const getClient = (): Client => getContext(_contextKey);

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -1,12 +1,10 @@
-import { Readable, writable } from 'svelte/store';
-import { DocumentNode } from 'graphql';
-import { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import {
-  OperationContext,
-  CombinedError,
-  createRequest,
-  stringifyVariables,
-} from '@urql/core';
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import type { OperationContext, CombinedError } from '@urql/core';
+import type { DocumentNode } from 'graphql';
+import type { Readable } from 'svelte/store';
+
+import { createRequest, stringifyVariables } from '@urql/core';
+import { writable } from 'svelte/store';
 
 import { _storeUpdate } from './internal';
 

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -1,15 +1,15 @@
-import { onDestroy } from 'svelte';
-
-import {
-  createRequest,
+import type {
   OperationContext,
   OperationResult,
   GraphQLRequest,
   TypedDocumentNode,
 } from '@urql/core';
+import type { DocumentNode } from 'graphql';
+import type { Source } from 'wonka';
 
+import { onDestroy } from 'svelte';
+import { createRequest } from '@urql/core';
 import {
-  Source,
   pipe,
   map,
   make,
@@ -22,10 +22,11 @@ import {
   take,
 } from 'wonka';
 
-import { OperationStore, operationStore } from './operationStore';
+import type { OperationStore } from './operationStore';
+
+import { operationStore } from './operationStore';
 import { getClient } from './context';
 import { _markStoreUpdate } from './internal';
-import { DocumentNode } from 'graphql';
 
 interface SourceRequest<Data = any, Variables = object>
   extends GraphQLRequest<Data, Variables> {


### PR DESCRIPTION
## Summary

In a Svelte project I can use the `*.svelte` and `*.ts` uncompiled files directly in my project and compile them with my own bundler.

## Set of changes

1. Add `"svelte": "src/index.ts"` line to `package.json`;
1. fix `import type` when needed (for compliance with default SvelteKit tsconfig);
1. **what I don't know is how to export `src` dir in the final bundle, can you please enlight me?**
