### PR TITLE
(docs) - update storage-rn installation instructions

### DIFF
--- a/docs/graphcache/offline.md
+++ b/docs/graphcache/offline.md
@@ -91,7 +91,9 @@ const client = createClient({
 
 For React Native, we can use the async storage package `@urql/storage-rn`.
 
-Before installing the [library](https://github.com/FormidableLabs/urql/tree/main/packages/storage-rn), ensure you have installed the necessary peer dependencies: NetInfo ([RN](https://github.com/react-native-netinfo/react-native-netinfo) | [Expo](https://docs.expo.dev/versions/latest/sdk/netinfo/)) and AsyncStorage ([RN](https://react-native-async-storage.github.io/async-storage/docs/install) | [Expo](https://docs.expo.dev/versions/v42.0.0/sdk/async-storage/)).
+Before installing the [library](https://github.com/FormidableLabs/urql/tree/main/packages/storage-rn), ensure you have installed the necessary peer dependencies:
+- NetInfo ([RN](https://github.com/react-native-netinfo/react-native-netinfo) | [Expo](https://docs.expo.dev/versions/latest/sdk/netinfo/)) and
+- AsyncStorage ([RN](https://react-native-async-storage.github.io/async-storage/docs/install) | [Expo](https://docs.expo.dev/versions/v42.0.0/sdk/async-storage/)).
 
 ```sh
 yarn add @urql/storage-rn
@@ -99,7 +101,7 @@ yarn add @urql/storage-rn
 npm install --save @urql/storage-rn
 ```
 
-Then you can create the custom storage to use in the offline exchange:
+You can then create the custom storage and use it in the offline exchange:
 
 
 ```js

--- a/docs/graphcache/offline.md
+++ b/docs/graphcache/offline.md
@@ -93,6 +93,15 @@ For React Native, we can use the async storage package `@urql/storage-rn`.
 
 Before installing the [library](https://github.com/FormidableLabs/urql/tree/main/packages/storage-rn), ensure you have installed the necessary peer dependencies: NetInfo ([RN](https://github.com/react-native-netinfo/react-native-netinfo) | [Expo](https://docs.expo.dev/versions/latest/sdk/netinfo/)) and AsyncStorage ([RN](https://react-native-async-storage.github.io/async-storage/docs/install) | [Expo](https://docs.expo.dev/versions/v42.0.0/sdk/async-storage/)).
 
+```sh
+yarn add @urql/storage-rn
+# or
+npm install --save @urql/storage-rn
+```
+
+Then you can create the custom storage to use in the offline exchange:
+
+
 ```js
 import { makeAsyncStorage } from '@urql/storage-rn';
 

--- a/packages/storage-rn/README.md
+++ b/packages/storage-rn/README.md
@@ -11,9 +11,9 @@ Install NetInfo ([RN](https://github.com/react-native-netinfo/react-native-netin
 Install `@urql/storage-rn` alongside `urql` and `@urql/exchange-graphcache`:
 
 ```sh
-yarn add @urql/graphcache-rn-async-storage
+yarn add @urql/storage-rn
 # or
-npm install --save @urql/graphcache-rn-async-storage
+npm install --save @urql/storage-rn
 ```
 
 Then add it to the offline exchange:


### PR DESCRIPTION
## Summary

Forgot to update the installation instructions for storage-rn after renaming the package.

## Set of changes

- update the installation script in the readme
- add the installation script to the docs site
