### PR TITLE
docs(next-urql): fix README syntax highlighting

### DIFF
--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -222,12 +222,12 @@ The great part about writing thin bindings like this is that they are zero cost 
 
 If you want to use a `Client` in Next.js' newer methods like `getServerSideProps` you may use the `initUrqlClient` function to create a client on the fly. This will need to be done per request.
 
-```
-import { initUrqlClient, NextUrqlPageContext } from 'next-urql';
+```javascript
+import { initUrqlClient } from 'next-urql';
 
 export const getServerSideProps = async (ctx) => {
   const client = initUrqlClient({
-    url: /graphql',
+    url: '/graphql',
   }, false /* set to false to disable suspense */);
 
   const result = await client.query(QUERY, {}).toPromise();


### PR DESCRIPTION
## Summary

I noticed the last code block in the next-urql README.md was not highlighted.

## Set of changes

Added javascript as the language used for the code block and removed unused import in the example.
