### PR TITLE
(execute) - Subscription support

### DIFF
--- a/.changeset/hungry-monkeys-fry.md
+++ b/.changeset/hungry-monkeys-fry.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-execute': minor
+---
+
+Add subscription support

--- a/scripts/eslint/common.js
+++ b/scripts/eslint/common.js
@@ -60,6 +60,7 @@ module.exports = {
         '*.spec.tsx',
       ],
       rules: {
+        'es5/no-generators': 'off',
         'es5/no-es6-methods': 'off',
         'es5/no-es6-static-methods': 'off',
 


### PR DESCRIPTION
* add support for subscriptions in execute exchange

## Summary

The execute exchange is excellent for testing and various other uses cases. This PR adds support for subscriptions. In `graphql-js` v16, this will be even easier to implement since `execute` will support subscriptions out of the box.

These changes are non-breaking, but let me know if this requires an RFC.

Example of a subscription that generates numbers. This can be added to e.g. `rootValues`:

```js
const subscription = async function* numbers(...args) {
  let number = 0
  while (true) {
    await sleep(1000)
    yield { number: number++ }
  }
}
```

## Set of changes

- Added subscription support
  - Added new `subscribeFieldResolver` argument to the exchange
  - Changed `execute` argument to object
  - When an operation has ended, call `done` on the generator.
- Updated tests


