### PR TITLE
(core) - bump typed document node for gql16

### DIFF
--- a/.changeset/gentle-readers-tan.md
+++ b/.changeset/gentle-readers-tan.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Bump `@graphql-typed-document-node/core` to 3.1.1 for `graphql@16` support

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@graphql-typed-document-node/core": "^3.1.0",
+    "@graphql-typed-document-node/core": "^3.1.1",
     "wonka": "^4.0.14"
   },
   "publishConfig": {

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -78,7 +78,7 @@ export function operationStore<Data = any, Vars = object, Result = Data>(
     if ('query' in value! || 'variables' in value!) {
       const prev = createRequest(
         internal.query,
-        internal.variables || undefined
+        internal.variables || ({} as Vars)
       );
       const next = createRequest(
         value.query || internal.query,

--- a/packages/svelte-urql/src/operationStore.ts
+++ b/packages/svelte-urql/src/operationStore.ts
@@ -76,7 +76,10 @@ export function operationStore<Data = any, Vars = object, Result = Data>(
     let hasUpdate = false;
 
     if ('query' in value! || 'variables' in value!) {
-      const prev = createRequest(internal.query, internal.variables);
+      const prev = createRequest(
+        internal.query,
+        internal.variables || undefined
+      );
       const next = createRequest(
         value.query || internal.query,
         value.variables || internal.variables

--- a/packages/svelte-urql/src/operations.ts
+++ b/packages/svelte-urql/src/operations.ts
@@ -183,7 +183,7 @@ export function mutation<Data = any, Variables = object>(
     store.set(update);
     return pipe(
       client.executeMutation(
-        createRequest(store.query, store.variables || {}),
+        createRequest(store.query, store.variables || ({} as Variables)),
         store.context
       ),
       take(1),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,10 +1467,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@graphql-typed-document-node/core@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
-  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
 "@hapi/accept@5.0.2":
   version "5.0.2"


### PR DESCRIPTION
## Summary

[typed-document-node v3.1.1 introduces gql16 capabilities](https://github.com/dotansimha/graphql-typed-document-node/releases/tag/core%40v3.1.1)

## Set of changes

- bump our dep to 3.1.1 for all folks upgrading
