### PR TITLE
fix: ignore empty relay pagination pages

### DIFF
--- a/.changeset/fluffy-toys-live.md
+++ b/.changeset/fluffy-toys-live.md
@@ -1,0 +1,5 @@
+---
+"@urql/exchange-graphcache": patch
+---
+
+Fix ignore empty relay edges when using the `relayPagination` resolver

--- a/exchanges/graphcache/src/extras/relayPagination.test.ts
+++ b/exchanges/graphcache/src/extras/relayPagination.test.ts
@@ -1319,3 +1319,112 @@ it('handles subsequent queries with larger first values', () => {
   expect(res.partial).toBe(false);
   expect(res.data).toEqual(pageTwo);
 });
+
+it('ignores empty pages when paginating', () => {
+  const PaginatingForward = gql`
+    query($first: Int!, $after: String) {
+      __typename
+      items(first: $first, after: $after) {
+        __typename
+        nodes {
+          __typename
+          id
+        }
+        pageInfo {
+          __typename
+          startCursor
+          endCursor
+        }
+      }
+    }
+  `;
+  const PaginatingBackward = gql`
+    query($last: Int!, $before: String) {
+      __typename
+      items(last: $last, before: $before) {
+        __typename
+        nodes {
+          __typename
+          id
+        }
+        pageInfo {
+          __typename
+          startCursor
+          endCursor
+        }
+      }
+    }
+  `;
+
+  const store = new Store({
+    resolvers: {
+      Query: {
+        items: relayPagination(),
+      },
+    },
+  });
+
+  const forwardOne = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      nodes: [itemNode(1), itemNode(2)],
+      pageInfo: {
+        __typename: 'PageInfo',
+        startCursor: '1',
+        endCursor: '2',
+      },
+    },
+  };
+  const forwardAfter = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      nodes: [],
+      pageInfo: {
+        __typename: 'PageInfo',
+        startCursor: null,
+        endCursor: null,
+      },
+    },
+  };
+  const backwardBefore = {
+    __typename: 'Query',
+    items: {
+      __typename: 'ItemsConnection',
+      nodes: [],
+      pageInfo: {
+        __typename: 'PageInfo',
+        startCursor: null,
+        endCursor: null,
+      },
+    },
+  };
+
+  write(
+    store,
+    { query: PaginatingForward, variables: { first: 2 } },
+    forwardOne
+  );
+  write(
+    store,
+    { query: PaginatingBackward, variables: { last: 1, before: '1' } },
+    backwardBefore
+  );
+
+  const res = query(store, {
+    query: PaginatingForward,
+    variables: { first: 2 },
+  });
+
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual(forwardOne);
+  write(
+    store,
+    { query: PaginatingForward, variables: { first: 1, after: '2' } },
+    forwardAfter
+  );
+
+  expect(res.partial).toBe(false);
+  expect(res.data).toEqual(forwardOne);
+});

--- a/exchanges/graphcache/src/extras/relayPagination.ts
+++ b/exchanges/graphcache/src/extras/relayPagination.ts
@@ -214,6 +214,9 @@ export const relayPagination = (
       if (page === null) {
         continue;
       }
+      if (page.nodes.length === 0 && page.edges.length === 0 && typename) {
+        continue;
+      }
 
       if (
         mergeMode === 'inwards' &&


### PR DESCRIPTION
Resolves #2430 

## Summary

Ignores empty pages in the `relayPagination` helper when there is at least one result, so as to preserve the start & end cursor when an empty result is returned with null cursor values.

## Set of changes

- Ignore empty pages when we already have at least one page in the cursor
- Adds test for the intended behavior