### PR TITLE
(next-urql) - prevent next-urql from doing a prepass when the response has ended

### DIFF
--- a/.changeset/real-hairs-attend.md
+++ b/.changeset/real-hairs-attend.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Fix bail when the `getInitialProps` call indicates we've finished the response

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -147,7 +147,7 @@ export function withUrqlClient(
         let pageProps = {} as any;
         if (AppOrPage.getInitialProps) {
           pageProps = await AppOrPage.getInitialProps(appOrPageCtx as any);
-          if (ctx.res?.writableEnded || ctx.res?.finished) {
+          if (ctx.res && (ctx.res.writableEnded || ctx.res.finished)) {
             return { ...pageProps, urqlClient };
           }
         }

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -147,6 +147,9 @@ export function withUrqlClient(
         let pageProps = {} as any;
         if (AppOrPage.getInitialProps) {
           pageProps = await AppOrPage.getInitialProps(appOrPageCtx as any);
+          if (ctx.res?.writableEnded || ctx.res?.finished) {
+            return { ...pageProps, urqlClient };
+          }
         }
 
         // Check the window object to determine whether or not we are on the server.


### PR DESCRIPTION
## Summary

When `getInitialProps` indicates that the response has ended, we should not go into `prepass` but instead we should just return the data we have up until that point. As it indicates that the route has errored _or_ redirected

## Set of changes

- check `res.finished` before continuing the prepass
