### PR TITLE
(vue) - allow for passing in the client as a ref

### DIFF
--- a/.changeset/tasty-dragons-check.md
+++ b/.changeset/tasty-dragons-check.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': minor
+---
+
+Allow passing in a Ref of client to `provideClient`

--- a/.changeset/tasty-dragons-check.md
+++ b/.changeset/tasty-dragons-check.md
@@ -2,4 +2,4 @@
 '@urql/vue': minor
 ---
 
-Allow passing in a Ref of client to `provideClient`
+Allow passing in a Ref of client to `provideClient` and `install`

--- a/packages/vue-urql/src/useClient.ts
+++ b/packages/vue-urql/src/useClient.ts
@@ -1,14 +1,25 @@
-import { App, getCurrentInstance, inject, provide } from 'vue';
+import { App, getCurrentInstance, inject, provide, Ref, isRef } from 'vue';
 import { Client, ClientOptions } from '@urql/core';
 
-export function provideClient(opts: ClientOptions | Client) {
-  const client = opts instanceof Client ? opts : new Client(opts);
+export function provideClient(opts: ClientOptions | Client | Ref<Client>) {
+  let client: Client;
+  if (isRef(opts)) {
+    client = opts.value;
+  } else {
+    client = opts instanceof Client ? opts : new Client(opts);
+  }
+
   provide('$urql', client);
   return client;
 }
 
-export function install(app: App, opts: ClientOptions | Client) {
-  const client = opts instanceof Client ? opts : new Client(opts);
+export function install(app: App, opts: ClientOptions | Client | Ref<Client>) {
+  let client: Client;
+  if (isRef(opts)) {
+    client = opts.value;
+  } else {
+    client = opts instanceof Client ? opts : new Client(opts);
+  }
   app.provide('$urql', client);
 }
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/FormidableLabs/urql/discussions/1961

## Set of changes

- Allow for passing in `Ref<Client>` to `provideClient` and `install`
