### PR TITLE
(graphcache) - reproduce nested fragments bug

### DIFF
--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -1611,6 +1611,7 @@ describe('schema awareness', () => {
           author: {
             id: '1',
             name: 'Jovi',
+            __typename: 'Author',
           },
         },
         {
@@ -1633,7 +1634,6 @@ describe('schema awareness', () => {
 
     const result = jest.fn();
     const forward: ExchangeIO = ops$ => pipe(ops$, delay(1), map(response));
-
     pipe(
       cacheExchange({
         schema: minifyIntrospectionQuery(
@@ -1658,6 +1658,7 @@ describe('schema awareness', () => {
           author: {
             id: '1',
             name: 'Jovi',
+            __typename: 'Author',
           },
         },
         {
@@ -1688,6 +1689,7 @@ describe('schema awareness', () => {
           author: {
             id: '1',
             name: 'Jovi',
+            __typename: 'Author',
           },
         },
         {


### PR DESCRIPTION
Bug from https://github.com/FormidableLabs/urql/discussions/2103

## Summary

We seem to erroneously read for nested-fragments, this reproduces the bug.

EDIT: after https://github.com/FormidableLabs/urql/pull/2107/commits/f2f871e83bcaf4dacfac8f98258cee9d7ec72485 doesn't reproduce

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
