### PR TITLE
(core) - fix issue with ssr-exchange looping for reexecuted ops

### DIFF
--- a/.changeset/flat-queens-refuse.md
+++ b/.changeset/flat-queens-refuse.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix issue where the ssr-exchange would loop due to checking network-only revalidations

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -80,6 +80,8 @@ const deserializeResult = (
   hasNext: result.hasNext,
 });
 
+const revalidated = new Set<number>();
+
 /** The ssrExchange can be created to capture data during SSR and also to rehydrate it on the client */
 export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
   const staleWhileRevalidate = !!(params && params.staleWhileRevalidate);
@@ -128,8 +130,9 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
       map(op => {
         const serialized = data[op.key]!;
         const result = deserializeResult(op, serialized);
-        if (staleWhileRevalidate) {
+        if (staleWhileRevalidate && !revalidated.has(op.key)) {
           result.stale = true;
+          revalidated.add(op.key);
           reexecuteOperation(client, op);
         }
 


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/urql/issues/1888

## Summary

When an operation would get reexecuted due to `staleWhileRevalidate: true` it would keep on hitting this branch as we don't filter out `network-only` results from the `ssrCache` response

## Set of changes

- Guard against infinite loops within the `ssrExchange`
