### PR TITLE
(react-urql) - pin correct version of use-sync-external store

### DIFF
--- a/.changeset/early-shoes-crash.md
+++ b/.changeset/early-shoes-crash.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+pin version for `use-sync-external-store`

--- a/packages/react-urql/package.json
+++ b/packages/react-urql/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@urql/core": "^2.4.0",
-    "use-sync-external-store": "^1.0.0-rc.0 || ^1.0.0",
+    "use-sync-external-store": "1.0.0-rc.0 || ^1.0.0",
     "wonka": "^4.0.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16355,10 +16355,10 @@ use-subscription@1.5.1:
   dependencies:
     object-assign "^4.1.1"
 
-"use-sync-external-store@^1.0.0-rc.0 || ^1.0.0":
-  version "1.0.0-rc.0-next-fe905f152-20220107"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.0.0-rc.0-next-fe905f152-20220107.tgz#1a244bd9c97f6853552df1f5a29fca726e7a3e96"
-  integrity sha512-1kK4h4Qubjnkmk6UObQKkYv+XwGTd5SuH6/hx1dfzEEvIWLkVd326Lg7Y1EOxfMUxJ5binWXndYX8ZrXFKHGuw==
+"use-sync-external-store@1.0.0-rc.0 || ^1.0.0":
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.0.0-rc.0.tgz#0d8fb7cbc31ddfb3ee01225f6b0a700cf59c449b"
+  integrity sha512-0U9Xlc2QDFzSGMB0DvcJQL0+DIdxDPJC7mnZlYFbl7wrSrPMcs89X5TVkNB6Dzg618m8lZop+U+J6ow3vq9RAQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Summary

pin correct version of use-sync-external store as it was automatically going to experimental versions

## Set of changes

- pin correct version of use-sync-external store
