### PR TITLE
fix(introspection): usage in node-esm

### DIFF
--- a/.changeset/quiet-bears-tan.md
+++ b/.changeset/quiet-bears-tan.md
@@ -1,0 +1,5 @@
+---
+'@urql/introspection': patch
+---
+
+Avoid making the imports of `@urql/introspection` more specific than they need to be, this because we aren't optimizing for bundle size and in pure node usage this can confuse Node as `import x from 'graphql'` won't share the same module scope as `import x from 'graphql/x/y.mjs'`

--- a/scripts/rollup/cleanup-plugin.js
+++ b/scripts/rollup/cleanup-plugin.js
@@ -38,9 +38,9 @@ function cleanup(opts = {}) {
 
       return transform(code, {
         plugins: [
-          [babelPluginModularGraphQL, { extension: opts.extension }],
+          !opts.maintainImports && [babelPluginModularGraphQL, { extension: opts.extension }],
           removeEmptyImports
-        ],
+        ].filter(Boolean),
         babelrc: false
       });
     }

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -105,7 +105,7 @@ export const makeOutputPlugins = ({ isProduction, extension }) => {
       'process.env.NODE_ENV': JSON.stringify('production')
     }),
     cjsCheck({ extension }),
-    cleanup({ extension }),
+    cleanup({ extension, maintainImports: settings.name === 'urql-introspection' }),
     isProduction ? terserMinified : (extension !== '.js' ? terserPretty : null),
     isProduction && settings.isAnalyze && visualizer({
       filename: path.resolve(settings.cwd, 'node_modules/.cache/analyze.html'),


### PR DESCRIPTION
## Summary

Avoid making the imports of `@urql/introspection` more specific than they need to be, this because we aren't optimizing for bundle size and in pure node usage this can confuse Node as `import x from 'graphql'` won't share the same module scope as `import x from 'graphql/x/y.mjs'`

## Set of changes

- creates an exclusion on the modular-graphql-imports for `introspection`
