### PR TITLE
fix(react): Prevent the operation queue from being flushed during synchronous cache reads

### DIFF
--- a/.changeset/hip-ears-wash.md
+++ b/.changeset/hip-ears-wash.md
@@ -1,0 +1,6 @@
+---
+'@urql/core': patch
+urql: patch
+---
+
+Fix missing React updates after an incoming response that schedules a mount. We now prevent dispatched operations from continuing to flush synchronously when the original source that runs the queue has terminated. This is important for the React bindings, because an update (e.g. `setState`) may recursively schedule a mount, which then disabled other `setState` updates from being processed. Previously we assumed that React used a trampoline scheduler for updates, however it appears that `setState` can recursively start more React work.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -163,11 +163,13 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
   // activated to allow `reexecuteOperation` to be trampoline-scheduled
   let isOperationBatchActive = false;
   function dispatchOperation(operation?: Operation | void) {
-    isOperationBatchActive = true;
     if (operation) nextOperation(operation);
-    while (isOperationBatchActive && (operation = queue.shift()))
-      nextOperation(operation);
-    isOperationBatchActive = false;
+    if (!isOperationBatchActive) {
+      isOperationBatchActive = true;
+      while (isOperationBatchActive && (operation = queue.shift()))
+        nextOperation(operation);
+      isOperationBatchActive = false;
+    }
   }
 
   /** Defines how result streams are created */

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -165,7 +165,8 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
   function dispatchOperation(operation?: Operation | void) {
     isOperationBatchActive = true;
     if (operation) nextOperation(operation);
-    while ((operation = queue.shift())) nextOperation(operation);
+    while (isOperationBatchActive && (operation = queue.shift()))
+      nextOperation(operation);
     isOperationBatchActive = false;
   }
 
@@ -195,7 +196,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
     if (operation.kind === 'mutation') {
       return pipe(
         result$,
-        onStart(() => dispatchOperation(operation)),
+        onStart(() => nextOperation(operation)),
         take(1)
       );
     }
@@ -241,9 +242,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         for (let i = queue.length - 1; i >= 0; i--)
           if (queue[i].key === operation.key) queue.splice(i, 1);
         // Dispatch a teardown signal for the stopped operation
-        dispatchOperation(
-          makeOperation('teardown', operation, operation.context)
-        );
+        nextOperation(makeOperation('teardown', operation, operation.context));
       }),
       share
     );
@@ -269,9 +268,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
       // operation's exchange results
       if (operation.kind === 'mutation' || active.has(operation.key)) {
         queue.push(operation);
-        if (!isOperationBatchActive) {
-          Promise.resolve().then(dispatchOperation);
-        }
+        Promise.resolve().then(dispatchOperation);
       }
     },
 
@@ -344,7 +341,10 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
               dispatchOperation(operation);
             }
           }),
-          onEnd(observer.complete),
+          onEnd(() => {
+            isOperationBatchActive = false;
+            observer.complete();
+          }),
           subscribe(observer.next)
         ).unsubscribe;
       });

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -44,8 +44,6 @@ export type UseQueryResponse<Data = any, Variables = object> = [
 const isSuspense = (client: Client, context?: Partial<OperationContext>) =>
   client.suspense && (!context || context.suspense !== false);
 
-let currentInit = false;
-
 export function useQuery<Data = any, Variables = object>(
   args: UseQueryArgs<Variables, Data>
 ): UseQueryResponse<Data, Variables> {
@@ -127,18 +125,14 @@ export function useQuery<Data = any, Variables = object>(
     args.pause,
   ] as const;
 
-  const [state, setState] = useState(() => {
-    currentInit = true;
-    try {
-      return [
+  const [state, setState] = useState(
+    () =>
+      [
         source,
         computeNextState(initialState, getSnapshot(source, suspense)),
         deps,
-      ] as const;
-    } finally {
-      currentInit = false;
-    }
-  });
+      ] as const
+  );
 
   let currentResult = state[1];
   if (source !== state[0] && hasDepsChanged(state[2], deps)) {
@@ -160,14 +154,12 @@ export function useQuery<Data = any, Variables = object>(
 
     const updateResult = (result: Partial<UseQueryState<Data, Variables>>) => {
       hasResult = true;
-      if (!currentInit) {
-        setState(state => {
-          const nextResult = computeNextState(state[1], result);
-          return state[1] !== nextResult
-            ? [state[0], nextResult, state[2]]
-            : state;
-        });
-      }
+      setState(state => {
+        const nextResult = computeNextState(state[1], result);
+        return state[1] !== nextResult
+          ? [state[0], nextResult, state[2]]
+          : state;
+      });
     };
 
     if (source) {


### PR DESCRIPTION
Resolve #2554

⚠️ **We urgently recommend all users of the React bindings to upgrade to this patch as soon as it becomes available!**
Don't forget to deduplicate `@urql/core` to the newest version if you do upgrade, since its fix is important.

During some circumstances we may receive an update that then leads to a mount. React may decide to then recursively & synchronously continue this mount. During it, we used to then block other updates using a `currentInit` flag while the component synchronously reads from the cache. However, since the cache read dispatched its operation (and then terminated), we previously then "piggybacked" off of this dispatch, and flushed other operations.
This means that some potential updates could get lost if they were queued up by the update that  lead to the mounted component. We instead want to prevent the queue from further being flushed when the synchronous read terminates, and always schedule a microtick that then gets another chance to flush out the queue.
We furthermore prevent recursive calls from restarting our operation queue.

This allows us to remove the `currentInit` check entirely and prevent edge cases from causing missed updates. Such cases would always follow this pattern:

1. The cache updates, e.g. by receiving a new response
2. The cache schedules multiple component updates
3. The component updates and mounts a new query
4. The mounted query prevents further updates
5. The further updates are processed but cannot update states

The new pattern is now:

1. The cache updates, e.g. by receiving a new response
2. The cache schedules multiple component updates
3. The component updates and mounts a new query
4. The scheduled updates complete in the next micro-tick
