### PR TITLE
feat: use "application/graphql+json" content-type header

### DIFF
--- a/docs/advanced/persistence-and-uploads.md
+++ b/docs/advanced/persistence-and-uploads.md
@@ -131,7 +131,7 @@ support file uploads, which is a drop-in replacement for the default
 
 It works by using the [`extract-files` package](https://www.npmjs.com/package/extract-files). When
 the `multipartFetchExchange` sees at least one `File` in the variables it receives for a mutation,
-then it will send a `multipart/form-data` POST request instead of a standard `application/json`
+then it will send a `multipart/form-data` POST request instead of a standard `application/graphql+json`
 one. This is basically the same kind of request that we'd expect to send for regular HTML forms.
 
 ### Installation & Setup

--- a/docs/graphcache/schema-awareness.md
+++ b/docs/graphcache/schema-awareness.md
@@ -19,9 +19,9 @@ on `cacheExchange` allows us to pass an introspected schema to Graphcache:
 ```js
 const introspectedSchema = {
   __schema: {
-    queryType: { name: 'Query', },
-    mutationType: { name: 'Mutation', },
-    subscriptionType: { name: 'Subscription', },
+    queryType: { name: 'Query' },
+    mutationType: { name: 'Mutation' },
+    subscriptionType: { name: 'Subscription' },
   },
 };
 
@@ -97,7 +97,7 @@ import * as fs from 'fs';
 
 fetch('http://localhost:3000/graphql', {
   method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
+  headers: { 'Content-Type': 'application/graphql+json' },
   body: JSON.stringify({
     variables: {},
     query: getIntrospectionQuery({ descriptions: false }),
@@ -161,7 +161,7 @@ import { getIntrospectedSchema, minifyIntrospectionQuery } from '@urql/introspec
 
 fetch('http://localhost:3000/graphql', {
   method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
+  headers: { 'Content-Type': 'application/graphql+json' },
   body: JSON.stringify({
     variables: {},
     query: getIntrospectionQuery({ descriptions: false }),

--- a/examples/with-defer-stream-directives/server/index.js
+++ b/examples/with-defer-stream-directives/server/index.js
@@ -84,7 +84,7 @@ polka()
     if (result.type === 'RESPONSE') {
       result.headers.forEach(({ name, value }) => res.setHeader(name, value));
       res.writeHead(result.status, {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/graphql+json',
       });
       res.end(JSON.stringify(result.payload));
     } else if (result.type === 'MULTIPART_RESPONSE') {
@@ -104,7 +104,7 @@ polka()
         const chunk = Buffer.from(JSON.stringify(result), 'utf8');
         const data = [
           '',
-          'Content-Type: application/json; charset=utf-8',
+          'Content-Type: application/graphql+json; charset=utf-8',
           '',
           chunk,
         ];

--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@urql/core": ">=2.3.3",
+    "@urql/core": ">=2.3.6",
     "wonka": "^4.0.14"
   }
 }

--- a/exchanges/multipart-fetch/src/multipartFetchExchange.ts
+++ b/exchanges/multipart-fetch/src/multipartFetchExchange.ts
@@ -36,7 +36,10 @@ export const multipartFetchExchange: Exchange = ({
       if (files.size) {
         url = makeFetchURL(operation);
         fetchOptions = makeFetchOptions(operation);
-        if (fetchOptions.headers!['content-type'] === 'application/json') {
+        if (
+          fetchOptions.headers!['content-type'] === 'application/json' ||
+          fetchOptions.headers!['content-type'] === 'application/graphql+json'
+        ) {
           delete fetchOptions.headers!['content-type'];
         }
 

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -76,6 +76,6 @@ export const makeFetchOptions = (
     method: useGETMethod ? 'GET' : 'POST',
     headers: useGETMethod
       ? extraOptions.headers
-      : { 'content-type': 'application/json', ...extraOptions.headers },
+      : { 'content-type': 'application/graphql+json', ...extraOptions.headers },
   };
 };

--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -202,7 +202,7 @@ external withUrqlClient:
 Which can then be used like so:
 
 ```reason
-let headers = Fetch.HeadersInit.make({ "Content-Type": "application/json" });
+let headers = Fetch.HeadersInit.make({ "Content-Type": "application/graphql+json" });
 let client = {
   url: "https://mygraphqlapi.com/graphql",
   fetchOptions: Fetch.RequestInit.make(~headers, ~method_=POST, ())


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

The recept [GraphQL over HTTP specification](https://github.com/graphql/graphql-over-http/blob/92b57a9179834318b6f15e1d23afc49368dd5e3c/spec/GraphQLOverHTTP.md#content-types) encourages GraphQL requests to have a `Content-Type: application/graphql+json` header. This way GraphQL requests can finally be reliably distinguished from other HTTP requests ([see the issue](https://github.com/graphql/graphql-spec/issues/938)).

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

- `urql` now sets `Content-Type: application/graphql+json` request header on the issued requests.
- Adjusts tests accordingly. 
