### PR TITLE
fix(execute): correct return for context function

### DIFF
--- a/.changeset/light-dolls-taste.md
+++ b/.changeset/light-dolls-taste.md
@@ -1,0 +1,5 @@
+---
+"@urql/exchange-execute": patch
+---
+
+fix return for context function argument

--- a/exchanges/execute/src/execute.ts
+++ b/exchanges/execute/src/execute.ts
@@ -33,7 +33,7 @@ import {
 export interface ExecuteExchangeArgs {
   schema: GraphQLSchema;
   rootValue?: any;
-  context?: ((op: Operation) => void) | any;
+  context?: ((op: Operation) => any) | any;
   fieldResolver?: GraphQLFieldResolver<any, any>;
   typeResolver?: GraphQLTypeResolver<any, any>;
   subscribeFieldResolver?: GraphQLFieldResolver<any, any>;


### PR DESCRIPTION
Resolves #2580

## Summary

This corrects the return type to be the same as just passing one without a function `any`
