### PR TITLE
(graphcache) - improve perf by using String.indexOf in getField

### DIFF
--- a/.changeset/afraid-kiwis-end.md
+++ b/.changeset/afraid-kiwis-end.md
@@ -1,0 +1,5 @@
+---
+"@urql/exchange-graphcache": patch
+---
+
+Improve perf by using String.indexOf in getField

--- a/.changeset/afraid-kiwis-end.md
+++ b/.changeset/afraid-kiwis-end.md
@@ -1,5 +1,5 @@
 ---
-"@urql/exchange-graphcache": patch
+'@urql/exchange-graphcache': patch
 ---
 
-Improve perf by using String.startsWith in getField
+Improve perf by using String.indexOf in getField

--- a/.changeset/afraid-kiwis-end.md
+++ b/.changeset/afraid-kiwis-end.md
@@ -2,4 +2,4 @@
 "@urql/exchange-graphcache": patch
 ---
 
-Improve perf by using String.indexOf in getField
+Improve perf by using String.startsWith in getField

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -39,8 +39,8 @@ export const isFieldAvailableOnType = (
   typename: string,
   fieldName: string
 ): boolean =>
-  fieldName.indexOf(BUILTIN_NAME) === 0 ||
-  typename.indexOf(BUILTIN_NAME) === 0 ||
+  fieldName.startsWith(BUILTIN_NAME) ||
+  typename.startsWith(BUILTIN_NAME) ||
   !!getField(schema, typename, fieldName);
 
 export const isInterfaceOfType = (
@@ -69,10 +69,7 @@ const getField = (
   typename: string,
   fieldName: string
 ) => {
-  if (
-    fieldName.indexOf(BUILTIN_NAME) === 0 ||
-    typename.indexOf(BUILTIN_NAME) === 0
-  ) return;
+  if (fieldName.startsWith(BUILTIN_NAME) || typename.startsWith(BUILTIN_NAME)) return;
 
   expectObjectType(schema, typename);
   const object = schema.types![typename] as SchemaObject;

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -11,7 +11,7 @@ import {
   OptimisticMutationConfig,
 } from '../types';
 
-const BUILTIN_NAME = "__";
+const BUILTIN_NAME = '__';
 
 export const isFieldNullable = (
   schema: SchemaIntrospector,
@@ -39,8 +39,8 @@ export const isFieldAvailableOnType = (
   typename: string,
   fieldName: string
 ): boolean =>
-  fieldName.startsWith(BUILTIN_NAME) ||
-  typename.startsWith(BUILTIN_NAME) ||
+  fieldName.indexOf(BUILTIN_NAME) === 0 ||
+  typename.indexOf(BUILTIN_NAME) === 0 ||
   !!getField(schema, typename, fieldName);
 
 export const isInterfaceOfType = (
@@ -69,7 +69,11 @@ const getField = (
   typename: string,
   fieldName: string
 ) => {
-  if (fieldName.startsWith(BUILTIN_NAME) || typename.startsWith(BUILTIN_NAME)) return;
+  if (
+    fieldName.indexOf(BUILTIN_NAME) === 0 ||
+    typename.indexOf(BUILTIN_NAME) === 0
+  )
+    return;
 
   expectObjectType(schema, typename);
   const object = schema.types![typename] as SchemaObject;

--- a/exchanges/graphcache/src/ast/schemaPredicates.ts
+++ b/exchanges/graphcache/src/ast/schemaPredicates.ts
@@ -11,7 +11,7 @@ import {
   OptimisticMutationConfig,
 } from '../types';
 
-const BUILTIN_NAME_RE = /^__/;
+const BUILTIN_NAME = "__";
 
 export const isFieldNullable = (
   schema: SchemaIntrospector,
@@ -39,8 +39,8 @@ export const isFieldAvailableOnType = (
   typename: string,
   fieldName: string
 ): boolean =>
-  BUILTIN_NAME_RE.test(fieldName) ||
-  BUILTIN_NAME_RE.test(typename) ||
+  fieldName.indexOf(BUILTIN_NAME) === 0 ||
+  typename.indexOf(BUILTIN_NAME) === 0 ||
   !!getField(schema, typename, fieldName);
 
 export const isInterfaceOfType = (
@@ -69,7 +69,10 @@ const getField = (
   typename: string,
   fieldName: string
 ) => {
-  if (BUILTIN_NAME_RE.test(typename) || BUILTIN_NAME_RE.test(fieldName)) return;
+  if (
+    fieldName.indexOf(BUILTIN_NAME) === 0 ||
+    typename.indexOf(BUILTIN_NAME) === 0
+  ) return;
 
   expectObjectType(schema, typename);
   const object = schema.types![typename] as SchemaObject;


### PR DESCRIPTION
## Summary

[benchmark](https://perf.link/#eyJpZCI6InNlZjQ2MWM3NDFrIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSAnX190eXBlbmFtZSc7XG5jb25zdCBCVUlMVElOX05BTUVfUkUgPSAvXl9fLztcbmNvbnN0IEJVSUxUSU5fTkFNRSA9ICdfXyc7IiwidGVzdHMiOlt7Im5hbWUiOiJpbmRleE9mIiwiY29kZSI6ImRhdGEuaW5kZXhPZihCVUlMVElOX05BTUUpID09PSAwOyIsInJ1bnMiOlszOTUwMDAwLDQwMDIwMDAsMjY0MDAwMCwzNDk3MDAwLDE4ODEwMDAsMTI1OTAwMCw0MTQ5MDAwLDM1MjIwMDAsMTg5MjAwMCwyMzc0MDAwLDMwNDgwMDAsMTI4ODAwMCwxODEwMDAsODMwMDAwLDExNDAwMDAsMTk0NzAwMCwyNTU3MDAwLDM3MDAwMDAsNDA2OTAwMCwxNzk4MDAwLDEzNTAwMCwzMTgwMDAsMjI4NjAwMCwxODc2MDAwLDE4MzkwMDAsMzA0OTAwMCwxNjM1MDAwLDE4MTEwMDAsMzYyODAwMCwzMzYyMDAwLDE0ODEwMDAsMTk0MzAwMCwxNzg3MDAwLDIyNTIwMDAsMzM3NjAwMCwxOTM4MDAwLDI0MTAwMDAsMjUwODAwMCwzMDY4MDAwLDg4NjAwMCwxMTAwMDAwLDMxNDkwMDAsMTQyOTAwMCw2NzIwMDAsMjY5NjAwMCwxMzAwMCw1NjcwMDAsNjM2MDAwLDE3MDAwLDMxMTkwMDAsOTgwMDAsMzczNjAwMCwxNDcyMDAwLDQxNzUwMDAsOTg1MDAwLDE0MzYwMDAsMzI4NTAwMCw5NzEwMDAsMTk3MzAwMCwxODQyMDAwLDI1NzAwMDAsMTQ0NjAwMCwxMDgxMDAwLDMxNzgwMDAsMTA4MjAwMCwxNDY3MDAwLDQwNTYwMDAsMTA3NzAwMCwxNjIzMDAwLDI0MzMwMDAsMzczNzAwMCwxNjM3MDAwLDE4MTAwMCwzMTgxMDAwLDI5MDYwMDAsMjI2NDAwMCwyOTYzMDAwLDIwNjEwMDAsNjEyMDAwLDQwMjEwMDAsMTg2ODAwMCwzNDg0MDAwLDc5MjAwMCw1MjcwMDAsMjQ1NTAwMCwzMTMwMDAsMzIyMDAwLDMxMjYwMDAsMzc1NDAwMCwzMjUyMDAwLDIxMjkwMDAsMjgyMDAwMCwxNDAzMDAwLDExMTUwMDAsMjk5NDAwMCwxMTU4MDAwLDIyMjYwMDAsNDE0NTAwMCw3NTcwMDAsNTkwMDBdLCJvcHMiOjIwNjk1ODB9LHsibmFtZSI6InN0YXJ0c1dpdGgiLCJjb2RlIjoiZGF0YS5zdGFydHNXaXRoKEJVSUxUSU5fTkFNRSk7IiwicnVucyI6WzMwMTcwMDAsMjQ5NTAwMCwxNjEwMDAwLDQxMTkwMDAsODk1MDAwLDM2MDcwMDAsMzM5NzAwMCwzMTc2MDAwLDMzMTUwMDAsNDQxMDAwLDIxOTEwMDAsMjA4NzAwMCwyNTcwMDAwLDM1ODQwMDAsMzYxNTAwMCwzOTA2MDAwLDIyNzkwMDAsMjExNzAwMCwyOTIwMDAwLDg4MjAwMCwxNzE3MDAwLDc2NDAwMCwyNDg1MDAwLDEwNDAwMDAsNjgwMDAsNDI5MDAwLDMzMjYwMDAsMzQwMzAwMCwzNzcxMDAwLDE4NDAwMDAsMTczMDAwMCwzNjYwMDAsMTAzNDAwMCwxMjgwMDAwLDM0NDUwMDAsMTkwMDAsMjE2NTAwMCw2MzEwMDAsMTYzMDAwMCw2OTMwMDAsMzY3MDAwMCw5ODQwMDAsMTcwMDAsMjAwMDAsMjI3NDAwMCwxMzQwMDAwLDQyMDMwMDAsMjc5MzAwMCw5NTIwMDAsMTY3MzAwMCwyMzAxMDAwLDQ1MjgwMDAsMjkyODAwMCwzODEyMDAwLDk2MjAwMCw2MDEwMDAsMjUwODAwMCwxODM0MDAwLDIwMDMwMDAsMzI5OTAwMCw0MDc0MDAwLDk2OTAwMCwzODkwMDAsMzkxMjAwMCwyMjg2MDAwLDQyOTUwMDAsMjM5OTAwMCwzNzk3MDAwLDM1MjcwMDAsMzc2MDAwLDQzOTAwMCw0NzUwMDAsMzA3MzAwMCwyOTk4MDAwLDM5MDAwLDQxMjcwMDAsMTc4MTAwMCwxMDg5MDAwLDY3MDAwMCwyOTg3MDAwLDE5MTUwMDAsMTUyNDAwMCw5NDYwMDAsMjM4NTAwMCwxMjM2MDAwLDIxOTAwMCwxMTEwMDAsMjMzNjAwMCwzNDQxMDAwLDI5NDUwMDAsNDcxMDAwLDc1MDAwMCwxNDUwMDAsMTk4NjAwMCw2NDMwMDAsMTg3MDAwMCwxMzc3MDAwLDM0MDMwMDAsMjg1OTAwMCwzODQ0MDAwXSwib3BzIjoyMDQ4NjkwfSx7Im5hbWUiOiJSZWdleCIsImNvZGUiOiJCVUlMVElOX05BTUVfUkUudGVzdChkYXRhKSIsInJ1bnMiOls0OTEwMDAsNDQ2MDAwLDIxNTAwMCwzNjkzMDAwLDc0MDAwLDk0MjAwMCwzMTY3MDAwLDQ2NjAwMCwxNjAyMDAwLDI0OTUwMDAsMTM2MDAwLDE5MTMwMDAsMjgxMDAwMCwyMDAwLDE2OTYwMDAsMTE2OTAwMCwyMDAwLDE0NTcwMDAsMzEwMzAwMCwxNzAxMDAwLDIzNzEwMDAsMzQ1MzAwMCwyMDAwLDI3NjIwMDAsMTQxNzAwMCwxNzAwMCwzMTE5MDAwLDk1ODAwMCwzMTgwMDAsMjAwMCwyMDAwLDEwNjIwMDAsMTAwMCwyMDAwLDEwMDAwMDAsMTIzNjAwMCw1MTAwMDAsMTMwNjAwMCwxNjczMDAwLDY0NDAwMCwxODg1MDAwLDMyNTkwMDAsNTMxMDAwLDE0MzYwMDAsMTY4MDAwMCwzOTcwMDAsMTQxODAwMCwzMTgwMDAsMjAwMCwzMTAyMDAwLDEwMDAsMjk1MDAwMCwyNTcwMDAwLDE5ODkwMDAsMTM0MDAwMCwzMjAwMCwxNjYyMDAwLDI4NTAwMCw4OTcwMDAsMTk4MjAwMCwyMzc2MDAwLDEwMzUwMDAsMTQ3NzAwMCwyMTQ0MDAwLDEyNjUwMDAsNTM2MDAwLDE3MzcwMDAsMjAwMCwxMjU2MDAwLDkyMDAwLDIwMDAsMTUyNzAwMCwxMTQzMDAwLDEwMDAsNTQzMDAwLDEyMDYwMDAsMTcwMDAwLDMwOTcwMDAsMzE4OTAwMCwxMzAzMDAwLDM3MTAwMCwyNTYxMDAwLDE3ODUwMDAsMTc3OTAwMCwyODIxMDAwLDExMTAwMCwyNzM1MDAwLDM1MzcwMDAsODc1MDAwLDY2NTAwMCwxOTcxMDAwLDI0OTAwMCwxNzI2MDAwLDEwMDAsMTAwMCwyMDQ2MDAwLDMyNTAwMDAsMjQ2MDAwLDI4MjMwMDAsMTM1MzAwMF0sIm9wcyI6MTMyMTc4MH1dLCJ1cGRhdGVkIjoiMjAyMS0wOS0xM1QxNDoxNDozNC4zOTVaIn0%3D)

## Set of changes

- remove regex and use `indexOf`