### PR TITLE
(retry) - Fix delay misqueue in React Native

### DIFF
--- a/.changeset/four-moose-scream.md
+++ b/.changeset/four-moose-scream.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-retry': patch
+---
+
+Fix operations sometimes not being executed after a retry is supposed to be triggered, due to a `setTimeout` reordering issue when the timer isn't as predictable as it should be.

--- a/exchanges/retry/src/retryExchange.ts
+++ b/exchanges/retry/src/retryExchange.ts
@@ -5,7 +5,7 @@ import {
   merge,
   filter,
   fromValue,
-  delay,
+  debounce,
   mergeMap,
   takeUntil,
 } from 'wonka';
@@ -96,7 +96,7 @@ export const retryExchange = ({
               retryCount,
             })
           ),
-          delay(delayAmount),
+          debounce(() => delayAmount),
           // Stop retry if a teardown comes in
           takeUntil(teardown$)
         );


### PR DESCRIPTION
Resolve #1932 

**NOTE:** This is simply an _attempt_ at resolving the issue above. I'm not sure if this is actually the cause so it'll need to be tested.

## Summary

Our current theory is that because the `delay` operator separately applies a timeout (e.g. `setTimeout`) to each signal, that signals in the same tick (in this case `Push` then `End`) are sometimes flipped. Usually this isn't an issue but with only one value to push the reordering can cause the signal to be swallowed entirely.

To mitigate this I'm attempting to simply validate this by swapping out `delay` with `debounce`, since the latter applies timeouts differently but otherwise behaves identically (in theory) for single values.

## Set of changes

- Replace `delay` with `debounce` in `retryExchange` retry logic