### PR TITLE
Support multiple API clients

### DIFF
--- a/.changeset/bright-hornets-remember.md
+++ b/.changeset/bright-hornets-remember.md
@@ -5,3 +5,47 @@
 Exposed callUseQuery to allow executing queries in app setup functions.
 Add clientId parameter to useClient and provideClient, as well as useQuery to support multi-client setups (Note: You must provide app.provide('\$myUrql', myUrqlClient) yourself).
 Then it becomes trivial to write code like const useMyApiQuery = (args) => useQuery(args, '$myUrql') and provide this function across your app to execute queries against a concrete API Client
+
+For example:
+
+```ts
+export function createApp() {
+  const app = createApp();
+
+  const myApiExchange = createSSRExchange({
+    isClient: !import.meta.env.SSR,
+    initialState: initialState?.myApi,
+    staleWhileRevalidate: false,
+  });
+  const myApi = new Client({
+    url: 'https://my-api.com',
+    exchanges: [dedupExchange, cacheExchange, myApiExchange, fetchExchange],
+  });
+  app.provide('$myApi', myApi);
+
+  const anotherApiExchange = createSSRExchange({
+    isClient: !import.meta.env.SSR,
+    initialState: initialState?.anotherApi,
+    staleWhileRevalidate: false,
+  });
+  const anotherApi = new Client({
+    url: 'https://another-api.com',
+    exchanges: [dedupExchange, cacheExchange, anotherApiExchange, fetchExchange],
+  });
+  app.provide('$anotherApi', anotherApi);
+
+  return app;
+}
+
+export function useMyApiQuery<T = any, V = object>(
+  args: UseQueryArgs<T, V>
+): UseQueryResponse<T, V> {
+  return useQuery(args, '$myApi');
+}
+
+export function useAnotherApiQuery<T = any, V = object>(
+  args: UseQueryArgs<T, V>
+): UseQueryResponse<T, V> {
+  return useQuery(args, '$anotherApi');
+}
+```

--- a/.changeset/bright-hornets-remember.md
+++ b/.changeset/bright-hornets-remember.md
@@ -1,0 +1,7 @@
+---
+'@urql/vue': patch
+---
+
+Exposed callUseQuery to allow executing queries in app setup functions.
+Add clientId parameter to useClient and provideClient, as well as useQuery to support multi-client setups (Note: You must provide app.provide('\$myUrql', myUrqlClient) yourself).
+Then it becomes trivial to write code like const useMyApiQuery = (args) => useQuery(args, '$myUrql') and provide this function across your app to execute queries against a concrete API Client

--- a/.changeset/bright-hornets-remember.md
+++ b/.changeset/bright-hornets-remember.md
@@ -34,6 +34,19 @@ export function createApp() {
   });
   app.provide('$anotherApi', anotherApi);
 
+  const apiResult = callUseQuery(
+    {
+      query: 'some query',
+    },
+    myApi
+  );
+
+  apiResult.then(() => {
+    // well, now we can execute requests right here before components are rendered
+    // and at the same time leverage the goodies in callUseQuery that
+    // and we don't need to parse a string query ourselves, and then call client.executeQuery
+  });
+
   return app;
 }
 

--- a/packages/vue-urql/src/index.ts
+++ b/packages/vue-urql/src/index.ts
@@ -5,6 +5,7 @@ export { install, provideClient } from './useClient';
 
 export {
   useQuery,
+  callUseQuery,
   UseQueryArgs,
   UseQueryResponse,
   UseQueryState,

--- a/packages/vue-urql/src/useClient.ts
+++ b/packages/vue-urql/src/useClient.ts
@@ -1,7 +1,12 @@
 import { App, getCurrentInstance, inject, provide, Ref, isRef, ref } from 'vue';
 import { Client, ClientOptions } from '@urql/core';
 
-export function provideClient(opts: ClientOptions | Client | Ref<Client>) {
+export const defaultClientId = '$urql';
+
+export function provideClient(
+  opts: ClientOptions | Client | Ref<Client>,
+  clientId: string = defaultClientId
+) {
   let client: Ref<Client>;
   if (!isRef(opts)) {
     client = ref(opts instanceof Client ? opts : new Client(opts));
@@ -9,7 +14,7 @@ export function provideClient(opts: ClientOptions | Client | Ref<Client>) {
     client = opts;
   }
 
-  provide('$urql', client);
+  provide(clientId, client);
   return client.value;
 }
 
@@ -20,17 +25,17 @@ export function install(app: App, opts: ClientOptions | Client | Ref<Client>) {
   } else {
     client = opts;
   }
-  app.provide('$urql', client);
+  app.provide(defaultClientId, client);
 }
 
-export function useClient(): Ref<Client> {
+export function useClient(clientId: string = defaultClientId): Ref<Client> {
   if (process.env.NODE_ENV !== 'production' && !getCurrentInstance()) {
     throw new Error(
       'use* functions may only be called during the `setup()` or other lifecycle hooks.'
     );
   }
 
-  const client = inject('$urql') as Ref<Client>;
+  const client = inject(clientId) as Ref<Client>;
   if (process.env.NODE_ENV !== 'production' && !client) {
     throw new Error(
       'No urql Client was provided. Did you forget to install the plugin or call `provideClient` in a parent?'

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -18,7 +18,7 @@ import {
   GraphQLRequest,
 } from '@urql/core';
 
-import { useClient } from './useClient';
+import { defaultClientId, useClient } from './useClient';
 import { unwrapPossibleProxy } from './utils';
 
 type MaybeRef<T> = T | Ref<T>;
@@ -56,9 +56,10 @@ const watchOptions = {
 };
 
 export function useQuery<T = any, V = object>(
-  args: UseQueryArgs<T, V>
+  args: UseQueryArgs<T, V>,
+  clientId: string = defaultClientId
 ): UseQueryResponse<T, V> {
-  return callUseQuery(args);
+  return callUseQuery(args, useClient(clientId));
 }
 
 export function callUseQuery<T = any, V = object>(


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

I have two GraphQL APIs in my app
I need to be able to provide myself two urql instances
As a consequence, I can't use useQuery as it injects the first (or last?!) provideClient client arg

Followup of https://github.com/FormidableLabs/urql/pull/2173

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->


I need to be able to create my own useThisApiQuery and useAnotherApiQuery functions with the respective client, and having this function exposed is a way for me to stich things together

A better solution may be to improve the provideClient and useClient functions with an optional argument that defaults to the currently used `'$urql'`, then improve the useQuery function with a second optional argument to select the correct client to run the query against
In this particular case, it would be trivial to reuse the functions provided by this library by doing so

```
provideClient(client, '$myApiIdentifier');
```

```
export function useMyApiQuery<T = any, V = object>(args: UseQueryArgs<T, V>) {
    return useQuery(args, '$myApiIdentifier');
}
```

To be honest, I may very well need to execute queries and it seems that the client's `executeQuery` function isn't very friendly towards executing a string-query, as I'd need to call `createRequest`, etc, so I'd still expose `callUseQuery` to the public API of the library. Even with my second idea, the `useQuery` wrapper function will not help because if I want to call the API in my app bootstrap files (in order to start some requests very early on), it will try to inject the client, as opposed to directly using one. In that case, we could make the parameter accept both an identifier or a client, but that will unnecessarily increase the complexity, and IMO that's undesirable when one could simply expose `callUseQuery`

As for my second suggestion, that'd make for much cleaner code in my app

PR only includes exposing `callUseQuery` as that'll do for me at this point and I'd like to know your thoughts on my second suggestion.
And before you flame me on how to do GQL, the frontend app will connect to two completely distinct GQL APIs
