### PR TITLE
fix(core): fix issue with synchronous `toPromise` queries

### DIFF
--- a/.changeset/poor-games-teach.md
+++ b/.changeset/poor-games-teach.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix issue where a synchronous `toPromise()` return would not result in the stream tearing down

--- a/packages/core/src/utils/streamUtils.ts
+++ b/packages/core/src/utils/streamUtils.ts
@@ -1,16 +1,23 @@
-import { Source, pipe, toPromise, filter, take } from 'wonka';
+import { Source, subscribe, pipe } from 'wonka';
 import { OperationResult, PromisifiedSource } from '../types';
 
 export function withPromise<T extends OperationResult>(
   source$: Source<T>
 ): PromisifiedSource<T> {
   (source$ as PromisifiedSource<T>).toPromise = () => {
-    return pipe(
-      source$,
-      filter(result => !result.stale && !result.hasNext),
-      take(1),
-      toPromise
-    );
+    return new Promise(resolve => {
+      const subscription = pipe(
+        source$,
+        subscribe(result => {
+          if (!result.stale && !result.hasNext) {
+            Promise.resolve().then(() => {
+              subscription.unsubscribe();
+              resolve(result);
+            });
+          }
+        })
+      );
+    });
   };
 
   return source$ as PromisifiedSource<T>;


### PR DESCRIPTION
Resolves #2364

## Summary

Fix issue where a synchronous `toPromise()` return would not result in the stream tearing down, this would make it so that subsequent calls would not pass through the exchange-chain

## Set of changes

- refactor the implementation of `toPromise` to leverage a subscription that returns on first non-stale completed result
