### PR TITLE
(refocus) - use context of the operation we are reexecuting

### DIFF
--- a/.changeset/green-queens-exercise.md
+++ b/.changeset/green-queens-exercise.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-refocus': patch
+---
+
+Fix use context of the reexecuting operation

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -18,6 +18,7 @@ export const refocusExchange = (): Exchange => {
         watchedOperations.forEach(op => {
           client.reexecuteOperation(
             client.createRequestOperation('query', op, {
+              ...op.context,
               requestPolicy: 'cache-and-network',
             })
           );


### PR DESCRIPTION
Resolves #2094

## Summary

We used to lose the context on all operations we reexecute once focus is regained.

## Set of changes

- Spread context into new operation
