### PR TITLE
(chore) - fix broken link to architecture page

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The documentation contains everything you need to know about `urql`, and contain
 when you first get started:
 
 - **[Basics](https://formidable.com/open-source/urql/docs/basics/)** — contains the ["Getting Started" guide](https://formidable.com/open-source/urql/docs/#where-to-start) and all you need to know when first using `urql`.
-- **[Main Concepts](https://formidable.com/open-source/urql/docs/concepts/)** — explains how `urql` functions and is built and covers GraphQL clients in general, on the ["Architecture" page](https://formidable.com/open-source/urql/docs/architecture).
+- **[Architecture](https://formidable.com/open-source/urql/docs/architecture/)** — explains how `urql` functions and is built.
 - **[Advanced](https://formidable.com/open-source/urql/docs/advanced/)** — covers more uncommon use-cases and things you don't immediately need when getting started.
 - **[Graphcache](https://formidable.com/open-source/urql/docs/graphcache/)** — documents ["Normalized Caching" support](https://formidable.com/open-source/urql/docs/graphcache/normalized-caching/) which enables more complex apps and use-cases.
 - **[API](https://formidable.com/open-source/urql/docs/api/)** — the API documentation for each individual package.


### PR DESCRIPTION
## Summary

Resolves https://github.com/FormidableLabs/urql/issues/1959

## Set of changes

- consolidate concepts link to only include architecture
