### PR TITLE
(docs) - add pause to lazy-query

### DIFF
--- a/docs/basics/ui-patterns.md
+++ b/docs/basics/ui-patterns.md
@@ -157,7 +157,7 @@ const TodoQuery = gql`
 `;
 
 const Component = () => {
-  const [result, fetch] = useQuery({ query: TodoQuery });
+  const [result, fetch] = useQuery({ query: TodoQuery, pause: true });
   const router = useRouter();
 
   return (


### PR DESCRIPTION
We were missing the pause in the `useQuery` hook