### PR TITLE
(graphcache) - Fix nullable lists with schema awareness

### DIFF
--- a/.changeset/polite-jobs-call.md
+++ b/.changeset/polite-jobs-call.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix regression from [#1869](https://github.com/FormidableLabs/urql/pull/1869) that caused nullable lists to always cause a cache miss, if schema awareness is enabled.

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -500,7 +500,8 @@ const resolveResolverResult = (
       if (childResult === undefined && !_isListNullable) {
         return undefined;
       } else {
-        ctx.partial = ctx.partial || _isListNullable;
+        ctx.partial =
+          ctx.partial || (childResult === undefined && _isListNullable);
         data[i] = childResult != null ? childResult : null;
         hasChanged = hasChanged || data[i] !== prevData![i];
       }
@@ -565,7 +566,8 @@ const resolveLink = (
       if (childLink === undefined && !_isListNullable) {
         return undefined;
       } else {
-        ctx.partial = ctx.partial || _isListNullable;
+        ctx.partial =
+          ctx.partial || (childLink === undefined && _isListNullable);
         newLink[i] = childLink || null;
         hasChanged = hasChanged || newLink[i] !== prevData![i];
       }


### PR DESCRIPTION
Resolve #1969

## Summary

#1869 introduced a regression for nullable lists when schema awareness is used. The intended behaviour is that any `undefined` value in a list (due to a cache miss) causes the list to also become undefined immediately, or to default to a `null` value when it's nullable. Unfortunately, when the list is marked as nullable (as derived by a passed schema with schema awareness) it'd now always be marked as "partial".
