### PR TITLE
(react) - fix issue where the cache infinitely loops

### DIFF
--- a/.changeset/selfish-singers-nail.md
+++ b/.changeset/selfish-singers-nail.md
@@ -1,0 +1,5 @@
+---
+"urql": patch
+---
+
+fix issue where the cache infinitely loops

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -99,10 +99,11 @@ export function useQuery<Data = any, Variables = object>(
               !result
           ),
           subscribe(_result => {
+            result = _result;
             if (suspense) {
               cache.set(request.key, result);
             }
-            result = _result;
+
             if (resolve) {
               resolve(result);
               resolve = undefined;

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -137,10 +137,10 @@ export function useQuery<Data = any, Variables = object>(
       const unsub = pipe(
         source,
         subscribe(_result => {
+          result = _result;
           if (suspense) {
             cache.set(request.key, result);
           }
-          result = _result;
           notify();
         })
       ).unsubscribe;


### PR DESCRIPTION
## Summary

Issue found in https://github.com/FormidableLabs/urql/discussions/2235 we were setting the resolved promise as the cache-entry resulting in an infinite loop.

[Fixed React sandbox](https://codesandbox.io/s/stoic-pond-q81st?file=/src/useQuery.ts)
[Fixed Next sandbox](https://codesandbox.io/s/crimson-fire-pv25l?file=/lib/useQuery.ts)

fixes #2239

## Set of changes

- set cache after assigning `result`
