### PR TITLE
docs: refactored examples that use the logical `!`

### DIFF
--- a/docs/basics/react-preact.md
+++ b/docs/basics/react-preact.md
@@ -195,10 +195,12 @@ executed. We can do this by setting the `pause` option to `true`:
 
 ```jsx
 const Todos = ({ from, limit }) => {
+  const shouldPause = from === undefined || from === null ||
+                      limit === undefined || limit === null;
   const [result, reexecuteQuery] = useQuery({
     query: TodosListQuery,
     variables: { from, limit },
-    pause: !from || !limit,
+    pause: shouldPause,
   });
 
   // ...

--- a/docs/basics/vue.md
+++ b/docs/basics/vue.md
@@ -269,6 +269,8 @@ import { useQuery } from '@urql/vue';
 export default {
   props: ['from', 'limit'],
   setup({ from, limit }) {
+    const shouldPause = computed(() => from === undefined || from === null ||
+                                      limit === undefined || limit === null);
     return useQuery({
       query: `
         query ($from: Int!, $limit: Int!) {
@@ -279,7 +281,7 @@ export default {
         }
       `,
       variables: { from, limit },
-      pause: computed(() => !from.value || !limit.value)
+      pause: shouldPause
     });
   }
 };

--- a/docs/basics/vue.md
+++ b/docs/basics/vue.md
@@ -269,8 +269,7 @@ import { useQuery } from '@urql/vue';
 export default {
   props: ['from', 'limit'],
   setup({ from, limit }) {
-    const shouldPause = computed(() => from === undefined || from === null ||
-                                      limit === undefined || limit === null);
+    const shouldPause = computed(() => from == null || limit == null);
     return useQuery({
       query: `
         query ($from: Int!, $limit: Int!) {


### PR DESCRIPTION
## Summary

Using the bang operator (!) on non-boolean values can lead to unexpected results. For example, in the case of [this example](../blob/main/docs/basics/react-preact.md#pausing-usequery), using the `pause` option inside the `useQuery` hook, one might set the value of the `from` variable to be `0`. In that case the checks would be inaccurate since `!0 === true`. However, we only expect to pause the query only when `from` or `limit` is nullish. We can replace that condition with a more robust one.

Yes, it's an edge case, but new developers reading this documentation might not be aware of the presence of this bug and might have some unexpected results using this example in their code.

## Set of changes

Replaced `!from || !limit` with the more accurate `from === undefined || from === null || limit === undefined || limit === null` in the `useQuery` hook/composable on [React/Preact Basics](../blob/main/docs/basics/react-preact.md#pausing-usequery) and [Vue basics](../blob/main/docs/basics/vue.md#pausing-usequery).
An intermediate variable `shouldPause` got used to avoid inlining that long condition into the `pause` option.
