### PR TITLE
(graphcache) - expose a way to interact with the client outside of operations

### DIFF
--- a/exchanges/graphcache/src/core.d.ts
+++ b/exchanges/graphcache/src/core.d.ts
@@ -1,0 +1,8 @@
+import { Client as BaseClient } from '@urql/core';
+import { Cache } from './types';
+
+declare module '@urql/core' {
+  export interface Client extends BaseClient {
+    cache: Cache;
+  }
+}

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -192,17 +192,7 @@ export const noopDataState = (
   clearDataState();
 };
 
-export const getCurrentOperation = (): OperationType => {
-  invariant(
-    currentOperation !== null,
-    'Invalid Cache call: The cache may only be accessed or mutated during' +
-      'operations like write or query, or as part of its resolvers, updaters, ' +
-      'or optimistic configs.',
-    2
-  );
-
-  return currentOperation;
-};
+export const getCurrentOperation = (): OperationType | null => currentOperation;
 
 /** As we're writing, we keep around all the records and links we've read or have written to */
 export const getCurrentDependencies = (): Dependencies => {
@@ -414,8 +404,8 @@ export const gc = () => {
 };
 
 const updateDependencies = (entityKey: string, fieldKey?: string) => {
-  if (fieldKey !== '__typename') {
-    if (entityKey !== currentData!.queryRootKey) {
+  if (fieldKey !== '__typename' && currentData) {
+    if (entityKey !== currentData.queryRootKey) {
       currentDependencies![entityKey] = true;
     } else if (fieldKey !== undefined) {
       currentDependencies![joinKeys(entityKey, fieldKey)] = true;

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -1138,7 +1138,7 @@ describe('plain usage', () => {
     ]);
   });
 
-  it('should update a query without an operation', () => {
+  it('should update/read a query without an operation', () => {
     const store = new Store();
     const cache = store as Cache;
     let called = false;
@@ -1167,5 +1167,52 @@ describe('plain usage', () => {
     expect(called).toBeTruthy();
 
     expect(cache.readQuery({ query: TodosWithoutTypename })).toEqual(newData);
+  });
+
+  it('should update/read a fragment without an operation', () => {
+    const store = new Store();
+    const cache = store as Cache;
+
+    const TodoFragment = gql`
+      fragment todoFields on Todo {
+        id
+        text
+        complete
+        __typename
+        author {
+          id
+          name
+          __typename
+        }
+      }
+    `;
+    const newData = {
+      id: '0',
+      text: 'I am new',
+      complete: true,
+      __typename: 'Todo',
+      author: { id: '0', name: 'Jovi', __typename: 'Author' },
+    };
+
+    write(store, { query: TodosWithoutTypename }, todosData);
+
+    let result = cache.readFragment(TodoFragment, newData, { id: '1' });
+    expect(result).toEqual({
+      author: {
+        __typename: 'Author',
+        id: '0',
+        name: 'Jovi',
+      },
+      complete: false,
+      id: '0',
+      text: 'Go to the shops',
+      __typename: 'Todo',
+    });
+
+    cache.writeFragment(TodoFragment, newData, { id: '1' });
+
+    result = cache.readFragment(TodoFragment, newData, { id: '1' });
+
+    expect(result).toEqual(newData);
   });
 });

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -1,6 +1,7 @@
 import { TypedDocumentNode } from '@urql/core';
 import { GraphQLError, DocumentNode, FragmentDefinitionNode } from 'graphql';
 import { IntrospectionData } from './ast';
+import './core.d.ts';
 
 // Helper types
 export type NullArray<T> = Array<null | T | NullArray<T>>;

--- a/exchanges/graphcache/tsconfig.json
+++ b/exchanges/graphcache/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"],
+  "include": ["./src"],
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {


### PR DESCRIPTION
## Summary

This is very much a draft and experiment whether this is a good idea.

We've repeatedly seen the need for people to update data coming from external sources (socket.io,...) outside of GraphQL so with this PR we want to enable this once and for all. Our stance towards this has been hesitant because of the unintended side-effects that might be created by doing this so this should be considered an escape hatch.

An example would be:

```js
import { useClient, gql } from 'urql';

const TodoFragment = gql`
    fragment todoFields on Todo {
      id
      text
      complete
      __typename
    }
`;

export const Component = () => {
  const client = useClient();
  useEffect(() => {
    myTodoSocket.subscribe((updatedTodo) => {
      cache.updateFragment(TodoFragment, { ...updatedTodo, __typename: 'Todo' }, { id: updatedTodo.id })
    })
  }, [])
}
```

TODO:

- [ ] test whether operations are correctly invoked after updating a query
- [ ] find a way to correctly include `core.d.ts` so client is extended with the cache helper

## Set of changes

- expose `cache` on the client interface
- add helpers so the cache can track deps and data state while updating data
