### PR TITLE
(graphcache) - fix returning totalCount in relay pagination

### DIFF
--- a/.changeset/loud-spies-love.md
+++ b/.changeset/loud-spies-love.md
@@ -2,4 +2,4 @@
 '@urql/exchange-graphcache': patch
 ---
 
-Return `totalCount` when available
+Return additional available fields on a `Connection` when using relay-pagination

--- a/.changeset/loud-spies-love.md
+++ b/.changeset/loud-spies-love.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Return `totalCount` when available

--- a/exchanges/graphcache/src/extras/relayPagination.test.ts
+++ b/exchanges/graphcache/src/extras/relayPagination.test.ts
@@ -180,7 +180,6 @@ it('can query totalCount', () => {
     },
   });
 });
-
 it('works with backwards pagination', () => {
   const Pagination = gql`
     query($cursor: String) {


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/urql/issues/2007

## Summary

In the `relay-pagination` we can have "edges", "nodes" and "pageInfo" but along side that we can also have a `totalCount` we should support and return this.

## Set of changes

- return `totalCount`
