### PR TITLE
fix(graphcache): default storage not clearing idb batch result

### DIFF
--- a/.changeset/two-masks-draw.md
+++ b/.changeset/two-masks-draw.md
@@ -2,4 +2,4 @@
 '@urql/exchange-graphcache': patch
 ---
 
-Fix issue where our default-storage would persist data after it has been cleared
+Fix default storage persisting data after `clear()` was called on it

--- a/.changeset/two-masks-draw.md
+++ b/.changeset/two-masks-draw.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix issue where our default-storage would persist data after it has been cleared

--- a/exchanges/graphcache/src/default-storage/index.ts
+++ b/exchanges/graphcache/src/default-storage/index.ts
@@ -40,7 +40,7 @@ export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
   const ENTRIES_STORE_NAME = 'entries';
   const METADATA_STORE_NAME = 'metadata';
 
-  const batch: Record<string, string | undefined> = Object.create(null);
+  let batch: Record<string, string | undefined> = Object.create(null);
   const timestamp = Math.floor(new Date().valueOf() / (1000 * 60 * 60 * 24));
   const maxAge = timestamp - (opts.maxAge || 7);
 
@@ -105,6 +105,7 @@ export const makeDefaultStorage = (opts?: StorageOptions): DefaultStorage => {
         );
         transaction.objectStore(METADATA_STORE_NAME).clear();
         transaction.objectStore(ENTRIES_STORE_NAME).clear();
+        batch = Object.create(null);
         return getTransactionPromise(transaction);
       });
     },


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/urql/issues/2443

## Summary

In the default-storage when we call `clear` we should reset the batch else our users aren't able to reset the normalized cache without reading out the previous cached storage.

## Set of changes

- reset `batch` to an empty object
