### PR TITLE
(react) - Update initial state to not require abort on mount

### DIFF
--- a/.changeset/funny-pugs-tan.md
+++ b/.changeset/funny-pugs-tan.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Update `useQuery` implementation to avoid an aborted render on initial mount. We abort a render-on-update once when the state needs to be updated according to the `OperationResult` source we need to listen to and execute. However, we can avoid this on the initial mount as we've done in a prior version. This fix **does not** change any of the current behaviour, but simply avoids the confusing state transition on mount.


### PR DESCRIPTION
Resolve #2226

## Summary

Previously, the `useSyncExternalStore` reimplementation regressed
on us constructing the correct initial state on mount, and instead
relied on an abort on mount, which is confusing to users.
Instead, we can simply revert to what we've done prior to the
change and ensure that the initial state is accurate.

This fix **does not** change any of the current behaviour, but simply avoids the confusing state transition on mount.

## Set of changes

- Update initial state in `useQuery` implementation