### PR TITLE
(examples) - Added missing useState and useEffect import.

### DIFF
--- a/examples/with-refresh-auth/src/App.jsx
+++ b/examples/with-refresh-auth/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Provider } from 'urql';
 
 import client from './client';


### PR DESCRIPTION
## Summary

I decided to try and test the auth exchange package's example and noticed it wasn't compiling so I added the missing imports (useState and useEffect).