### PR TITLE
(chore) - Upgrade babel-plugin-modular-import

### DIFF
--- a/.changeset/chilly-camels-know.md
+++ b/.changeset/chilly-camels-know.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-execute': patch
+---
+
+Upgrade modular imports for graphql package, which fixes an issue in `@urql/exchange-execute`, where `graphql@16` files wouldn't resolve the old `subscribe` import from the correct file

--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@urql/core": ">=2.3.2",
+    "@urql/core": ">=2.3.3",
     "wonka": "^4.0.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/jest": "^26.0.23",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "babel-plugin-modular-graphql": "1.0.1",
+    "babel-plugin-modular-graphql": "^1.1.0",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "dotenv": "^8.2.0",
     "eslint": "^7.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3966,10 +3966,10 @@ babel-plugin-macros@^3.0.1:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
-babel-plugin-modular-graphql@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-modular-graphql/-/babel-plugin-modular-graphql-1.0.1.tgz#ea78f23fab06e5436f52c8cebe7bbe5fe01b7337"
-  integrity sha512-ZFS/dDv0If6QAmwET5aqIx0lO3JdRRvcdL/nD+AiEGfAKpc68rzvtxQcJ2HNTBp8LnwqGA40HEEaAeY9ty3ZMA==
+babel-plugin-modular-graphql@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-modular-graphql/-/babel-plugin-modular-graphql-1.1.0.tgz#d1d509913295f0320cc1ce38361b229ca04480ba"
+  integrity sha512-U9QXdxvJhxLU4YYrF7646bB4muLXWdW0sXXKrI9FkGDErqjw0utVn+Zk5W0nNXP82rAmg5vl+cv2nAyZ1dnbxg==
 
 babel-plugin-named-asset-import@^0.3.1:
   version "0.3.7"


### PR DESCRIPTION
## Summary

Upgrade to latest release of `babel-plugin-modular-import` to guarantee consistent imports across all three major releases of `graphql`.

## Set of changes

- Update `babel-plugin-modular-graphql`
- Bump `@urql/exchange-execute`
