### PR TITLE
fix: svelte documentation links for context

### DIFF
--- a/docs/api/svelte.md
+++ b/docs/api/svelte.md
@@ -70,7 +70,7 @@ This store will be updated as the incoming data changes.
 | `stale`      | `boolean`              | A flag that may be set to `true` by exchanges to indicate that the `data` is incomplete or out-of-date, and that the result will be updated soon.  |
 | `fetching`   | `boolean`              | A flag that indicates whether the operation is currently in progress, which means that the `data` and `error` is out-of-date for the given inputs. |
 
-## Pausable
+## Pausable
 
 The `queryStore` and `subscriptionStore`'s stores are pausable. This means they inherit the
 following properties from the `Pausable` store.
@@ -88,8 +88,8 @@ stores above manually. This is to cater to greater flexibility. However, for con
 instead of keeping a `Client` singleton, we may also use [Svelte's Context
 API](https://svelte.dev/tutorial/context-api).
 
-`@urql/svelte` provides wrapper functions around Svelte's [`setContext`](https://svelte.dev/docs#setContext) and
-[`getContext`](https://svelte.dev/docs#getContext) functions:
+`@urql/svelte` provides wrapper functions around Svelte's [`setContext`](https://svelte.dev/docs#run-time-svelte-setcontext) and
+[`getContext`](https://svelte.dev/docs#run-time-svelte-getcontext) functions:
 
 - `setContextClient`
 - `getContextClient`

--- a/docs/basics/svelte.md
+++ b/docs/basics/svelte.md
@@ -99,8 +99,8 @@ components. This will share one `Client` with the rest of our app, if we for ins
 ```
 
 The `setClient` method internally calls [Svelte's `setContext`
-function](https://svelte.dev/docs#setContext). The `@urql/svelte` package also exposes a `getClient`
-function that uses [`getContext`](https://svelte.dev/docs#getContext) to retrieve the `Client` in
+function](https://svelte.dev/docs#run-time-svelte-setcontext). The `@urql/svelte` package also exposes a `getClient`
+function that uses [`getContext`](https://svelte.dev/docs#run-time-svelte-getcontext) to retrieve the `Client` in
 child components. This is used throughout `@urql/svelte`'s API.
 
 We can also use a convenience function, `initClient`. This function combines the `createClient` and


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Fixes out of date links to Svelte documentation for the `Context` section
and also removes a ZWNBSP character which breaks the H2 for
`Pausable` heading.

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
