### PR TITLE
Add executionResult to CombinedError

### DIFF
--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -43,15 +43,18 @@ export class CombinedError extends Error {
   public graphQLErrors: GraphQLError[];
   public networkError?: Error;
   public response?: any;
+  public executionResult?: any;
 
   constructor({
     networkError,
     graphQLErrors,
     response,
+    executionResult,
   }: {
     networkError?: Error;
     graphQLErrors?: Array<string | Partial<GraphQLError> | Error>;
     response?: any;
+    executionResult?: any;
   }) {
     const normalizedGraphQLErrors = (graphQLErrors || []).map(
       rehydrateGraphQlError
@@ -65,6 +68,33 @@ export class CombinedError extends Error {
     this.graphQLErrors = normalizedGraphQLErrors;
     this.networkError = networkError;
     this.response = response;
+    this.executionResult = executionResult;
+  }
+
+  toString() {
+    return this.message;
+  }
+}
+
+export class NoContentError extends Error {
+  public name: string;
+  public message: string;
+  response?: any;
+  executionResult?: any;
+
+  constructor({
+    response,
+    executionResult,
+  }: {
+    response?: any;
+    executionResult?: any;
+  }) {
+    super('No Content');
+
+    this.name = 'NoContentError';
+    this.message = 'No Content';
+    this.response = response;
+    this.executionResult = executionResult;
   }
 
   toString() {

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -1,5 +1,5 @@
 import { ExecutionResult, Operation, OperationResult } from '../types';
-import { CombinedError } from './error';
+import { CombinedError, NoContentError } from './error';
 
 export const makeResult = (
   operation: Operation,
@@ -7,7 +7,10 @@ export const makeResult = (
   response?: any
 ): OperationResult => {
   if ((!('data' in result) && !('errors' in result)) || 'path' in result) {
-    throw new Error('No Content');
+    throw new NoContentError({
+      response,
+      executionResult: result,
+    });
   }
 
   return {
@@ -17,6 +20,7 @@ export const makeResult = (
       ? new CombinedError({
           graphQLErrors: result.errors,
           response,
+          executionResult: result,
         })
       : undefined,
     extensions:
@@ -67,13 +71,15 @@ export const mergeResultPatch = (
 export const makeErrorResult = (
   operation: Operation,
   error: Error,
-  response?: any
+  response?: any,
+  executionResult?: any
 ): OperationResult => ({
   operation,
   data: undefined,
   error: new CombinedError({
     networkError: error,
     response,
+    executionResult,
   }),
   extensions: undefined,
 });


### PR DESCRIPTION
## Summary

Hello urql team 👋

This pull request tries to solve this kind of issues:
- https://github.com/FormidableLabs/urql/discussions/2041
- https://spectrum.chat/urql/help/need-help-to-access-body-response-in-an-error-exchange~60c361a3-59de-420b-adae-918a1cd67030

Currently, if a response does not look like a GQL response (no `data` or `errors` array), the details will be lost because even if the `response` is available in `CombinedError`, it's not readable anymore since it has been consumed once (`bodyUsed: true`).

As sometimes we can't customise the server errors (in my case, a third-party entity with an auth-server **before** the GQL server - all authentication errors are lost then), this PR add the `result` body inside `CombinedError` in error cases (I'm juste not sure about the naming).

Of course it could be the case for a custom `fetchExchange`, but it will have to look like this:

<details>

```ts
/* eslint-disable */
import {
  CombinedError,
  Exchange,
  ExecutionResult,
  makeErrorResult,
  mergeResultPatch,
  Operation,
  OperationResult,
} from "@urql/core";
import { makeFetchBody, makeFetchOptions, makeFetchURL } from "@urql/core/internal";
import { filter, make, merge, mergeMap, onPush, pipe, share, Source, takeUntil } from "wonka";
import { isAuthServerError } from "./authServer"

// From utils/result.ts

const makeResult = (
  operation: Operation,
  result: ExecutionResult,
  response?: any,
): OperationResult => {
  // @ts-expect-error
  // 👇👇👇👇👇👇👇👇 Just to add this, to "fix" the issue
  if (isAuthServerError(result)) {
    result = { errors: [result] };
  }
  // 👆👆👆👆👆👆👆👆

  if ((!("data" in result) && !("errors" in result)) || "path" in result) {
    throw new Error("No Content");
  }

  return {
    operation,
    data: result.data,
    error: Array.isArray(result.errors)
      ? new CombinedError({
          graphQLErrors: result.errors,
          response,
        })
      : undefined,
    extensions: (typeof result.extensions === "object" && result.extensions) || undefined,
    hasNext: !!result.hasNext,
  };
};

// From internal/fetchSource.ts

const asyncIterator = typeof Symbol !== "undefined" ? Symbol.asyncIterator : null;
const decoder = typeof TextDecoder !== "undefined" ? new TextDecoder() : null;
const jsonHeaderRe = /content-type:[^\r\n]*application\/json/i;
const boundaryHeaderRe = /boundary="?([^=";]+)"?/i;

type ChunkData = { done: false; value: Buffer | Uint8Array } | { done: true };

// NOTE: We're avoiding referencing the `Buffer` global here to prevent
// auto-polyfilling in Webpack
const toString = (input: Buffer | ArrayBuffer): string =>
  input.constructor.name === "Buffer"
    ? (input as Buffer).toString()
    : decoder!.decode(input as ArrayBuffer);

// DERIVATIVE: Copyright (c) 2021 Marais Rossouw <hi@marais.io>
// See: https://github.com/maraisr/meros/blob/219fe95/src/browser.ts
const executeIncrementalFetch = (
  onResult: (result: OperationResult) => void,
  operation: Operation,
  response: Response,
): Promise<void> => {
  // NOTE: Guarding against fetch polyfills here
  const contentType = (response.headers && response.headers.get("Content-Type")) || "";
  if (!/multipart\/mixed/i.test(contentType)) {
    return response.json().then(payload => {
      onResult(makeResult(operation, payload, response));
    });
  }

  let boundary = "---";
  const boundaryHeader = contentType.match(boundaryHeaderRe);
  if (boundaryHeader) boundary = "--" + boundaryHeader[1];

  let read: () => Promise<ChunkData>;
  let cancel = () => {
    /*noop*/
  };
  // @ts-expect-error
  if (asyncIterator && response[asyncIterator]) {
    // @ts-expect-error
    const iterator = response[asyncIterator]();
    read = iterator.next.bind(iterator);
  } else if ("body" in response && response.body) {
    const reader = response.body.getReader();
    cancel = reader.cancel.bind(reader);
    read = reader.read.bind(reader);
  } else {
    throw new TypeError("Streaming requests unsupported");
  }

  let buffer = "";
  let isPreamble = true;
  let nextResult: OperationResult | null = null;
  let prevResult: OperationResult | null = null;

  function next(data: ChunkData): Promise<void> | void {
    if (!data.done) {
      const chunk = toString(data.value);
      let boundaryIndex = chunk.indexOf(boundary);
      if (boundaryIndex > -1) {
        boundaryIndex += buffer.length;
      } else {
        boundaryIndex = buffer.indexOf(boundary);
      }

      buffer += chunk;
      while (boundaryIndex > -1) {
        const current = buffer.slice(0, boundaryIndex);
        const next = buffer.slice(boundaryIndex + boundary.length);

        if (isPreamble) {
          isPreamble = false;
        } else {
          const headersEnd = current.indexOf("\r\n\r\n") + 4;
          const headers = current.slice(0, headersEnd);
          const body = current.slice(headersEnd, current.lastIndexOf("\r\n"));

          let payload: any;
          if (jsonHeaderRe.test(headers)) {
            try {
              payload = JSON.parse(body);
              nextResult = prevResult = prevResult
                ? mergeResultPatch(prevResult, payload, response)
                : makeResult(operation, payload, response);
            } catch (_error) {}
          }

          if (next.slice(0, 2) === "--" || (payload && !payload.hasNext)) {
            if (!prevResult) return onResult(makeResult(operation, {}, response));
            break;
          }
        }

        buffer = next;
        boundaryIndex = buffer.indexOf(boundary);
      }
    }

    if (nextResult) {
      onResult(nextResult);
      nextResult = null;
    }

    if (!data.done && (!prevResult || prevResult.hasNext)) {
      return read().then(next);
    }
  }

  return read().then(next).finally(cancel);
};

const makeFetchSource = (
  operation: Operation,
  url: string,
  fetchOptions: RequestInit,
): Source<OperationResult> => {
  const maxStatus = fetchOptions.redirect === "manual" ? 400 : 300;
  const fetcher = operation.context.fetch;

  return make<OperationResult>(({ next, complete }) => {
    const abortController = typeof AbortController !== "undefined" ? new AbortController() : null;
    if (abortController) {
      fetchOptions.signal = abortController.signal;
    }

    let ended = false;
    let statusNotOk = false;
    let response: Response;

    Promise.resolve()
      .then(() => {
        if (ended) return;
        return (fetcher || fetch)(url, fetchOptions);
      })
      .then((_response: Response | void) => {
        if (!_response) return;
        response = _response;
        statusNotOk = response.status < 200 || response.status >= maxStatus;
        return executeIncrementalFetch(next, operation, response);
      })
      .then(complete)
      .catch((error: Error) => {
        if (error.name !== "AbortError") {
          const result = makeErrorResult(
            operation,
            statusNotOk ? new Error(response.statusText) : error,
            response,
          );

          next(result);
          complete();
        }
      });

    return () => {
      ended = true;
      if (abortController) {
        abortController.abort();
      }
    };
  });
};

// From exchanges/fetch.ts

/** A default exchange for fetching GraphQL requests. */
export const fetchExchange: Exchange = ({ forward, dispatchDebug }) => {
  return ops$ => {
    const sharedOps$ = share(ops$);
    const fetchResults$ = pipe(
      sharedOps$,
      filter(operation => {
        return operation.kind === "query" || operation.kind === "mutation";
      }),
      mergeMap(operation => {
        const { key } = operation;
        const teardown$ = pipe(
          sharedOps$,
          filter(op => op.kind === "teardown" && op.key === key),
        );

        const body = makeFetchBody(operation);
        const url = makeFetchURL(operation, body);
        const fetchOptions = makeFetchOptions(operation, body);

        dispatchDebug({
          type: "fetchRequest",
          message: "A fetch request is being executed.",
          operation,
          data: {
            url,
            fetchOptions,
          },
        });

        return pipe(
          makeFetchSource(operation, url, fetchOptions),
          takeUntil(teardown$),
          onPush(result => {
            const error = !result.data ? result.error : undefined;

            dispatchDebug({
              type: error ? "fetchError" : "fetchSuccess",
              message: `A ${error ? "failed" : "successful"} fetch response has been returned.`,
              operation,
              data: {
                url,
                fetchOptions,
                value: error || result,
              },
            });
          }),
        );
      }),
    );

    const forward$ = pipe(
      sharedOps$,
      filter(operation => {
        return operation.kind !== "query" && operation.kind !== "mutation";
      }),
      forward,
    );

    return merge([fetchResults$, forward$]);
  };
};
```

</details>

The change consists in adding a `executionResult` field in `CombinedError` (could be `originalBody` maybe?). It's not breaking.
