### PR TITLE
feat(next-urql): send App props for pre-pass

### DIFF
--- a/packages/next-urql/README.md
+++ b/packages/next-urql/README.md
@@ -146,6 +146,8 @@ The second argument for `withUrqlClient` is an options object, this contains one
 `withUrqlClient` that the wrapped component does not use `getInitialProps` but the children of this wrapped component do. This opts you into
 `ssr` for these children.
 
+If you use custom `App.getInitialProps` and use this App props in the App and have `ssr === true` you you can pass the props through `generateAppProps` so the prepass step has all the information needed to render.
+
 ### Different Client configurations on the client and the server
 
 There are use cases where you may need different configurations for your `urql` Client on the client-side and the server-side; for example, you may want to interact with one GraphQL endpoint on the server-side and another on the client-side. `next-urql` supports this as of v0.3.0. We recommend using `typeof window === 'undefined'` or a `process.browser` check.
@@ -225,15 +227,18 @@ If you want to use a `Client` in Next.js' newer methods like `getServerSideProps
 ```javascript
 import { initUrqlClient } from 'next-urql';
 
-export const getServerSideProps = async (ctx) => {
-  const client = initUrqlClient({
-    url: '/graphql',
-  }, false /* set to false to disable suspense */);
+export const getServerSideProps = async ctx => {
+  const client = initUrqlClient(
+    {
+      url: '/graphql',
+    },
+    false /* set to false to disable suspense */
+  );
 
   const result = await client.query(QUERY, {}).toPromise();
 
   return {
-    props: { data: result.data }
+    props: { data: result.data },
   };
 };
 ```

--- a/packages/next-urql/src/types.ts
+++ b/packages/next-urql/src/types.ts
@@ -55,4 +55,5 @@ export interface WithUrqlClientOptions {
   ssr?: boolean;
   neverSuspend?: boolean;
   staleWhileRevalidate?: boolean;
+  getAppProps?: (ctx?: NextPageContext) => any;
 }

--- a/packages/next-urql/src/with-urql-client.ts
+++ b/packages/next-urql/src/with-urql-client.ts
@@ -160,7 +160,11 @@ export function withUrqlClient(
         }
 
         const props = { ...pageProps, urqlClient };
-        const appTreeProps = isApp ? props : { pageProps: props };
+
+        // Add an option to provide the custom App props when a custom `App.getInitialProps` is used.
+        const appProps = isApp ? {} : options?.getAppProps?.(ctx) ?? {};
+
+        const appTreeProps = isApp ? props : { ...appProps, pageProps: props };
 
         // Run the prepass step on AppTree. This will run all urql queries on the server.
         if (!options!.neverSuspend) {


### PR DESCRIPTION
Resolves #2573

## Summary

Using the next-urql library with withUrqlClient is used with ssr: true, all the Next App tree is re-rendered. When we use withUrqlClient in the `App` everything works fine. But when we use withUrqlClient in pages and have React Context providers in _app that receive props from App.getInitialProps. In the pre-pass step, this values (it only fetches the Page.getInitialProps) and no App props from App.getInitialProps. This can be an issue if, for example, we use a Feature Flag React context, the behavior in the pre-pass step will be different.

## Set of changes

Added a new option in `WithUrqlClientOptions`, `getAppProps` where you can send the props for the App. This way the App is rendered in prepass with the same context as without it.