### PR TITLE
feat: allow providing a custom isSubscriptionOperation function

### DIFF
--- a/.changeset/fast-spoons-relate.md
+++ b/.changeset/fast-spoons-relate.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': minor
+---
+
+Allow providing a custom `isSubscriptionOperation` implementation.

--- a/packages/core/src/exchanges/subscription.test.ts
+++ b/packages/core/src/exchanges/subscription.test.ts
@@ -76,3 +76,31 @@ it('should tear down the operation if the source subscription ends', async () =>
   expect(unsubscribe).not.toHaveBeenCalled();
   expect(reexecuteOperation).toHaveBeenCalled();
 });
+
+it('should allow providing a custom isSubscriptionOperation implementation', async () => {
+  const exchangeArgs = {
+    dispatchDebug: jest.fn(),
+    forward: () => empty as Source<OperationResult>,
+    client: {} as Client,
+  };
+
+  const isSubscriptionOperation = jest.fn(() => true);
+
+  const forwardSubscription: SubscriptionForwarder = () => ({
+    subscribe(observer) {
+      observer.next(subscriptionResult);
+      return { unsubscribe: jest.fn() };
+    },
+  });
+
+  await pipe(
+    fromValue(subscriptionOperation),
+    subscriptionExchange({ forwardSubscription, isSubscriptionOperation })(
+      exchangeArgs
+    ),
+    take(1),
+    toPromise
+  );
+
+  expect(isSubscriptionOperation).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

I have a live query implementation that can use the existing `subscriptionExchange`, but it would require customizing the `isSubscriptionOperation` function to the following:

```ts
import { isLiveQueryOperationDefinitionNode } from "@n1ru4l/graphql-live-query"

const isSubscriptionOperation = ({ query, variables }) => {
    const definition = getMainDefinition(query);

    const isSubscription =  definition.kind === 'OperationDefinition' &&  definition.operation === 'subscription'
    const isLiveQuery =  isLiveQueryOperationDefinitionNode(definition, variables)
    return isSubscription || isLiveQuery
  }
```

However, currently, this is not possible, requiring me to copy the subscription exchange code. Other solutions like relay and apollo easily allow customizing this.

## Set of changes

Adds a new parameter to `subscriptionExchange`, that allows providing a custom `isSubscriptionOperation` implementation.