### PR TITLE
undo prior art of catching errors manually

### DIFF
--- a/.changeset/four-pens-deliver.md
+++ b/.changeset/four-pens-deliver.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Undo logic to catch errors from incremental fetching and forking the response stream

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -146,14 +146,6 @@ export const makeFetchSource = (
       })
       .then(complete)
       .catch((error: Error) => {
-        if (error.name === 'SyntaxError' || error.name === 'TypeError') {
-          const e = new Error(error.message);
-          e.stack =
-            e.stack!.split('\n').slice(0, 2).join('\n') + '\n' + error.stack;
-          e.constructor = error.constructor;
-          throw e;
-        }
-
         if (error.name !== 'AbortError') {
           const result = makeErrorResult(
             operation,


### PR DESCRIPTION
## Summary

In #2210 I've done an attempt at catching errors that happen in the backwards chain of the exchange-stream. This because we have this part of the stream forked since #1854 to support incremental fetch-results.

The downside of this is that the `executeIncrementalFetch` is wrapped by a `.catch` itself to account for erroneous results from the server. In this attempt we tried to catch both `TypeError` as well as `SyntaxError` as those are the most common ones. However, `failed to fetch` is an example of a `TypeError` that actually comes from the `fetch` call which we want to report to the client.

I'm not entirely sure how we can prevent swallowing errors, one potential avenue would be to wrap user-supplied functions and mark them as errored out in the exchanges but this is a big caveat to have towards external exchange-authors. Trying to think of a way we could make the response-stream report errors during dev, maybe even just a console.error? However that could prove problematic for production systems that want to report this......

## Set of changes

- undo #2210
