### PR TITLE
(persisted-fetch) - Fix Crypto API support for Web Workers and Node ESM mode

### DIFF
--- a/.changeset/twenty-dolphins-grab.md
+++ b/.changeset/twenty-dolphins-grab.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-persisted-fetch': patch
+---
+
+Fix Crypto API support for Web Workers and Node Crypto in ESM mode. Previously, when Node Crypto was required in Node ESM mode it would result in an error instead, since we didn't try a dynamic import fallback.

--- a/exchanges/persisted-fetch/src/sha256.ts
+++ b/exchanges/persisted-fetch/src/sha256.ts
@@ -35,7 +35,7 @@ if (typeof window === 'undefined') {
   try {
     // Indirect eval/require to guarantee no side-effects in module scope
     // (optimization for minifiers)
-    nodeCrypto = new Function('require', 'return require("crypto")')(require);
+    nodeCrypto = new Function('return require("crypto")')();
   } catch (e) {}
 }
 

--- a/exchanges/persisted-fetch/src/sha256.ts
+++ b/exchanges/persisted-fetch/src/sha256.ts
@@ -35,11 +35,12 @@ if (typeof window === 'undefined' && !webCrypto) {
   // Indirect eval'd require/import to guarantee no side-effects in module scope
   // (optimization for minifiers)
   try {
-    nodeCrypto = Promise.resolve(new Function('return require("crypto")')());
+    nodeCrypto = Promise.resolve(
+      new Function('require', 'return require("crypto")')(require)
+    );
   } catch (_error) {
-    // @ts-expect-error
     try {
-      nodeCrypto = import('crypto');
+      nodeCrypto = new Function('return import("crypto")')();
     } catch (_error) {}
   }
 }

--- a/exchanges/persisted-fetch/src/sha256.ts
+++ b/exchanges/persisted-fetch/src/sha256.ts
@@ -1,15 +1,15 @@
-const jsCrypto =
-  typeof window !== 'undefined'
-    ? window.crypto || (window as any).msCrypto
-    : undefined;
-const cryptoSubtle =
-  jsCrypto && (jsCrypto.subtle || (jsCrypto as any).webkitSubtle);
-const isIE = !!(jsCrypto && (window as any).msCrypto);
+const globals: { crypto?: Crypto; msCrypto?: Crypto } = (typeof window !==
+'undefined'
+  ? window
+  : typeof self !== 'undefined'
+  ? self
+  : null) as any;
+const webCrypto = globals && (globals.crypto || globals.msCrypto);
 
 const sha256Browser = (bytes: Uint8Array): Promise<Uint8Array> => {
-  const hash = cryptoSubtle!.digest({ name: 'SHA-256' }, bytes);
+  const hash = webCrypto!.subtle.digest({ name: 'SHA-256' }, bytes);
   return new Promise((resolve, reject) => {
-    if (isIE) {
+    if (globals.msCrypto) {
       // IE11
       (hash as any).oncomplete = function onComplete(event: any) {
         resolve(new Uint8Array(event.target.result));
@@ -30,61 +30,56 @@ const sha256Browser = (bytes: Uint8Array): Promise<Uint8Array> => {
   });
 };
 
-let nodeCrypto;
-if (typeof window === 'undefined') {
+let nodeCrypto: Promise<typeof import('crypto')> | void;
+if (typeof window === 'undefined' && !webCrypto) {
+  // Indirect eval'd require/import to guarantee no side-effects in module scope
+  // (optimization for minifiers)
   try {
-    // Indirect eval/require to guarantee no side-effects in module scope
-    // (optimization for minifiers)
-    nodeCrypto = new Function('return require("crypto")')();
-  } catch (e) {}
+    nodeCrypto = Promise.resolve(new Function('return require("crypto")')());
+  } catch (_error) {
+    // @ts-expect-error
+    try {
+      nodeCrypto = import('crypto');
+    } catch (_error) {}
+  }
 }
 
 export const hash = async (query: string): Promise<string> => {
-  if (
-    typeof window === 'undefined'
-      ? !nodeCrypto || !nodeCrypto.createHash
-      : !cryptoSubtle
-  ) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        '[@urql/exchange-persisted-fetch]: The ' +
-          (typeof window === 'undefined'
-            ? 'Node Crypto'
-            : 'window.crypto.subtle') +
-          ' API is not available.\n' +
-          'This is an unexpected error. Please report it by filing a GitHub Issue.'
-      );
+  // Node.js support
+  if (nodeCrypto) {
+    return nodeCrypto.then(crypto =>
+      crypto.createHash('sha256').update(query).digest('hex')
+    );
+  } else if (webCrypto) {
+    let buf: Uint8Array;
+    if (typeof TextEncoder !== 'undefined') {
+      buf = new TextEncoder().encode(query);
+    } else {
+      buf = new Uint8Array(query.length);
+      for (let i = 0, l = query.length; i < l; i++) {
+        // NOTE: We assume that the input GraphQL Query only uses UTF-8 at most
+        // since GraphQL mostly consists of ASCII, this is completely fine
+        buf[i] = query.charCodeAt(i);
+      }
     }
 
-    return Promise.resolve('');
+    const out = await sha256Browser(buf);
+
+    let hash = '';
+    for (let i = 0, l = out.length; i < l; i++) {
+      const hex = out[i].toString(16);
+      hash += '00'.slice(0, Math.max(0, 2 - hex.length)) + hex;
+    }
+
+    return hash;
   }
 
-  // Node.js support
-  if (typeof window === 'undefined') {
-    return Promise.resolve(
-      '' + nodeCrypto.createHash('sha256').update(query).digest('hex')
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(
+      '[@urql/exchange-persisted-fetch]: The Node Crypto and Web Crypto APIs are not available.\n' +
+        'This is an unexpected error. Please report it by filing a GitHub Issue.'
     );
   }
 
-  let buf: Uint8Array;
-  if (typeof TextEncoder !== 'undefined') {
-    buf = new TextEncoder().encode(query);
-  } else {
-    buf = new Uint8Array(query.length);
-    for (let i = 0, l = query.length; i < l; i++) {
-      // NOTE: We assume that the input GraphQL Query only uses UTF-8 at most
-      // since GraphQL mostly consists of ASCII, this is completely fine
-      buf[i] = query.charCodeAt(i);
-    }
-  }
-
-  const out = await sha256Browser(buf);
-
-  let hash = '';
-  for (let i = 0, l = out.length; i < l; i++) {
-    const hex = out[i].toString(16);
-    hash += '00'.slice(0, Math.max(0, 2 - hex.length)) + hex;
-  }
-
-  return hash;
+  return Promise.resolve('');
 };


### PR DESCRIPTION
Resolves #2077 

## Summary

Add support for Web Workers via the `self` global and fix support in Node ESM by trying a dynamic import when `require` fails. This also fixes up a mistake in IE11 support, where `msCrypto` was treated as `msCrypto.subtle` accidentally.

## Set of changes

- Check for `self` and `window` global
- Fix `msCrypto.subtle` usage
- Add dynamic `import("crypto")` fallback in require check
