### PR TITLE
(urql/svelte) - mark fetching: false on operationStore init

### DIFF
--- a/.changeset/slow-pets-beg.md
+++ b/.changeset/slow-pets-beg.md
@@ -1,0 +1,6 @@
+---
+'@urql/svelte': patch
+---
+
+Fix initialize `operationStore` with `fetching: false`, the invocation of `query` or any other operation will mark it as `true`
+when deemed appropriate

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -48,7 +48,7 @@ export function operationStore<Data = any, Vars = object, Result = Data>(
 
   const state = {
     stale: false,
-    fetching: true,
+    fetching: false,
     data: undefined,
     error: undefined,
     extensions: undefined,


### PR DESCRIPTION
fixes https://github.com/FormidableLabs/urql/issues/2043

## Summary

When we create the `operationStore` we'll mark `fetching` as `false` so we can support all operations. When we invoke `query` it will be marked as `true` due to https://github.com/FormidableLabs/urql/blob/main/packages/svelte-urql/src/operations.ts#L81

## Set of changes

- mark `fetching` as `false` on store-init
