### PR TITLE
fix(next-urql): avoid a redundant copy of the urql-client

### DIFF
--- a/.changeset/long-tomatoes-joke.md
+++ b/.changeset/long-tomatoes-joke.md
@@ -1,0 +1,5 @@
+---
+'next-urql': patch
+---
+
+Stop keeping a global copy of the client in our `init-urql-client` method

--- a/.changeset/long-tomatoes-joke.md
+++ b/.changeset/long-tomatoes-joke.md
@@ -1,5 +1,6 @@
 ---
-'next-urql': patch
+'next-urql': major
 ---
 
-Stop keeping a global copy of the client in our `init-urql-client` method
+Rmove global client var from our `init-urql-client` method, this impacts applications that rely on
+the client being shared across wrapped `pages/` a migration path is to wrap `_app` instead.

--- a/packages/next-urql/src/init-urql-client.ts
+++ b/packages/next-urql/src/init-urql-client.ts
@@ -1,15 +1,10 @@
 import { createClient, Client, ClientOptions } from 'urql';
 
-let urqlClient: Client | null = null;
-
-export function resetClient() {
-  urqlClient = null;
-}
-
 export function initUrqlClient(
   clientOptions: ClientOptions,
   canEnableSuspense: boolean
 ): Client | null {
+  let urqlClient: Client | null = null;
   // Create a new Client for every server-side rendered request.
   // This ensures we reset the state for each rendered page.
   // If there is an exising client instance on the client-side, use it.

--- a/packages/next-urql/src/init-urql-client.ts
+++ b/packages/next-urql/src/init-urql-client.ts
@@ -4,21 +4,17 @@ export function initUrqlClient(
   clientOptions: ClientOptions,
   canEnableSuspense: boolean
 ): Client | null {
-  let urqlClient: Client | null = null;
   // Create a new Client for every server-side rendered request.
   // This ensures we reset the state for each rendered page.
   // If there is an exising client instance on the client-side, use it.
   const isServer = typeof window === 'undefined';
-  if (isServer || !urqlClient) {
-    urqlClient = createClient({
-      ...clientOptions,
-      suspense: canEnableSuspense && (isServer || clientOptions.suspense),
-    });
-    // Serialize the urqlClient to null on the client-side.
-    // This ensures we don't share client and server instances of the urqlClient.
-    (urqlClient as any).toJSON = () => null;
-  }
-
+  const urqlClient = createClient({
+    ...clientOptions,
+    suspense: canEnableSuspense && (isServer || clientOptions.suspense),
+  });
+  // Serialize the urqlClient to null on the client-side.
+  // This ensures we don't share client and server instances of the urqlClient.
+  (urqlClient as any).toJSON = () => null;
   // Return both the Client instance and the ssrCache.
   return urqlClient;
 }

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -18,7 +18,7 @@ import {
   fetchExchange,
 } from 'urql';
 
-import { initUrqlClient, resetClient } from './init-urql-client';
+import { initUrqlClient } from './init-urql-client';
 
 import {
   NextUrqlClientConfig,
@@ -89,7 +89,6 @@ export function withUrqlClient(
       }, [urqlClient, urqlServerState, version]);
 
       const resetUrqlClient = useCallback(() => {
-        resetClient();
         ssr = ssrExchange({ initialState: undefined });
         forceUpdate();
       }, []);


### PR DESCRIPTION
Resolves #2524

## Summary

In `next-urql` we have three flows, two of which are on the server and one of which is on the client.

### Server

First and foremost we have the classic `getInitialProps`, the automated way of handling data, this is the one that runs two passes on the server with `react-ssr-prepass`. It's our way of passing the `urql-client` from `getInitialProps` to be used for `renderToString`, code located [here](https://github.com/FormidableLabs/urql/blob/main/packages/next-urql/src/with-urql-client.ts#L118-L179) this first pass builds up the cache so we can use it during the `renderToString` pass. After the state is JSON.stringified and the client is ignored thanks to a `toJSON: () => null`.

Secondly we have the `getXProps` methods, [which we documented is a self-serve solution](https://formidable.com/open-source/urql/docs/advanced/server-side-rendering/#using-getstaticprops-or-getserversideprops) as we can't easily intervene in these functions.

Both of the above don't rely on the global variable set in `initUrqlClient` as we always [reset it](https://github.com/FormidableLabs/urql/blob/main/packages/next-urql/src/init-urql-client.ts#L17) when reaching that code-path.

### Client

This is where stuff gets a bit more complicated and I can understand the reason why we went with the approach of sharing a client but reevaluating it, we should get rid off it so people won't fall into this as the issue outlines, we aren't offering a choice. I would advise people that want this behavior to wrap `_app` in `withUrqlClient` and people who don't want this behavior to do it on a page-basis.

## Set of changes

- remove global client var
