### PR TITLE
fix(react): execute subscriptions with latest vars

### DIFF
--- a/.changeset/tasty-cooks-promise.md
+++ b/.changeset/tasty-cooks-promise.md
@@ -1,0 +1,5 @@
+---
+"urql": patch
+---
+
+Fix issue where a paused subscription would execute with stale variables.

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -110,7 +110,7 @@ export function useSubscription<Data = any, Result = Data, Variables = object>(
         ...opts,
       });
 
-      setState(state => [source, state[1], state[2]]);
+      setState(state => [source, state[1], deps]);
     },
     [client, args.context, request]
   );


### PR DESCRIPTION
Resolves #2330

## Summary

This is a similar fix to https://github.com/FormidableLabs/urql/pull/1982

A paused subscription would not execute with the proper variables if they were different from the point of pausing, this because we would commit the previous deps which would result in the hook thinking nothing changed, this resets the source to null.

## Set of changes

- fix stale sources in subscriptions
