### PR TITLE
add v-bind:key directive to basic vue docs

### DIFF
--- a/docs/basics/vue.md
+++ b/docs/basics/vue.md
@@ -125,7 +125,7 @@ todo items. Let's dive right into it!
   </div>
   <div v-else>
     <ul v-if="data">
-      <li v-for="todo in data.todos">{{ todo.title }}</li>
+      <li v-for="todo in data.todos" :key="todo.id">{{ todo.title }}</li>
     </ul>
   </div>
 </template>
@@ -213,7 +213,7 @@ outputs of `useQuery` are reactive and may change over time.
 ```jsx
 <template>
   <ul v-if="data">
-    <li v-for="todo in data.todos">{{ todo.title }}</li>
+    <li v-for="todo in data.todos" :key="todo.id">{{ todo.title }}</li>
   </ul>
   <button @click="from += 10">Next Page</button>
 </template>
@@ -464,7 +464,7 @@ our examples to have a suspending component by changing our usage of `useQuery`:
 ```jsx
 <template>
   <ul>
-    <li v-for="todo in data.todos">{{ todo.title }}</li>
+    <li v-for="todo in data.todos" :key="todo.id">{{ todo.title }}</li>
   </ul>
 </template>
 


### PR DESCRIPTION
## Summary

Following along the urql docs for Vue on vue version ^3.2.13, I expected to see my data surface to the user interface after inserting my open endpoint and updating the logic, but I ran into:

```
10:7  error  Elements in iteration expect to have 'v-bind:key' directives  vue/require-v-for-key
```

## Set of changes

I added the 'v-bind:key' directive example to the three `v-for` loops in the code examples so that users will anticipate having to provide a key. This PR only consists of changes to the copy in `/docs/basics/vue.md`. Ran `yarn test` on my branch to be sure everything else was looking good. 

I need help with the changeset. When I run `yarn changeset`, type `urql-docs` and enter, nothing happens. 
