### PR TITLE
(core) - Prevent Buffer from being auto-polyfilled

### DIFF
--- a/.changeset/lucky-pens-end.md
+++ b/.changeset/lucky-pens-end.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Prevent `Buffer` from being polyfilled by an automatic detection in Webpack. Instead of referencing the `Buffer` global we now simply check the constructor name.

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -10,10 +10,12 @@ const boundaryHeaderRe = /boundary="?([^=";]+)"?/i;
 
 type ChunkData = { done: false; value: Buffer | Uint8Array } | { done: true };
 
+// NOTE: We're avoiding referencing the `Buffer` global here to prevent
+// auto-polyfilling in Webpack
 const toString = (input: Buffer | ArrayBuffer): string =>
-  typeof Buffer !== 'undefined' && Buffer.isBuffer(input)
-    ? input.toString()
-    : decoder!.decode(input);
+  input.constructor.name === 'Buffer'
+    ? (input as Buffer).toString()
+    : decoder!.decode(input as ArrayBuffer);
 
 // DERIVATIVE: Copyright (c) 2021 Marais Rossouw <hi@marais.io>
 // See: https://github.com/maraisr/meros/blob/219fe95/src/browser.ts


### PR DESCRIPTION
Resolves #2026

Prevent `Buffer` from being automatically replaced and polyfilled by Webpack's automatic Node.js polyfilling. We achieve this by not using the global and instead check the constructor name of the object we receive.
