### PR TITLE
(storage-rn) - Fix issue where cache data is not cleared correctly

### DIFF
--- a/.changeset/moody-eels-cough.md
+++ b/.changeset/moody-eels-cough.md
@@ -1,0 +1,5 @@
+---
+'@urql/storage-rn': patch
+---
+
+Fix issue where the in-memory cache would not be cleared

--- a/packages/storage-rn/README.md
+++ b/packages/storage-rn/README.md
@@ -26,7 +26,7 @@ import { makeAsyncStorage } from '@urql/storage-rn';
 const storage = makeAsyncStorage({
   dataKey: 'graphcache-data', // tTe AsyncStorage key used for the data (defaults to graphcache-data)
   metadataKey: 'graphcache-metadata', // The AsyncStorage key used for the metadata (defaults to graphcache-metadata)
-  maxAge: 7 // How long to persist the data in storage (defaults to 7 days)
+  maxAge: 7, // How long to persist the data in storage (defaults to 7 days)
 });
 
 const cache = offlineExchange({

--- a/packages/storage-rn/README.md
+++ b/packages/storage-rn/README.md
@@ -24,7 +24,7 @@ import { offlineExchange } from '@urql/exchange-graphcache';
 import { makeAsyncStorage } from '@urql/storage-rn';
 
 const storage = makeAsyncStorage({
-  dataKey: 'graphcache-data', // tTe AsyncStorage key used for the data (defaults to graphcache-data)
+  dataKey: 'graphcache-data', // The AsyncStorage key used for the data (defaults to graphcache-data)
   metadataKey: 'graphcache-metadata', // The AsyncStorage key used for the metadata (defaults to graphcache-metadata)
   maxAge: 7, // How long to persist the data in storage (defaults to 7 days)
 });

--- a/packages/storage-rn/src/makeAsyncStorage.ts
+++ b/packages/storage-rn/src/makeAsyncStorage.ts
@@ -34,7 +34,7 @@ export const makeAsyncStorage: (
   const todayDayStamp = Math.floor(
     new Date().valueOf() / (1000 * 60 * 60 * 24)
   );
-  const allData = {};
+  let allData = {};
 
   return {
     readData: async () => {
@@ -129,6 +129,7 @@ export const makeAsyncStorage: (
 
     clear: async () => {
       try {
+        allData = {}
         await AsyncStorage.removeItem(dataKey);
         await AsyncStorage.removeItem(metadataKey);
       } catch (_err) {}

--- a/packages/storage-rn/src/makeAsyncStorage.ts
+++ b/packages/storage-rn/src/makeAsyncStorage.ts
@@ -129,7 +129,7 @@ export const makeAsyncStorage: (
 
     clear: async () => {
       try {
-        allData = {}
+        allData = {};
         await AsyncStorage.removeItem(dataKey);
         await AsyncStorage.removeItem(metadataKey);
       } catch (_err) {}


### PR DESCRIPTION
## Summary

When clearing the React Native Storage (for example, on logout), the AsyncStorage keys are cleared correctly. However, @urql/storage-rn caches these keys in local memory. This isn't cleared correctly, which means that unless you recreate the entire Urql client the old data persists in local memory even after calling `clear()`.

## Set of changes

#### `storage-rn/makeAsnyStorage.ts`
* Set the `allData` variable to an empty object when `clear()` is called