### PR TITLE
(react-urql): defer suspending to data or error access

### DIFF
--- a/.changeset/sour-planes-cheer.md
+++ b/.changeset/sour-planes-cheer.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+In light of the `render-as-you-fetch` pattern we want to defer suspending to as late as possible

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -106,12 +106,38 @@ export function useQuery<Data = any, Variables = object>(
           });
 
           cache.set(request.key, promise);
-          throw promise;
+          const res = {};
+          Object.defineProperty(res, 'data', {
+            get() {
+              throw promise;
+            },
+          });
+
+          Object.defineProperty(res, 'error', {
+            get() {
+              throw promise;
+            },
+          });
+
+          return res;
         } else {
           subscription.unsubscribe();
         }
       } else if (suspense && result != null && 'then' in result) {
-        throw result;
+        const res = {};
+        Object.defineProperty(res, 'data', {
+          get() {
+            throw result;
+          },
+        });
+
+        Object.defineProperty(res, 'error', {
+          get() {
+            throw result;
+          },
+        });
+
+        return res;
       }
 
       return (result as OperationResult<Data, Variables>) || { fetching: true };


### PR DESCRIPTION
## Summary

In the `render-as-you-fetch` pattern we say that we want to start all the fetches and suspend when we need one of them, so when does this change become effective?

Consider the following component

```jsx
const LazyComponent = lazy(() => import());

const Page = () => {
  const [result] = useQuery()
  
  return <LazyComponent  result={result} />
}
```

Before this change we would see the following happen

- render Page
- execute useQuery
- suspend
- render Page
- execute useQuery
- return JSX
- Suspend

After this change we will see the following happen

- render Page
- execute useQuery
- return JSX
- Suspend

This is similar to how other libraries do it, [react-suspense-fetch](https://github.com/dai-shi/react-suspense-fetch/blob/main/src/index.ts#L150-L160) as an example

Should we also include `operation` as a throwable?

## Set of changes

- defer suspending to the data or error property accessor
