### PR TITLE
fix(vue): prevent executeQuery from taking a fetching or prior result

### DIFF
--- a/.changeset/small-points-protect.md
+++ b/.changeset/small-points-protect.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Fix wait for the first non-stale result when using `await executeQuery`

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -128,7 +128,6 @@ export function callUseQuery<T = any, V = object>(
 
       return {
         ...response,
-        // @ts-ignore
         then(onFulfilled, onRejected) {
           const promise = new Promise(resolve => {
             const sub = pipe(
@@ -145,10 +144,10 @@ export function callUseQuery<T = any, V = object>(
               })
             );
           });
-          return promise.then(res => {
-            // @ts-ignore
-            onFulfilled(res);
-          }, onRejected);
+          return promise.then(
+            x => onFulfilled!(x as UseQueryState<T, V>),
+            onRejected
+          );
         },
       };
     },
@@ -199,7 +198,6 @@ export function callUseQuery<T = any, V = object>(
 
   const response: UseQueryResponse<T, V> = {
     ...state,
-    // @ts-ignore
     then(onFulfilled, onRejected) {
       const promise = new Promise(resolve => {
         if (!source.value) return resolve(state);
@@ -217,10 +215,11 @@ export function callUseQuery<T = any, V = object>(
           })
         );
       });
-      return promise.then(res => {
-        // @ts-ignore
-        onFulfilled(res);
-      }, onRejected);
+
+      return promise.then(
+        x => onFulfilled!(x as UseQueryState<T, V>),
+        onRejected
+      );
     },
   };
 

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -4,7 +4,7 @@ import { DocumentNode } from 'graphql';
 
 import { WatchStopHandle, Ref, ref, watchEffect, reactive, isRef } from 'vue';
 
-import { Source, pipe, subscribe, onEnd, map } from 'wonka';
+import { Source, pipe, subscribe, onEnd } from 'wonka';
 
 import {
   Client,
@@ -133,12 +133,11 @@ export function callUseQuery<T = any, V = object>(
             let hasResult = false;
             const sub = pipe(
               s,
-              map(() => state),
-              subscribe(result => {
-                if (!result.fetching.value && !result.stale.value) {
+              subscribe(() => {
+                if (!state.fetching.value && !state.stale.value) {
                   if (sub) sub.unsubscribe();
                   hasResult = true;
-                  resolve(result);
+                  resolve(state);
                 }
               })
             );
@@ -200,12 +199,11 @@ export function callUseQuery<T = any, V = object>(
         let hasResult = false;
         const sub = pipe(
           source.value,
-          map(() => state),
-          subscribe(result => {
-            if (!result.fetching.value && !result.stale.value) {
+          subscribe(() => {
+            if (!state.fetching.value && !state.stale.value) {
               if (sub) sub.unsubscribe();
               hasResult = true;
-              resolve(result);
+              resolve(state);
             }
           })
         );


### PR DESCRIPTION
Fixes #2409 

## Summary

Due to the promise already being executed we would be returning old data to the user, this was enforced by us unsubscribing immediately in `take(1)`. Now we wait for the first non fetching and stale result.

## Set of changes

- wait for the first non-stale result
