### PR TITLE
fix(svelte): delay unsubscribe to writeable

### DIFF
--- a/.changeset/heavy-carpets-join.md
+++ b/.changeset/heavy-carpets-join.md
@@ -1,0 +1,5 @@
+---
+'@urql/svelte': patch
+---
+
+Fix issue with `subscriptionStore` and `queryStore` eagerly terminating the subscription due to `derived`

--- a/packages/svelte-urql/src/queryStore.ts
+++ b/packages/svelte-urql/src/queryStore.ts
@@ -56,7 +56,9 @@ export function queryStore<Data = any, Variables = object>(
     ...initialResult,
     operation,
   };
-  const result$ = writable(initialState);
+  const result$ = writable(initialState, () => {
+    return subscription.unsubscribe;
+  });
   const isPaused$ = writable(!!args.pause);
 
   const subscription = pipe(
@@ -99,7 +101,6 @@ export function queryStore<Data = any, Variables = object>(
   return {
     ...derived(result$, (result, set) => {
       set(result);
-      return subscription.unsubscribe;
     }),
     ...createPausable(isPaused$),
   };

--- a/packages/svelte-urql/src/subscriptionStore.ts
+++ b/packages/svelte-urql/src/subscriptionStore.ts
@@ -49,7 +49,9 @@ export function subscriptionStore<Data, Variables extends object = {}>(
     ...initialResult,
     operation,
   };
-  const result$ = writable(initialState);
+  const result$ = writable(initialState, () => {
+    return subscription.unsubscribe;
+  });
   const isPaused$ = writable(!!args.pause);
 
   const subscription = pipe(
@@ -92,7 +94,6 @@ export function subscriptionStore<Data, Variables extends object = {}>(
   return {
     ...derived(result$, (result, set) => {
       set(result);
-      return subscription.unsubscribe;
     }),
     ...createPausable(isPaused$),
   };


### PR DESCRIPTION
Resolves #2513 
Resolves #2508
Resolves #2473

## Summary

Apparently `derivable` calls `unsubscribe` eagerly on initial invocation making it so that none of our stores were actually listening for changes.

## Set of changes

- unsubscribe in writable
