### PR TITLE
docs: remove double negation

### DIFF
--- a/docs/basics/svelte.md
+++ b/docs/basics/svelte.md
@@ -378,7 +378,7 @@ There are some more tricks we can use with `queryStore`.
 
 ## Mutations
 
-The `mutationStore` function isn't dissimilar from the `queryStore` function but is triggered manually and
+The `mutationStore` function is similar to the `queryStore` function but is triggered manually and
 can accept a [`GraphQLRequest` object](../api/core.md#graphqlrequest).
 
 ### Sending a mutation

--- a/docs/basics/vue.md
+++ b/docs/basics/vue.md
@@ -567,7 +567,7 @@ it.](../api/vue.md#usequery)
 
 ## Mutations
 
-The `useMutation` function isn't dissimilar from `useQuery` but is triggered manually and accepts
+The `useMutation` function is similar to `useQuery` but is triggered manually and accepts
 only a `DocumentNode` or `string` as an input.
 
 ### Sending a mutation


### PR DESCRIPTION
## Summary

Replace `isn't dissimilar from` with `is similar to`.
... or was there a reason for the double negation? I stumbled across this for so many times now, that I had to make this PR 😅