### PR TITLE
(introspection) - Fix usage of `executeSync` causing invalid mjs import

### DIFF
--- a/.changeset/ninety-colts-tap.md
+++ b/.changeset/ninety-colts-tap.md
@@ -1,0 +1,5 @@
+---
+'@urql/introspection': patch
+---
+
+Fix import of `executeSync` rather than `execute` causing an incompatibility when several `.mjs` imports and a main `import { executeSync } from 'graphql'` are causing two different modules to be instantiated.

--- a/packages/introspection/src/getIntrospectedSchema.ts
+++ b/packages/introspection/src/getIntrospectedSchema.ts
@@ -3,7 +3,7 @@ import {
   GraphQLSchema,
   parse,
   buildSchema,
-  executeSync,
+  execute,
   getIntrospectionQuery,
 } from 'graphql';
 
@@ -22,7 +22,7 @@ export const getIntrospectedSchema = (
     return input;
   }
 
-  const initialIntrospection: any = executeSync({
+  const initialIntrospection: any = execute({
     document: parse(getIntrospectionQuery({ descriptions: false })),
     schema: input as GraphQLSchema,
   });


### PR DESCRIPTION
Fix #2250

## Summary

Resolves an issue where the old version of `babel-plugin-modular-graphql` wasn't warning us forcefully about `executeSync` not being present in all versions we support, which resulted in it being imported from `"graphql"`, which then instantiates non-mjs duplicate modules in some versions of Node.js (i.e. when Node isn't in ESM mode)

## Set of changes

- Replace `executeSync` with `execute`

This release will simply then cause a rebuild and re-release with `babel-plugin-modular-graphql@1.1.0`
