### PR TITLE
fix(graphcache): Shift layers with future updates and improve layer behaviour

### DIFF
--- a/.changeset/pink-turkeys-live.md
+++ b/.changeset/pink-turkeys-live.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix issues with continuously updating operations (i.e. subscriptions and `hasNext: true` queries) by shifting their layers in Graphcache behind those that are still awaiting a result. This causes continuous updates to not overwrite one-off query results while still keeping continuously updating operations at the highest possible layer.

--- a/.changeset/pink-turkeys-live.md
+++ b/.changeset/pink-turkeys-live.md
@@ -1,5 +1,5 @@
 ---
-'@urql/exchange-graphcache': patch
+'@urql/exchange-graphcache': minor
 ---
 
 Fix issues with continuously updating operations (i.e. subscriptions and `hasNext: true` queries) by shifting their layers in Graphcache behind those that are still awaiting a result. This causes continuous updates to not overwrite one-off query results while still keeping continuously updating operations at the highest possible layer.

--- a/.changeset/unlucky-moles-stare.md
+++ b/.changeset/unlucky-moles-stare.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Prevent creating unnecessary layers, which should improve performance slightly.

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -200,7 +200,11 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
       optimisticKeysToDependencies.delete(key);
     }
 
-    reserveLayer(store.data, operation.key, result.hasNext);
+    reserveLayer(
+      store.data,
+      operation.key,
+      operation.kind === 'subscription' || result.hasNext
+    );
 
     let queryDependencies: void | Dependencies;
     let data: Data | null = result.data;

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -529,13 +529,9 @@ describe('deferred changes', () => {
     InMemoryData.initDataState('write', data, 1);
     InMemoryData.writeRecord('Query', 'index', 1);
     InMemoryData.clearDataState();
-
-    InMemoryData.initDataState('write', data, 3);
-    InMemoryData.writeRecord('Query', 'index', 3);
-    InMemoryData.clearDataState();
+    expect(data.optimisticOrder).toEqual([3]);
 
     // The layers must then be squashed
-    expect(data.optimisticOrder).toEqual([3]);
     InMemoryData.noopDataState(data, 3, false);
     expect(data.optimisticOrder).toEqual([]);
   });

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -111,7 +111,7 @@ export const initDataState = (
     // We don't create new layers for read operations and instead simply
     // apply the currently available layer, if any
     currentOptimisticKey = layerKey;
-  } else if (isOptimistic || data.optimisticOrder.length > 0) {
+  } else if (isOptimistic || data.optimisticOrder.length > 1) {
     // If this operation isn't optimistic and we see it for the first time,
     // then it must've been optimistic in the past, so we can proactively
     // clear the optimistic data before writing
@@ -131,6 +131,8 @@ export const initDataState = (
   } else {
     // Otherwise we don't create an optimistic layer and clear the
     // operation's one if it already exists
+    // We also do this when only one layer exists to avoid having to squash
+    // any layers at the end of writing this layer
     currentOptimisticKey = null;
     deleteLayer(data, layerKey);
   }

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -107,6 +107,10 @@ export const initDataState = (
 
   if (!layerKey) {
     currentOptimisticKey = null;
+  } else if (currentOperation === 'read') {
+    // We don't create new layers for read operations and instead simply
+    // apply the currently available layer, if any
+    currentOptimisticKey = layerKey;
   } else if (isOptimistic || data.optimisticOrder.length > 0) {
     // If this operation isn't optimistic and we see it for the first time,
     // then it must've been optimistic in the past, so we can proactively
@@ -188,7 +192,7 @@ export const noopDataState = (
   isOptimistic?: boolean
 ) => {
   if (layerKey && !isOptimistic) data.deferredKeys.delete(layerKey);
-  initDataState('read', data, layerKey, isOptimistic);
+  initDataState('write', data, layerKey, isOptimistic);
   clearDataState();
 };
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

This pull request introduces several small tweaks to Graphcache's data layering.

Usually we reserve layers per query operation, create optimistic layers for optimistic mutations, and write to these layers as responses come in in the order they've been reserved in. If they haven't been reserved they'll be created on demand. This means that layers are essentially just queues and we `unshift` to this queue whenever a layer is created. Queueing in order isn't always desireable however.

As we've found out, when a layer expects future updates (`hasNext: true`, as it's been added with deferred results, via `@defer`) it's added to the queue and multiple queries that are started while this layer is still waiting for updates will layer on top of it. We've deemed this acceptable. After all, it's very unlikely that any query will go on to conflict with another query that's been deferred, since this would imply a deferred vs non-deferred overlap. However, we knew that this behaviour could eventually still cause trouble due to subscriptions (which theoretically may never stop updating) and the updates to queries they may trigger.

A subscription may cause updates at any time, and could hence cause refetches for queries at any time. This can cause problems, because when two subsequent subscription events cause a query to reexecute each time concurrently, then these the queued up query is in a layer lower than the subscription and hence its result has no chance to ever update the cache, if its data overlaps with the subscription's update.

It turns out that there's a very elegant solution for the above problems. **Layer Shifting**.

Whenever a subscription or query result with `hasNext: true` comes in, we proactively call `reserveLayer` with this truthy flag. This now causes the layer to be shifted ahead in the queue until it's past all layers that are still empty. This means it _loses_ precedence in the layering, i.e. becomes a lower layer. This is desireable however in this case.
Any layer that expects update should be the highest layer with data. However, it should also be the lower than all empty layers, so that layers for which we're still awaiting data can still override its update.

```
previously: [ x, 0, 1, 0 ]
new behaviour: [ 0, x, 1, 0 ]
```

The above is an illustration of this. In this case, our layers are ordered from latest & highest precedence (left) to oldest & lowest precedence (right). In this example `0` stands for empty layers (still fetching), while `1` stands for written layers (not fetching). The `x` stands for a layer that will be written using `hasNext: true`.
Instead of us adding this `x` layer to a place where it'll always override the first `0` layer, it's instead shifted behind it.

## Set of changes

- Treat subscription results as if they carried `hasNext: true`
- Ensure `query` (i.e. `read`) operations don't cause layers to be created
- Shift `hasNext: true` layers behind currently empty layers
- Avoid adding a layer when only one layer has been reserved (performance optimisation)
