### PR TITLE
chore(build): remove modular graphql

### DIFF
--- a/.changeset/beige-chefs-add.md
+++ b/.changeset/beige-chefs-add.md
@@ -1,0 +1,10 @@
+---
+'@urql/exchange-auth': minor
+'@urql/exchange-execute': minor
+'@urql/exchange-graphcache': minor
+'@urql/exchange-persisted-fetch': minor
+'@urql/exchange-populate': minor
+'@urql/core': minor
+---
+
+Remove the `babel-plugin-modular-graphql` helper, this because the graphql package hasn't converted to ESM yet which gives issues in node environments

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@types/jest": "^26.0.23",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "babel-plugin-modular-graphql": "^1.1.0",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "cjs-module-lexer": "^1.2.2",
     "cypress": "^9.5.1",

--- a/scripts/rollup/cleanup-plugin.js
+++ b/scripts/rollup/cleanup-plugin.js
@@ -1,6 +1,5 @@
 import { transformSync as transform } from '@babel/core';
 import { createFilter } from '@rollup/pluginutils';
-import babelPluginModularGraphQL from 'babel-plugin-modular-graphql';
 
 function removeEmptyImports({ types: t }) {
   return {
@@ -37,10 +36,7 @@ function cleanup(opts = {}) {
       }
 
       return transform(code, {
-        plugins: [
-          !opts.maintainImports && [babelPluginModularGraphQL, { extension: opts.extension }],
-          removeEmptyImports
-        ].filter(Boolean),
+        plugins: [removeEmptyImports],
         babelrc: false
       });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,11 +4083,6 @@ babel-plugin-macros@^3.0.1:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
-babel-plugin-modular-graphql@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-modular-graphql/-/babel-plugin-modular-graphql-1.1.0.tgz#d1d509913295f0320cc1ce38361b229ca04480ba"
-  integrity sha512-U9QXdxvJhxLU4YYrF7646bB4muLXWdW0sXXKrI9FkGDErqjw0utVn+Zk5W0nNXP82rAmg5vl+cv2nAyZ1dnbxg==
-
 babel-plugin-named-asset-import@^0.3.1:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz#156cd55d3f1228a5765774340937afc8398067dd"


### PR DESCRIPTION
Resolves #2539

## Summary

It seems like importing from `graphql` makes us run into issues, especially in node-environments as imports from the root and imports from the specific packages make us run into the infamous multiple GraphQL instances error. Until the main package moves to full ESM compat with export maps, ... this will be the best fix to support previous versions of GraphQL and current ones

## Set of changes

- remove the modular babel plugin
