### PR TITLE
(react) - diff data correctly for the next state computing

### DIFF
--- a/.changeset/loud-vans-try.md
+++ b/.changeset/loud-vans-try.md
@@ -1,0 +1,5 @@
+---
+"urql": patch
+---
+
+fix diff data correctly for the next state computing, this avoids having UI-flashes due to undefined data

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -15,7 +15,7 @@ const isShallowDifferent = (a: any, b: any) => {
 };
 
 interface Stateish {
-  data: any;
+  data?: any;
   fetching: boolean;
   stale: boolean;
 }

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -15,6 +15,7 @@ const isShallowDifferent = (a: any, b: any) => {
 };
 
 interface Stateish {
+  data: any;
   fetching: boolean;
   stale: boolean;
 }
@@ -26,6 +27,7 @@ export const computeNextState = <T extends Stateish>(
   const newState = {
     ...prevState,
     ...result,
+    data: result.data || prevState.data,
     fetching: !!result.fetching,
     stale: !!result.stale,
   };

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -27,7 +27,7 @@ export const computeNextState = <T extends Stateish>(
   const newState = {
     ...prevState,
     ...result,
-    data: result.data || prevState.data,
+    data: result.data !== undefined ? result.data : prevState.data,
     fetching: !!result.fetching,
     stale: !!result.stale,
   };

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -4,11 +4,11 @@ export const initialState = {
   error: undefined,
   data: undefined,
   extensions: undefined,
-  operation: undefined,
+  operation: undefined
 };
 
 const isShallowDifferent = (a: any, b: any) => {
-  if (typeof a != 'object' || typeof b != 'object') return a !== b;
+  if (typeof a != "object" || typeof b != "object") return a !== b;
   for (const x in a) if (!(x in b)) return true;
   for (const x in b) if (a[x] !== b[x]) return true;
   return false;
@@ -16,6 +16,7 @@ const isShallowDifferent = (a: any, b: any) => {
 
 interface Stateish {
   data?: any;
+  error?: any;
   fetching: boolean;
   stale: boolean;
 }
@@ -27,9 +28,10 @@ export const computeNextState = <T extends Stateish>(
   const newState = {
     ...prevState,
     ...result,
-    data: result.data !== undefined || result.error ? result.data : prevState.data,
+    data:
+      result.data !== undefined || result.error ? result.data : prevState.data,
     fetching: !!result.fetching,
-    stale: !!result.stale,
+    stale: !!result.stale
   };
 
   return isShallowDifferent(prevState, newState) ? newState : prevState;

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -27,7 +27,7 @@ export const computeNextState = <T extends Stateish>(
   const newState = {
     ...prevState,
     ...result,
-    data: result.data !== undefined ? result.data : prevState.data,
+    data: result.data !== undefined || result.error ? result.data : prevState.data,
     fetching: !!result.fetching,
     stale: !!result.stale,
   };

--- a/packages/react-urql/src/hooks/state.ts
+++ b/packages/react-urql/src/hooks/state.ts
@@ -4,11 +4,11 @@ export const initialState = {
   error: undefined,
   data: undefined,
   extensions: undefined,
-  operation: undefined
+  operation: undefined,
 };
 
 const isShallowDifferent = (a: any, b: any) => {
-  if (typeof a != "object" || typeof b != "object") return a !== b;
+  if (typeof a != 'object' || typeof b != 'object') return a !== b;
   for (const x in a) if (!(x in b)) return true;
   for (const x in b) if (a[x] !== b[x]) return true;
   return false;
@@ -31,7 +31,7 @@ export const computeNextState = <T extends Stateish>(
     data:
       result.data !== undefined || result.error ? result.data : prevState.data,
     fetching: !!result.fetching,
-    stale: !!result.stale
+    stale: !!result.stale,
   };
 
   return isShallowDifferent(prevState, newState) ? newState : prevState;


### PR DESCRIPTION
Fixes #2236

## Summary

Currently we just merge in with `...result` which will override the data coming from the `...prevState` with undefined for a small amount of time.

[fixed repro](https://codesandbox.io/s/silly-estrela-dupqi)

## Set of changes

- don't just spread in result, look at the data attribute individually
