### PR TITLE
Variable name mismatch in subscription docs

### DIFF
--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -306,7 +306,7 @@ use subscriptions in a Node.js environment.
 ```js
 import { pipe, subscribe } from 'wonka';
 
-const newMessages = `
+const MessageSub = `
   subscription MessageSub {
     newMessages {
       id


### PR DESCRIPTION
In the standalone client example, a variable newMessages holding a query MessageSub is defined but never used; in the body an undefined variable MessageSub is referenced. Renamed to MessageSub uniformly.

<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

Docs have an example that can't be run

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

one-line docfix