### PR TITLE
(core) - filter network-only requests from the ssrExchange

### DIFF
--- a/.changeset/strong-islands-hope.md
+++ b/.changeset/strong-islands-hope.md
@@ -1,0 +1,5 @@
+---
+"@urql/core": patch
+---
+
+Filter `network-only` requests from the `ssrExchange`, this is to enable `staleWhileRevalidated` queries to successfully dispatch their queries

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -135,7 +135,11 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
     // it once, cachedOps$ needs to be merged after forwardedOps$
     let cachedOps$ = pipe(
       sharedOps$,
-      filter(operation => !!data[operation.key] && operation.context.requestPolicy !== 'network-only'),
+      filter(
+        operation =>
+          !!data[operation.key] &&
+          operation.context.requestPolicy !== 'network-only'
+      ),
       map(op => {
         const serialized = data[op.key]!;
         const result = deserializeResult(op, serialized, includeExtensions);

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -135,7 +135,7 @@ export const ssrExchange = (params?: SSRExchangeParams): SSRExchange => {
     // it once, cachedOps$ needs to be merged after forwardedOps$
     let cachedOps$ = pipe(
       sharedOps$,
-      filter(operation => !!data[operation.key]),
+      filter(operation => !!data[operation.key] && operation.context.requestPolicy !== 'network-only'),
       map(op => {
         const serialized = data[op.key]!;
         const result = deserializeResult(op, serialized, includeExtensions);


### PR DESCRIPTION
## Summary

On the prior lines we defer clearing the data by a microtick which means that the redispatched "network-only" request will also be served from the ssr-cache. We could also opt to defer the redispatch by a microtick but imo it's better to treat network-only requests as bypassing this. Another possible solution would be to check whether we've seen this before as a `revalidation`

fixes #2059

## Set of changes

- filter `network-only` from being served by the ssr-exchange
