### PR TITLE
(core) - Fix maskTypename not handling nested arrays

### DIFF
--- a/.changeset/metal-monkeys-knock.md
+++ b/.changeset/metal-monkeys-knock.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix issue where `maskTypename` would ignore array shapes

--- a/packages/core/src/utils/maskTypename.test.ts
+++ b/packages/core/src/utils/maskTypename.test.ts
@@ -25,6 +25,20 @@ it('strips typename from nested objects', () => {
   ).toEqual({ id: 1, author: { id: 2 } });
 });
 
+it('works with nested arrays', () => {
+  expect(
+    maskTypename({
+      __typename: 'Todo',
+      id: 1,
+      nodes: [[4, 5]],
+      author: {
+        id: 2,
+        __typename: 'Author',
+      },
+    })
+  ).toEqual({ id: 1, nodes: [[4, 5]], author: { id: 2 } });
+});
+
 it('strips typename from nested objects with arrays', () => {
   expect(
     maskTypename({

--- a/packages/core/src/utils/maskTypename.ts
+++ b/packages/core/src/utils/maskTypename.ts
@@ -1,4 +1,4 @@
-export const maskTypename = (data: any, isArray?: boolean): any => {
+export const maskTypename = (data: any): any => {
   if (!data || typeof data !== 'object') return data;
 
   return Object.keys(data).reduce(
@@ -10,7 +10,7 @@ export const maskTypename = (data: any, isArray?: boolean): any => {
           value,
         });
       } else if (Array.isArray(value)) {
-        acc[key] = value.map(x => maskTypename(x, true));
+        acc[key] = value.map(maskTypename);
       } else if (value && typeof value === 'object' && '__typename' in value) {
         acc[key] = maskTypename(value);
       } else {
@@ -19,6 +19,6 @@ export const maskTypename = (data: any, isArray?: boolean): any => {
 
       return acc;
     },
-    isArray ? [] : {}
+    Array.isArray(data) ? [] : {}
   );
 };

--- a/packages/core/src/utils/maskTypename.ts
+++ b/packages/core/src/utils/maskTypename.ts
@@ -1,4 +1,4 @@
-export const maskTypename = (data: any, isArray: boolean): any => {
+export const maskTypename = (data: any, isArray?: boolean): any => {
   if (!data || typeof data !== 'object') return data;
 
   return Object.keys(data).reduce(

--- a/packages/core/src/utils/maskTypename.ts
+++ b/packages/core/src/utils/maskTypename.ts
@@ -1,21 +1,24 @@
-export const maskTypename = (data: any): any => {
+export const maskTypename = (data: any, isArray: boolean): any => {
   if (!data || typeof data !== 'object') return data;
 
-  return Object.keys(data).reduce((acc, key: string) => {
-    const value = data[key];
-    if (key === '__typename') {
-      Object.defineProperty(acc, '__typename', {
-        enumerable: false,
-        value,
-      });
-    } else if (Array.isArray(value)) {
-      acc[key] = value.map(maskTypename);
-    } else if (value && typeof value === 'object' && '__typename' in value) {
-      acc[key] = maskTypename(value);
-    } else {
-      acc[key] = value;
-    }
+  return Object.keys(data).reduce(
+    (acc, key: string) => {
+      const value = data[key];
+      if (key === '__typename') {
+        Object.defineProperty(acc, '__typename', {
+          enumerable: false,
+          value,
+        });
+      } else if (Array.isArray(value)) {
+        acc[key] = value.map(x => maskTypename(x, true));
+      } else if (value && typeof value === 'object' && '__typename' in value) {
+        acc[key] = maskTypename(value);
+      } else {
+        acc[key] = value;
+      }
 
-    return acc;
-  }, {});
+      return acc;
+    },
+    isArray ? [] : {}
+  );
 };


### PR DESCRIPTION
resolves https://github.com/FormidableLabs/urql/issues/2072

## Summary

`maskTypename` wasn't taking array shapes in account when traversing the result shape

## Set of changes

- add `isArray` argument to `maskTypename` so the recursion can hold on to array shapes
