### PR TITLE
(react) Ensure useMutation is compatible with React 18

### DIFF
--- a/.changeset/fix-use-mutation-in-react-18.md
+++ b/.changeset/fix-use-mutation-in-react-18.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Fix `useMutation` not working correctly with React 18

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -70,6 +70,7 @@ export function useMutation<Data = any, Variables = object>(
   );
 
   useEffect(() => {
+    isMounted.current = true;
     return () => {
       isMounted.current = false;
     };


### PR DESCRIPTION
Resolves #2109.

## Summary

React 18 has introduced [Strict Effects](https://github.com/reactwg/react-18/discussions/19) in Strict Mode, which results in all effects being executed twice in dev mode, regardless of whether the contents of the dependency array has changed. I've also noticed that the same thing happens with Fast Refresh in React 17: all effects re-run. `useEffect`, even when called with dependency array of `[]`, doesn't give any semantic guarantees that it'll only be executed once (something I've only realised recently, and now have to rethink how I approach writing effects in React).



## Set of changes

Currently, `useMutation` has a `useEffect` that's incompatible with React 18 or Fast Refresh. The fix seems to be rather simple: set `isMounted` reference to `true` when the hook gets executed.

## Open questions

- Should we also update `preact-urql`?
- I am not sure what is the best way to write a test for this