### PR TITLE
(react) - fix issue with paused queries not executing correctly

### DIFF
--- a/.changeset/smart-bags-confess.md
+++ b/.changeset/smart-bags-confess.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Fix issue where a paused query would not behave correctly when calling `executeQuery`, this scenario occured when the query has variables, there would be cases where on the first call it would think that the dependencies had changed (previous request vs current request) which made the source reset to null

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -207,7 +207,7 @@ export function useQuery<Data = any, Variables = object>(
               })
             )
           : client.executeQuery(request, context);
-        return [source, state[1], state[2]];
+        return [source, state[1], deps];
       });
     },
     [


### PR DESCRIPTION
## Summary

Fix issue where a paused query would not behave correctly when calling `executeQuery`, this scenario occured when the query has variables, there would be cases where on the first call it would think that the dependencies had changed (previous request vs current request) which made the source reset to null.

Fixes #1978 

## Set of changes

- update the state to reflect latest deps when calling `executeQuery`
