### PR TITLE
(core) - allow for multiple concurrent mutations of the same key

### DIFF
--- a/.changeset/bright-llamas-report.md
+++ b/.changeset/bright-llamas-report.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Allow for repeated mutations that have similar inputs which results in the same key, this is for instance the case with file uploads

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -173,11 +173,16 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
   const makeResultSource = (operation: Operation) => {
     let result$ = pipe(
       results$,
-      filter(
-        (res: OperationResult) =>
-          res.operation.kind === operation.kind &&
-          res.operation.key === operation.key
-      )
+      filter((res: OperationResult) => {
+        if (res.operation.kind === 'mutation') {
+          return res.operation === operation;
+        } else {
+          return (
+            res.operation.kind === operation.kind &&
+            res.operation.key === operation.key
+          );
+        }
+      })
     );
 
     // Mask typename properties if the option for it is turned on


### PR DESCRIPTION
Resolves #2184 

## Summary

When we are dealing with mutations of let's say `files` then the key could be equal for different sets of variables, this PR moves mutations from key-checking to referential equality of the `operation` itself, this means that every request will have it's own result-source. This allows for us to repeat a set of mutations with different inputs

This was triggered by the discussion in https://github.com/FormidableLabs/urql/discussions/2183

## Set of changes

- move from key-checking to operation checking
