### PR TITLE
fix(core): support aborting in `withPromise` cases

### DIFF
--- a/.changeset/heavy-rabbits-beam.md
+++ b/.changeset/heavy-rabbits-beam.md
@@ -1,0 +1,5 @@
+---
+"@urql/core": patch
+---
+
+Support aborting in `withPromise` cases

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -168,6 +168,15 @@ export const makeFetchSource = (
           next(result);
           complete();
         }
+
+        const result = makeErrorResult(
+          operation,
+          statusNotOk ? new Error(response.statusText) : error,
+          response
+        );
+
+        next(result);
+        complete();
       });
 
     return () => {

--- a/packages/core/src/internal/fetchSource.ts
+++ b/packages/core/src/internal/fetchSource.ts
@@ -158,17 +158,6 @@ export const makeFetchSource = (
           throw error;
         }
 
-        if (error.name !== 'AbortError') {
-          const result = makeErrorResult(
-            operation,
-            statusNotOk ? new Error(response.statusText) : error,
-            response
-          );
-
-          next(result);
-          complete();
-        }
-
         const result = makeErrorResult(
           operation,
           statusNotOk ? new Error(response.statusText) : error,


### PR DESCRIPTION
Resolves #2441 

## Summary

Currently if your `fetch` implementation issues an abort  we will never trigger a result meaning `toPromise()` calls will hang forever. It is actually safe to dispatch a result as in the usual cases this will happen due to the `Query` unmounting or closing the subscription.

## Set of changes

- return an error result for an abort
