### PR TITLE
Export callUseQuery or support a multi-client environment

### DIFF
--- a/packages/vue-urql/src/index.ts
+++ b/packages/vue-urql/src/index.ts
@@ -5,6 +5,7 @@ export { install, provideClient } from './useClient';
 
 export {
   useQuery,
+  callUseQuery,
   UseQueryArgs,
   UseQueryResponse,
   UseQueryState,


### PR DESCRIPTION


<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

I have two GraphQL APIs in my app
I need to be able to provide myself two urql instances
As a consequence, I can't use useQuery as it injects the first (or last?!) provideClient client arg



## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

I need to be able to create my own useThisApiQuery and useAnotherApiQuery functions with the respective client, and having this function exposed is a way for me to stich things together

A better solution may be to improve the provideClient and useClient functions with an optional argument that defaults to the currently used `'$urql'`, then improve the useQuery function with a second optional argument to select the correct client to run the query against
In this particular case, it would be trivial to reuse the functions provided by this library by doing so

```
provideClient(client, '$myApiIdentifier');
```

```
export function useMyApiQuery<T = any, V = object>(args: UseQueryArgs<T, V>) {
    return useQuery(args, '$myApiIdentifier');
}
```

To be honest, I may very well need to execute queries and it seems that the client's `executeQuery` function isn't very friendly towards executing a string-query, as I'd need to call `createRequest`, etc, so I'd still expose `callUseQuery` to the public API of the library. Even with my second idea, the `useQuery` wrapper function will not help because if I want to call the API in my app bootstrap files (in order to start some requests very early on), it will try to inject the client, as opposed to directly using one. In that case, we could make the parameter accept both an identifier or a client, but that will unnecessarily increase the complexity, and IMO that's undesirable when one could simply expose `callUseQuery`

As for my second suggestion, that'd make for much cleaner code in my app

PR only includes exposing `callUseQuery` as that'll do for me at this point and I'd like to know your thoughts on my second suggestion.
And before you flame me on how to do GQL, the frontend app will connect to two completely distinct GQL APIs
