### PR TITLE
fix(core): limit the url-size to 2048 characters

### DIFF
--- a/.changeset/bright-masks-learn.md
+++ b/.changeset/bright-masks-learn.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+cut off `url` when using the GET method at 2048 characters (lowest url-size coming from chromium)

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -56,7 +56,14 @@ export const makeFetchURL = (
     );
   }
 
-  return `${url}?${search.join('&')}`;
+  const finalUrl = `${url}?${search.join('&')}`;
+
+  if (finalUrl.length > 2047) {
+    operation.context.preferGetMethod = false;
+    return url;
+  }
+
+  return finalUrl;
 };
 
 export const makeFetchOptions = (


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/urql/issues/2374

## Summary

Currently it looks like the lowest common denominator in url-size is 2048 characters. This means that currently when a query  grows big we can't really send it as GET without it erroring on some browsers.

This PR aims to fix that as when it calculates the url it will check the length and revert back to `POST` if it's too big

## Set of changes

- fall back to `POST` when the URL is too lengthy
