### PR TITLE
(core) - Prevent ignored characters from being sanitized in strings

### DIFF
--- a/.changeset/serious-queens-suffer.md
+++ b/.changeset/serious-queens-suffer.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Prevent ignored characters in GraphQL queries from being replaced inside strings and block strings. Previously we accepted sanitizing strings via regular expressions causing duplicate hashes as acceptable, since it'd only be caused when a string wasn't extracted into variables. This is fixed now however.

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -36,8 +36,7 @@ export const stringifyDocument = (
   )
     .split(GRAPHQL_STRING_RE)
     .map(replaceOutsideStrings)
-    .join('')
-    .trim();
+    .join('');
 
   if (typeof node !== 'string') {
     const operationName = 'definitions' in node && getOperationName(node);

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -21,6 +21,12 @@ export interface KeyedDocumentNode extends DocumentNode {
   __key: number;
 }
 
+const GRAPHQL_STRING_RE = /("{3}[\s\S]*"{3}|"(?:\\.|[^"])*")/g;
+const REPLACE_CHAR_RE = /([\s,]|#[^\n\r]+)+/g;
+
+const replaceOutsideStrings = (str: string, idx: number) =>
+  idx % 2 === 0 ? str.replace(REPLACE_CHAR_RE, ' ').trim() : str;
+
 export const stringifyDocument = (
   node: string | DefinitionNode | DocumentNode
 ): string => {
@@ -28,7 +34,9 @@ export const stringifyDocument = (
     ? (node.loc && node.loc.source.body) || print(node)
     : node
   )
-    .replace(/([\s,]|#[^\n\r]+)+/g, ' ')
+    .split(GRAPHQL_STRING_RE)
+    .map(replaceOutsideStrings)
+    .join('')
     .trim();
 
   if (typeof node !== 'string') {


### PR DESCRIPTION
Resolve #2290
Resolve #1960

## Summary

This updates our string sanitization to exclude replacing ignored characters inside of strings.
This is pretty crude but should stop us from accidentally messing up queries to the point where they don't produce valid hashes any longer.

Edit: Bundlesize will be affected in shared import by +59B.

## Set of changes

- Update `createRequest`'s stringification to exclude strings in sanitization
- Add appropriate test (previous test wasn't actually checking _our_ string sanitization)
