### PR TITLE
(core) - Add `includeExtensions` option to `ssrExchange`

### DIFF
--- a/.changeset/tidy-tables-promise.md
+++ b/.changeset/tidy-tables-promise.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Adding option to `ssrExchange` to include the `extensions` field of operation results in the cache.

--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@urql/core": ">=2.1.5",
+    "@urql/core": ">=2.3.2",
     "wonka": "^4.0.14"
   }
 }

--- a/packages/core/src/exchanges/ssr.test.ts
+++ b/packages/core/src/exchanges/ssr.test.ts
@@ -116,6 +116,34 @@ it('caches errored query results correctly', () => {
   });
 });
 
+it('caches extensions when includeExtensions=true', () => {
+  output.mockReturnValueOnce({
+    ...queryResponse,
+    extensions: {
+      foo: 'bar',
+    },
+  });
+
+  const ssr = ssrExchange({
+    includeExtensions: true,
+  });
+  const { source: ops$, next } = input;
+  const exchange = ssr(exchangeInput)(ops$);
+
+  publish(exchange);
+  next(queryOperation);
+
+  const data = ssr.extractData();
+  expect(Object.keys(data)).toEqual(['' + queryOperation.key]);
+
+  expect(data).toEqual({
+    [queryOperation.key]: {
+      data: '{"user":{"name":"Clive"}}',
+      extensions: '{"foo":"bar"}',
+    },
+  });
+});
+
 it('caches complex GraphQLErrors in query results correctly', () => {
   output.mockReturnValueOnce({
     ...queryResponse,


### PR DESCRIPTION
## Summary

I opened a discussion about this some months ago [here](https://github.com/FormidableLabs/urql/discussions/1764), but it did not get much attention so I'm trying to implement this myself :)

Adding a new `includeExtensions?: boolean` option to `ssrExchange`. When this option is enabled the `extensions` field of the operation results will be included in the serialised cache, and will be restored when restoring the cache.

The motivation behind this is to make cached and non-cached operations behave more consistently.
For example, when `extensions` include some metadata for the consumer to use (e.g. tracing/tracking info), then these data are not available when restoring the cache currently, as the `extensions` field don't get serialised/restored.

I added this as an option instead of making it the default behaviour to make this change backward compatible.

## Set of changes

- `@urql/core`: Adding `includeExtensions` as option to `ssrExchange`, and implemented the feature. Added a scenario to unit test to cover this.
- `urql-exchange-graphcache-default-storage`: Updating `@urql/core` dependency version to latest. I did not do this manually, this got updated when running `changeset`. I'm happy to revert this if you think it's a problem.
