### PR TITLE
(docs) - add missing imports to code-blocks

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -363,7 +363,9 @@ from, and the user should be logged out.
 
 If we're dealing with multiple authentication states at the same time, e.g. logouts, we need to ensure that the `Client` is reinitialized whenever the authentication state changes. Here's an example of how we may do this in React if necessary:
 
-```js
+```jsx
+import { createClient, Provider } from 'urql';
+
 const App = ({ isLoggedIn }: { isLoggedIn: boolean | null }) => {
   const client = useMemo(() => {
     if (isLoggedIn === null) {
@@ -378,9 +380,9 @@ const App = ({ isLoggedIn }: { isLoggedIn: boolean | null }) => {
   }
 
   return {
-    <GraphQLProvider value={client}>
+    <Provider value={client}>
       {/* app content  */}
-    <GraphQLProvider>
+    <Provider>
   }
 }
 ```

--- a/docs/advanced/server-side-rendering.md
+++ b/docs/advanced/server-side-rendering.md
@@ -117,7 +117,8 @@ import {
   dedupExchange,
   cacheExchange,
   fetchExchange,
-  ssrExchange
+  ssrExchange,
+  Provider,
 } from 'urql';
 
 const handleRequest = async (req, res) => {

--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -216,6 +216,9 @@ Here's an example of testing a list component, which uses a subscription.
 
 ```tsx
 import { OperationContext, makeOperation } from '@urql/core';
+import { mount } from 'enzyme';
+import { Provider } from 'urql';
+import { MyComponent } from './MyComponent';
 
 it('should update the list', done => {
   const mockClient = {

--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -62,6 +62,10 @@ it('renders', () => {
 Once you have your mock setup, calls to the client can be tested.
 
 ```tsx
+import { mount } from 'enzyme';
+import { Provider } from 'urql';
+import { MyComponent } from './MyComponent';
+
 it('skips the query', () => {
   mount(
     <Provider value={mockClient}>
@@ -75,6 +79,10 @@ it('skips the query', () => {
 Testing mutations and subscriptions also work in a similar fashion.
 
 ```tsx
+import { mount } from 'enzyme';
+import { Provider } from 'urql';
+import { MyComponent } from './MyComponent';
+
 it('triggers a mutation', () => {
   const wrapper = mount(
     <Provider value={mockClient}>
@@ -125,6 +133,10 @@ Response states are simulated by providing a stream, which contains a network re
 **Example snapshot test of response state**
 
 ```tsx
+import { mount } from 'enzyme';
+import { Provider } from 'urql';
+import { MyComponent } from './MyComponent';
+
 it('matches snapshot', () => {
   const responseState = {
     executeQuery: () =>
@@ -153,6 +165,7 @@ Error responses are similar to success responses, only the value in the stream i
 
 ```tsx
 import { Provider, CombinedError } from 'urql';
+import { fromValue } from 'wonka';
 
 const errorState = {
   executeQuery: () =>
@@ -169,6 +182,8 @@ const errorState = {
 Returning different values for many `useQuery` calls can be done by introducing conditionals into the mocked client functions.
 
 ```tsx
+import { fromValue } from 'wonka';
+
 let mockClient;
 beforeEach(() => {
   mockClient = () => {


### PR DESCRIPTION
Resolves #2187 

## Summary

This PR adds missing imports to chapters that were missing them.

## Set of changes

- add imports to a few chapters including ssr/auth
