### PR TITLE
(core) - fix incremental fetch not bubbling up JS-errors

### DIFF
--- a/.changeset/smart-brooms-fix.md
+++ b/.changeset/smart-brooms-fix.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix error bubbling, when an error happened in the exchange-pipeline we would treat it as a GraphQL-error

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -146,10 +146,7 @@ export const makeFetchSource = (
       })
       .then(complete)
       .catch((error: Error) => {
-        if (
-          error.name === 'SyntaxError' ||
-          error.name === 'TypeError'
-        ) {
+        if (error.name === 'SyntaxError' || error.name === 'TypeError') {
           const e = new Error(error.message);
           e.stack =
             e.stack!.split('\n').slice(0, 2).join('\n') + '\n' + error.stack;

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -147,7 +147,6 @@ export const makeFetchSource = (
       .then(complete)
       .catch((error: Error) => {
         if (
-          error.constructor === Error ||
           error.name === 'SyntaxError' ||
           error.name === 'TypeError'
         ) {

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -146,6 +146,18 @@ export const makeFetchSource = (
       })
       .then(complete)
       .catch((error: Error) => {
+        if (
+          error.constructor === Error ||
+          error.name === 'SyntaxError' ||
+          error.name === 'TypeError'
+        ) {
+          const e = new Error(error.message);
+          e.stack =
+            e.stack?.split('\n').slice(0, 2).join('\n') + '\n' + error.stack;
+          e.constructor = error.constructor;
+          throw e;
+        }
+
         if (error.name !== 'AbortError') {
           const result = makeErrorResult(
             operation,

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -153,7 +153,7 @@ export const makeFetchSource = (
         ) {
           const e = new Error(error.message);
           e.stack =
-            e.stack?.split('\n').slice(0, 2).join('\n') + '\n' + error.stack;
+            e.stack!.split('\n').slice(0, 2).join('\n') + '\n' + error.stack;
           e.constructor = error.constructor;
           throw e;
         }


### PR DESCRIPTION
## Summary

When we introduced incremental fetch we made sure that the backwards exchanges flow could be triggered multiple times for an `OperationResult` this made it so that the `fetchSource` would actually have the backwards execution of the exchanges like GraphCache writing data, ... inside of the `try catch` which means that if one of these throws we end up in the catch and handle this as if we encountered a `GraphQL` error.

fixes https://github.com/FormidableLabs/urql/issues/2191

## Set of changes

- filter out `Syntax`, `Type` and normal `Error` scenario's coming from the reverse-exchange run
