### PR TITLE
fix(graphcache): support repeated optimistic updates

### DIFF
--- a/.changeset/rich-panthers-wait.md
+++ b/.changeset/rich-panthers-wait.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Correctly reorder optimistic layers when we see repeated keys coming in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build
         run: yarn run build
       - name: e2e tests 🧪
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         with:
           command: yarn cypress run-ct
           working-directory: packages/react-urql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build
         run: yarn run build
       - name: e2e tests 🧪
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@v2
         with:
           command: yarn cypress run-ct
           working-directory: packages/react-urql

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -120,6 +120,12 @@ export const initDataState = (
     if (!isOptimistic && !data.commutativeKeys.has(layerKey)) {
       reserveLayer(data, layerKey);
     } else if (isOptimistic) {
+      if (
+        data.optimisticOrder.indexOf(layerKey) !== -1 &&
+        !data.commutativeKeys.has(layerKey)
+      ) {
+        data.optimisticOrder.splice(data.optimisticOrder.indexOf(layerKey), 1);
+      }
       // NOTE: This optimally shouldn't happen as it implies that an optimistic
       // write is being performed after a concrete write.
       data.commutativeKeys.delete(layerKey);

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-
 import { minifyIntrospectionQuery } from '@urql/introspection';
 import { formatDocument, gql, maskTypename } from '@urql/core';
 

--- a/exchanges/graphcache/src/test-utils/examples-1.test.ts
+++ b/exchanges/graphcache/src/test-utils/examples-1.test.ts
@@ -626,7 +626,7 @@ it('supports clearing a layer then reapplying optimistic updates', () => {
   });
 });
 
-it('supports updating an optimisticly updated entity', () => {
+it('supports seeing the same optimistic key multiple times (correctly reorders)', () => {
   const store = new Store({
     optimistic: {
       updateTodo: (args: any) => ({
@@ -687,4 +687,15 @@ it('supports updating an optimisticly updated entity', () => {
   queryRes = query(store, { query: Todos });
   expect(queryRes.partial).toBe(false);
   expect(queryRes.data.todos[0].complete).toEqual(true);
+
+  writeOptimistic(
+    store,
+    { query: updateTodo, variables: { id: '0', completed: false } },
+    2
+  );
+
+  queryRes = query(store, { query: Todos });
+
+  expect(queryRes.partial).toBe(false);
+  expect(queryRes.data.todos[0].complete).toEqual(false);
 });


### PR DESCRIPTION
Resolves #2478

## Summary

What was happening was that we have two optimistic mutations with the same key, let's refer to them as `a` and `b`, `a` would set the state to true and `b` would set the state to false.

When `a` comes in we tell our store that our current order of optimistic layers is `[a]` and apply the data of `state: true` to said layer, now we dispatch `b` we tell the store that our order is `[b, a]` and apply the state. Everything is fine up until now, until we dispatch `a` again as optimistic, we would not reorder the layers to say `[a, b]` and instead would hold on to our layer-ordering which prevented the correct state from being read.

This was a bit challenging as we use the ordering for both commutative and optimistic keys, hence the check whether we have a commutative key for the layer we are manipulating, if we are sure that it's not commutative but optimistic we remove the layer from the order and let the store reorder it itself.

## Set of changes

- support repeated optimistic keys
