### PR TITLE
(core) - tweak ExecutionResult to line up with the graphql lib

### DIFF
--- a/.changeset/seven-scissors-rescue.md
+++ b/.changeset/seven-scissors-rescue.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix error-type of an `ExecutionResult` to line up with subscription-libs

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,13 +6,13 @@ import { CombinedError } from './utils/error';
 
 export type ExecutionResult =
   | {
-      errors?: Array<string | Partial<GraphQLError> | Error>;
+      errors?: Array<readonly GraphQLError[]>;
       data?: null | Record<string, any>;
       extensions?: Record<string, any>;
       hasNext?: boolean;
     }
   | {
-      errors?: Array<string | Partial<GraphQLError> | Error>;
+      errors?: Array<readonly GraphQLError[]>;
       data: any;
       path: (string | number)[];
       hasNext?: boolean;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,13 +6,17 @@ import { CombinedError } from './utils/error';
 
 export type ExecutionResult =
   | {
-      errors?: Array<readonly GraphQLError[]>;
+      errors?:
+        | Array<Partial<GraphQLError> | string | Error>
+        | readonly GraphQLError[];
       data?: null | Record<string, any>;
       extensions?: Record<string, any>;
       hasNext?: boolean;
     }
   | {
-      errors?: Array<readonly GraphQLError[]>;
+      errors?:
+        | Array<Partial<GraphQLError> | string | Error>
+        | readonly GraphQLError[];
       data: any;
       path: (string | number)[];
       hasNext?: boolean;


### PR DESCRIPTION
## Summary

This tweaks the `ExecutionResult` type to line up with:

- [`graphql-ws`](https://github.com/graphql/graphql-js/blob/main/src/execution/execute.ts#L131)
- [`subscription-transport-ws`](https://github.com/graphql/graphql-js/blob/main/src/execution/execute.ts#L131)

Both link to `graphql` as they reuse this `ExecutionResult`, should we do too?

Resolves https://github.com/FormidableLabs/urql/issues/1989

## Set of changes

- tweak error to `GraphQLError`
