### PR TITLE
(core) - Fix (cloned) mutation operation being compared rather than a stable identity

### DIFF
--- a/.changeset/shaggy-frogs-attack.md
+++ b/.changeset/shaggy-frogs-attack.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix mutation operation being used as compared identity and instead add a stand-in comparison.

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -157,7 +157,7 @@ describe('promisified methods', () => {
     expect(received.key).toBeDefined();
     expect(received.variables).toEqual({ example: 1234 });
     expect(received.kind).toEqual('mutation');
-    expect(received.context).toEqual({
+    expect(received.context).toMatchObject({
       url: 'https://hostname.com',
       requestPolicy: 'cache-and-network',
       fetchOptions: undefined,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -179,7 +179,9 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         } else {
           return (
             res.operation.kind === operation.kind &&
-            res.operation.key === operation.key
+            res.operation.key === operation.key &&
+            (!res.operation.context._instance ||
+              res.operation.context._instance === operation.context._instance)
           );
         }
       })
@@ -281,6 +283,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
       if (!opts) opts = {};
 
       return {
+        _instance: undefined,
         url: client.url,
         fetchOptions: client.fetchOptions,
         fetch: client.fetch,
@@ -302,7 +305,9 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
           `Expected operation of type "${kind}" but found "${requestOperationType}"`
         );
       }
-      return makeOperation(kind, request, client.createOperationContext(opts));
+      const context = client.createOperationContext(opts);
+      if (kind === 'mutation') (context as any)._instance = [];
+      return makeOperation(kind, request, context);
     },
 
     executeRequestOperation(operation) {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -174,16 +174,12 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     let result$ = pipe(
       results$,
       filter((res: OperationResult) => {
-        if (res.operation.kind === 'mutation') {
-          return res.operation === operation;
-        } else {
-          return (
-            res.operation.kind === operation.kind &&
-            res.operation.key === operation.key &&
-            (!res.operation.context._instance ||
-              res.operation.context._instance === operation.context._instance)
-          );
-        }
+        return (
+          res.operation.kind === operation.kind &&
+          res.operation.key === operation.key &&
+          (!res.operation.context._instance ||
+            res.operation.context._instance === operation.context._instance)
+        );
       })
     );
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,6 +58,7 @@ export interface OperationDebugMeta {
 /** Additional metadata passed to [exchange]{@link Exchange} functions. */
 export interface OperationContext {
   [key: string]: any;
+  readonly _instance?: [] | undefined;
   additionalTypenames?: string[];
   fetch?: typeof fetch;
   fetchOptions?: RequestInit | (() => RequestInit);


### PR DESCRIPTION
Resolve #2225

## Summary

This addresses a regression from #2189 where a mutation's operation is compared to filter results.
Such a comparison will always fail in the presence of cache exchanges that create new operations to update
the document of the operation (or variables)

Instead, we can introduce a stand-in identity object for the mutation instead and use that to compare.
This isn't a final resolution of the issue but a quick workaround.

## Set of changes

- Add `OperationContext._identity` to compare mutation identities
