### PR TITLE
Upgrade react-ssr-prepass to 1.5.0 on next-urql.

### DIFF
--- a/packages/next-urql/package.json
+++ b/packages/next-urql/package.json
@@ -49,7 +49,7 @@
     "react-is": "^17.0.1"
   },
   "dependencies": {
-    "react-ssr-prepass": "^1.4.0"
+    "react-ssr-prepass": "^1.5.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13897,10 +13897,15 @@ react-sizeme@^3.0.1:
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
 
-react-ssr-prepass@^1.1.2, react-ssr-prepass@^1.4.0:
+react-ssr-prepass@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.4.0.tgz#33a3db19414f0f8f9f3f781c88f760ae366b4f51"
   integrity sha512-0SzdmiQUtHvhxCabHg9BI/pkJfijGkQ0jQL6fC4YFy7idaDOuaiQLsajIkkNxffFXtJFHIWFITlve2WB88e0Jw==
+
+react-ssr-prepass@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.5.0.tgz#bc4ca7fcb52365e6aea11cc254a3d1bdcbd030c5"
+  integrity sha512-yFNHrlVEReVYKsLI5lF05tZoHveA5pGzjFbFJY/3pOqqjGOmMmqx83N4hIjN2n6E1AOa+eQEUxs3CgRnPmT0RQ==
 
 react-static-plugin-md-pages@^0.3.2:
   version "0.3.2"


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

`react-ssr-prepass` was upgraded to included the new dispatcher methods for React 18 but the update was not pulled into `next-urql` so prepass errors out on server rendered next/dynamic modules.

## Set of changes

Upgrades `react-ssr-prepass` to `1.5.0`.