### PR TITLE
fix(docs): Add overflow for article legend

### DIFF
--- a/packages/site/src/screens/docs/article.js
+++ b/packages/site/src/screens/docs/article.js
@@ -47,6 +47,8 @@ const Legend = styled.aside`
     max-width: ${p => p.theme.layout.legend};
     padding: ${p => p.theme.spacing.lg} ${p => p.theme.spacing.md};
     margin: 0;
+    overflow: auto;
+    height: calc(100vh - ${p => p.theme.layout.header});
   }
 `;
 


### PR DESCRIPTION
Hi there! 👋 

## Summary

This PR adds overflow for article legend component to add vertical scroll on small height screens:

![screen](https://user-images.githubusercontent.com/7077307/183365481-66cf4b6d-29ce-48c2-8b46-ab12b3348559.png)

## Set of changes

Added `overflow: auto` and `height` rules for styled `Legend` component

Thank you! This library is awesome :heart: