### PR TITLE
(svelte) - add missing `pause` on the `operationStore`

### DIFF
--- a/.changeset/cool-zoos-whisper.md
+++ b/.changeset/cool-zoos-whisper.md
@@ -1,0 +1,5 @@
+---
+"@urql/svelte": patch
+---
+
+Add missing `pause` on the `operationStore` return value

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -21,7 +21,7 @@ export interface OperationStore<Data = any, Vars = any, Result = Data>
   // Input properties
   query: DocumentNode | TypedDocumentNode<Data, Vars> | string;
   variables: Vars | null;
-  context: Partial<OperationContext> | undefined;
+  context: Partial<OperationContext & { pause: boolean }> | undefined;
   // Output properties
   readonly stale: boolean;
   readonly fetching: boolean;


### PR DESCRIPTION
## Summary

Fixes #1924 

## Set of changes

- add missing property on operationStore return type