### PR TITLE
fix(graphcache): Switch fragment heuristic to always be truthy on writes

### DIFF
--- a/.changeset/thin-worms-unite.md
+++ b/.changeset/thin-worms-unite.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Switch `isFragmentHeuristicallyMatching()` to always return `true` for writes, so that we give every fragment a chance to be applied and to write to the cache.

--- a/exchanges/graphcache/src/operations/shared.ts
+++ b/exchanges/graphcache/src/operations/shared.ts
@@ -17,7 +17,7 @@ import {
 } from '../ast';
 
 import { warn, pushDebugNode, popDebugNode } from '../helpers/help';
-import { hasField } from '../store/data';
+import { hasField, isWriting } from '../store/data';
 import { Store, keyOfField } from '../store';
 
 import { getFieldArguments, shouldInclude, isInterfaceOfType } from '../ast';
@@ -141,11 +141,14 @@ const isFragmentHeuristicallyMatching = (
     16
   );
 
-  return !getSelectionSet(node).some(node => {
-    if (!isFieldNode(node)) return false;
-    const fieldKey = keyOfField(getName(node), getFieldArguments(node, vars));
-    return !hasField(entityKey, fieldKey);
-  });
+  return (
+    isWriting() ||
+    !getSelectionSet(node).some(node => {
+      if (!isFieldNode(node)) return false;
+      const fieldKey = keyOfField(getName(node), getFieldArguments(node, vars));
+      return !hasField(entityKey, fieldKey);
+    })
+  );
 };
 
 interface SelectionIterator {

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -85,6 +85,8 @@ export const makeData = (data?: Data): Data => {
   return newData;
 };
 
+export const isWriting = (): boolean => currentOperation === 'write';
+
 export const ownsData = (data?: Data): boolean =>
   !!data && currentOwnership!.has(data);
 


### PR DESCRIPTION
Previously we assumed that if an unknown fragment was being applied it'd
be an exceptional case and would not have to apply if the cache doesn't
already know all its fields.

We can now (theoretically) safely switch to always return `true` on writes.
When we encounter a field that isn't in the data, as returned by the API
then we can eagerly write anyway and let it fail.

This is safe because if we were to encounter `undefined` data, this signals
to the cache that the field should be deleted, which is correct.

This is important for cases where the fragment applies to an interface
of a node rather than to a concrete type.