### PR TITLE
fix(core): Implement stricter variable typings on generic

### DIFF
--- a/.changeset/stale-plants-design.md
+++ b/.changeset/stale-plants-design.md
@@ -1,0 +1,10 @@
+---
+'@urql/exchange-graphcache': major
+'@urql/core': major
+'@urql/preact': major
+'urql': major
+'@urql/svelte': major
+'@urql/vue': major
+---
+
+Implement stricter variables types, which require variables to always be passed and match TypeScript types when the generic is set or inferred. This is a breaking change for TypeScript users potentially, unless all types are adhered to.

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -1,4 +1,4 @@
-import { TypedDocumentNode } from '@urql/core';
+import { AnyVariables, TypedDocumentNode } from '@urql/core';
 import { GraphQLError, DocumentNode, FragmentDefinitionNode } from 'graphql';
 import { IntrospectionData } from './ast';
 
@@ -211,7 +211,7 @@ export interface SerializedEntries {
 
 export interface SerializedRequest {
   query: string;
-  variables?: object;
+  variables: AnyVariables;
 }
 
 export interface StorageAdapter {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -93,52 +93,61 @@ export interface Client {
     opts?: Partial<OperationContext> | undefined
   ): OperationContext;
 
-  createRequestOperation<Data = any, Variables = AnyVariables>(
+  createRequestOperation<
+    Data = any,
+    Variables extends AnyVariables = AnyVariables
+  >(
     kind: OperationType,
     request: GraphQLRequest<Data, Variables>,
     opts?: Partial<OperationContext> | undefined
   ): Operation<Data, Variables>;
 
   /** Executes an Operation by sending it through the exchange pipeline It returns an observable that emits all related exchange results and keeps track of this observable's subscribers. A teardown signal will be emitted when no subscribers are listening anymore. */
-  executeRequestOperation<Data = any, Variables = AnyVariables>(
+  executeRequestOperation<
+    Data = any,
+    Variables extends AnyVariables = AnyVariables
+  >(
     operation: Operation<Data, Variables>
   ): Source<OperationResult<Data, Variables>>;
 
-  query<Data = any, Variables = AnyVariables>(
+  query<Data = any, Variables extends AnyVariables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
     variables: Variables,
     context?: Partial<OperationContext>
   ): PromisifiedSource<OperationResult<Data, Variables>>;
 
-  readQuery<Data = any, Variables = AnyVariables>(
+  readQuery<Data = any, Variables extends AnyVariables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
     variables: Variables,
     context?: Partial<OperationContext>
   ): OperationResult<Data, Variables> | null;
 
-  executeQuery<Data = any, Variables = AnyVariables>(
+  executeQuery<Data = any, Variables extends AnyVariables = AnyVariables>(
     query: GraphQLRequest<Data, Variables>,
     opts?: Partial<OperationContext> | undefined
   ): Source<OperationResult<Data, Variables>>;
 
-  subscription<Data = any, Variables = AnyVariables>(
+  subscription<Data = any, Variables extends AnyVariables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
     variables: Variables,
     context?: Partial<OperationContext>
   ): Source<OperationResult<Data, Variables>>;
 
-  executeSubscription<Data = any, Variables = AnyVariables>(
+  executeSubscription<
+    Data = any,
+    Variables extends AnyVariables = AnyVariables
+  >(
     query: GraphQLRequest<Data, Variables>,
     opts?: Partial<OperationContext> | undefined
   ): Source<OperationResult<Data, Variables>>;
 
-  mutation<Data = any, Variables = AnyVariables>(
+  mutation<Data = any, Variables extends AnyVariables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
     variables: Variables,
     context?: Partial<OperationContext>
   ): PromisifiedSource<OperationResult<Data, Variables>>;
 
-  executeMutation<Data = any, Variables = AnyVariables>(
+  executeMutation<Data = any, Variables extends AnyVariables = AnyVariables>(
     query: GraphQLRequest<Data, Variables>,
     opts?: Partial<OperationContext> | undefined
   ): Source<OperationResult<Data, Variables>>;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -28,6 +28,7 @@ import { composeExchanges, defaultExchanges } from './exchanges';
 import { fallbackExchange } from './exchanges/fallback';
 
 import {
+  AnyVariables,
   Exchange,
   ExchangeInput,
   GraphQLRequest,
@@ -92,52 +93,52 @@ export interface Client {
     opts?: Partial<OperationContext> | undefined
   ): OperationContext;
 
-  createRequestOperation<Data = any, Variables = object>(
+  createRequestOperation<Data = any, Variables = AnyVariables>(
     kind: OperationType,
     request: GraphQLRequest<Data, Variables>,
     opts?: Partial<OperationContext> | undefined
   ): Operation<Data, Variables>;
 
   /** Executes an Operation by sending it through the exchange pipeline It returns an observable that emits all related exchange results and keeps track of this observable's subscribers. A teardown signal will be emitted when no subscribers are listening anymore. */
-  executeRequestOperation<Data = any, Variables = object>(
+  executeRequestOperation<Data = any, Variables = AnyVariables>(
     operation: Operation<Data, Variables>
   ): Source<OperationResult<Data, Variables>>;
 
-  query<Data = any, Variables extends object = {}>(
+  query<Data = any, Variables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
-    variables?: Variables,
+    variables: Variables,
     context?: Partial<OperationContext>
   ): PromisifiedSource<OperationResult<Data, Variables>>;
 
-  readQuery<Data = any, Variables extends object = {}>(
+  readQuery<Data = any, Variables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
-    variables?: Variables,
+    variables: Variables,
     context?: Partial<OperationContext>
   ): OperationResult<Data, Variables> | null;
 
-  executeQuery<Data = any, Variables = object>(
+  executeQuery<Data = any, Variables = AnyVariables>(
     query: GraphQLRequest<Data, Variables>,
     opts?: Partial<OperationContext> | undefined
   ): Source<OperationResult<Data, Variables>>;
 
-  subscription<Data = any, Variables extends object = {}>(
+  subscription<Data = any, Variables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
-    variables?: Variables,
+    variables: Variables,
     context?: Partial<OperationContext>
   ): Source<OperationResult<Data, Variables>>;
 
-  executeSubscription<Data = any, Variables = object>(
+  executeSubscription<Data = any, Variables = AnyVariables>(
     query: GraphQLRequest<Data, Variables>,
     opts?: Partial<OperationContext> | undefined
   ): Source<OperationResult<Data, Variables>>;
 
-  mutation<Data = any, Variables extends object = {}>(
+  mutation<Data = any, Variables = AnyVariables>(
     query: DocumentNode | TypedDocumentNode<Data, Variables> | string,
-    variables?: Variables,
+    variables: Variables,
     context?: Partial<OperationContext>
   ): PromisifiedSource<OperationResult<Data, Variables>>;
 
-  executeMutation<Data = any, Variables = object>(
+  executeMutation<Data = any, Variables = AnyVariables>(
     query: GraphQLRequest<Data, Variables>,
     opts?: Partial<OperationContext> | undefined
   ): Source<OperationResult<Data, Variables>>;
@@ -310,7 +311,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         return makeResultSource(operation);
       }
 
-      return make(observer => {
+      return make<OperationResult>(observer => {
         let source = active.get(operation.key);
 
         if (!source) {

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -38,7 +38,7 @@ export interface ObservableLike<T> {
 
 export interface SubscriptionOperation {
   query: string;
-  variables?: Record<string, unknown>;
+  variables: Record<string, unknown> | undefined;
   key: string;
   context: OperationContext;
 }
@@ -70,7 +70,7 @@ export const subscriptionExchange = ({
     const observableish = forwardSubscription({
       key: operation.key.toString(36),
       query: print(operation.query),
-      variables: operation.variables,
+      variables: operation.variables!,
       context: { ...operation.context },
     });
 

--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -1,7 +1,6 @@
-import { DocumentNode, print } from 'graphql';
-
+import { print } from 'graphql';
 import { getOperationName, stringifyVariables } from '../utils';
-import { Operation } from '../types';
+import { AnyVariables, GraphQLRequest, Operation } from '../types';
 
 export interface FetchBody {
   query?: string;
@@ -14,15 +13,17 @@ const shouldUseGet = (operation: Operation): boolean => {
   return operation.kind === 'query' && !!operation.context.preferGetMethod;
 };
 
-export const makeFetchBody = (request: {
-  query: DocumentNode;
-  variables?: object;
-}): FetchBody => ({
-  query: print(request.query),
-  operationName: getOperationName(request.query),
-  variables: request.variables || undefined,
-  extensions: undefined,
-});
+export function makeFetchBody<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(request: Omit<GraphQLRequest<Data, Variables>, 'key'>): FetchBody {
+  return {
+    query: print(request.query),
+    operationName: getOperationName(request.query),
+    variables: request.variables || undefined,
+    extensions: undefined,
+  };
+}
 
 export const makeFetchURL = (
   operation: Operation,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,12 +39,18 @@ export type RequestPolicy =
 /** How the operation has */
 export type CacheOutcome = 'miss' | 'partial' | 'hit';
 
+/** A default type for variables */
+export type AnyVariables = { [prop: string]: any } | void | undefined;
+
 /** A Graphql query, mutation, or subscription. */
-export interface GraphQLRequest<Data = any, Variables = object> {
+export interface GraphQLRequest<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> {
   /** Unique identifier of the request. */
   key: number;
   query: DocumentNode | TypedDocumentNode<Data, Variables>;
-  variables?: Variables;
+  variables: Variables;
 }
 
 /** Metadata that is only available in development for devtools. */
@@ -70,14 +76,19 @@ export interface OperationContext {
 }
 
 /** A [query]{@link Query} or [mutation]{@link Mutation} with additional metadata for use during transmission. */
-export interface Operation<Data = any, Variables = any>
-  extends GraphQLRequest<Data, Variables> {
+export interface Operation<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> extends GraphQLRequest<Data, Variables> {
   readonly kind: OperationType;
   context: OperationContext;
 }
 
 /** Resulting data from an [operation]{@link Operation}. */
-export interface OperationResult<Data = any, Variables = any> {
+export interface OperationResult<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> {
   /** The [operation]{@link Operation} which has been executed. */
   operation: Operation<Data, Variables>;
   /** The data returned from the Graphql server. */

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -81,7 +81,10 @@ export const keyDocument = (q: string | DocumentNode): KeyedDocumentNode => {
   return query as KeyedDocumentNode;
 };
 
-export const createRequest = <Data = any, Variables = AnyVariables>(
+export const createRequest = <
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
   q: string | DocumentNode | TypedDocumentNode<Data, Variables>,
   vars: Variables
 ): GraphQLRequest<Data, Variables> => {
@@ -90,7 +93,7 @@ export const createRequest = <Data = any, Variables = AnyVariables>(
   return {
     key: phash(query.__key, stringifyVariables(vars)) >>> 0,
     query,
-    variables: vars,
+    variables: vars as Variables,
   };
 };
 

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -11,7 +11,7 @@ import {
 
 import { hash, phash } from './hash';
 import { stringifyVariables } from './stringifyVariables';
-import { GraphQLRequest } from '../types';
+import { AnyVariables, GraphQLRequest } from '../types';
 
 interface WritableLocation {
   loc: Location | undefined;
@@ -81,9 +81,9 @@ export const keyDocument = (q: string | DocumentNode): KeyedDocumentNode => {
   return query as KeyedDocumentNode;
 };
 
-export const createRequest = <Data = any, Variables = object>(
+export const createRequest = <Data = any, Variables = AnyVariables>(
   q: string | DocumentNode | TypedDocumentNode<Data, Variables>,
-  vars?: Variables
+  vars: Variables
 ): GraphQLRequest<Data, Variables> => {
   if (!vars) vars = {} as Variables;
   const query = keyDocument(q);

--- a/packages/preact-urql/src/components/Mutation.ts
+++ b/packages/preact-urql/src/components/Mutation.ts
@@ -1,21 +1,27 @@
 import { VNode } from 'preact';
 import { DocumentNode } from 'graphql';
 import {
+  AnyVariables,
   TypedDocumentNode,
   OperationResult,
   OperationContext,
 } from '@urql/core';
 import { useMutation, UseMutationState } from '../hooks';
 
-export interface MutationProps<Data = any, Variables = object> {
+export interface MutationProps<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> {
   query: DocumentNode | TypedDocumentNode<Data, Variables> | string;
   children: (arg: MutationState<Data, Variables>) => VNode<any>;
 }
 
-export interface MutationState<Data = any, Variables = object>
-  extends UseMutationState<Data, Variables> {
+export interface MutationState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> extends UseMutationState<Data, Variables> {
   executeMutation: (
-    variables?: Variables,
+    variables: Variables,
     context?: Partial<OperationContext>
   ) => Promise<OperationResult<Data, Variables>>;
 }

--- a/packages/preact-urql/src/components/Query.ts
+++ b/packages/preact-urql/src/components/Query.ts
@@ -1,14 +1,18 @@
 import { VNode } from 'preact';
-import { OperationContext } from '@urql/core';
+import { AnyVariables, OperationContext } from '@urql/core';
 import { useQuery, UseQueryArgs, UseQueryState } from '../hooks';
 
-export interface QueryProps<Data = any, Variables = object>
-  extends UseQueryArgs<Variables, Data> {
+export type QueryProps<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = UseQueryArgs<Variables, Data> & {
   children: (arg: QueryState<Data, Variables>) => VNode<any>;
-}
+};
 
-export interface QueryState<Data = any, Variables = object>
-  extends UseQueryState<Data, Variables> {
+export interface QueryState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> extends UseQueryState<Data, Variables> {
   executeQuery: (opts?: Partial<OperationContext>) => void;
 }
 

--- a/packages/preact-urql/src/components/Subscription.ts
+++ b/packages/preact-urql/src/components/Subscription.ts
@@ -1,5 +1,5 @@
 import { VNode } from 'preact';
-import { OperationContext } from '@urql/core';
+import { AnyVariables, OperationContext } from '@urql/core';
 
 import {
   useSubscription,
@@ -8,23 +8,27 @@ import {
   SubscriptionHandler,
 } from '../hooks';
 
-export interface SubscriptionProps<
+export type SubscriptionProps<
   Data = any,
   Result = Data,
-  Variables = object
-> extends UseSubscriptionArgs<Variables, Data> {
+  Variables extends AnyVariables = AnyVariables
+> = UseSubscriptionArgs<Variables, Data> & {
   handler?: SubscriptionHandler<Data, Result>;
   children: (arg: SubscriptionState<Result, Variables>) => VNode<any>;
-}
+};
 
-export interface SubscriptionState<Data = any, Variables = object>
-  extends UseSubscriptionState<Data, Variables> {
+export interface SubscriptionState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> extends UseSubscriptionState<Data, Variables> {
   executeSubscription: (opts?: Partial<OperationContext>) => void;
 }
 
-export function Subscription<Data = any, Result = Data, Variables = object>(
-  props: SubscriptionProps<Data, Result, Variables>
-): VNode<any> {
+export function Subscription<
+  Data = any,
+  Result = Data,
+  Variables extends AnyVariables = AnyVariables
+>(props: SubscriptionProps<Data, Result, Variables>): VNode<any> {
   const subscription = useSubscription<Data, Result, Variables>(
     props,
     props.handler

--- a/packages/preact-urql/src/hooks/useMutation.ts
+++ b/packages/preact-urql/src/hooks/useMutation.ts
@@ -3,6 +3,7 @@ import { useState, useCallback, useRef, useEffect } from 'preact/hooks';
 import { pipe, toPromise } from 'wonka';
 
 import {
+  AnyVariables,
   TypedDocumentNode,
   OperationResult,
   OperationContext,
@@ -14,7 +15,10 @@ import {
 import { useClient } from '../context';
 import { initialState } from './constants';
 
-export interface UseMutationState<Data = any, Variables = object> {
+export interface UseMutationState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> {
   fetching: boolean;
   stale: boolean;
   data?: Data;
@@ -23,15 +27,21 @@ export interface UseMutationState<Data = any, Variables = object> {
   operation?: Operation<Data, Variables>;
 }
 
-export type UseMutationResponse<Data = any, Variables = object> = [
+export type UseMutationResponse<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = [
   UseMutationState<Data, Variables>,
   (
-    variables?: Variables,
+    variables: Variables,
     context?: Partial<OperationContext>
   ) => Promise<OperationResult<Data, Variables>>
 ];
 
-export function useMutation<Data = any, Variables = object>(
+export function useMutation<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
   query: DocumentNode | TypedDocumentNode<Data, Variables> | string
 ): UseMutationResponse<Data, Variables> {
   const isMounted = useRef(true);
@@ -42,7 +52,7 @@ export function useMutation<Data = any, Variables = object>(
   );
 
   const executeMutation = useCallback(
-    (variables?: Variables, context?: Partial<OperationContext>) => {
+    (variables: Variables, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
 
       return pipe(

--- a/packages/preact-urql/src/hooks/useRequest.ts
+++ b/packages/preact-urql/src/hooks/useRequest.ts
@@ -1,14 +1,21 @@
 import { DocumentNode } from 'graphql';
 import { useRef, useMemo } from 'preact/hooks';
-import { TypedDocumentNode, GraphQLRequest, createRequest } from '@urql/core';
+import {
+  AnyVariables,
+  TypedDocumentNode,
+  GraphQLRequest,
+  createRequest,
+} from '@urql/core';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
-export function useRequest<Data = any, Variables = object>(
+export function useRequest<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
   query: string | DocumentNode | TypedDocumentNode<Data, Variables>,
-  variables?: Variables
+  variables: Variables
 ): GraphQLRequest<Data, Variables> {
   const prev = useRef<undefined | GraphQLRequest<Data, Variables>>(undefined);
-
   return useMemo(() => {
     const request = createRequest<Data, Variables>(query, variables);
     // We manually ensure reference equality if the key hasn't changed

--- a/packages/react-urql/src/components/Mutation.ts
+++ b/packages/react-urql/src/components/Mutation.ts
@@ -1,21 +1,27 @@
 import { DocumentNode } from 'graphql';
 import { ReactElement } from 'react';
 import {
+  AnyVariables,
   TypedDocumentNode,
   OperationResult,
   OperationContext,
 } from '@urql/core';
 import { useMutation, UseMutationState } from '../hooks';
 
-export interface MutationProps<Data = any, Variables = object> {
+export interface MutationProps<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> {
   query: DocumentNode | TypedDocumentNode<Data, Variables> | string;
   children: (arg: MutationState<Data, Variables>) => ReactElement<any>;
 }
 
-export interface MutationState<Data = any, Variables = object>
-  extends UseMutationState<Data, Variables> {
+export interface MutationState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> extends UseMutationState<Data, Variables> {
   executeMutation: (
-    variables?: Variables,
+    variables: Variables,
     context?: Partial<OperationContext>
   ) => Promise<OperationResult<Data, Variables>>;
 }

--- a/packages/react-urql/src/components/Query.ts
+++ b/packages/react-urql/src/components/Query.ts
@@ -1,14 +1,18 @@
 import { ReactElement } from 'react';
-import { OperationContext } from '@urql/core';
+import { AnyVariables, OperationContext } from '@urql/core';
 import { useQuery, UseQueryArgs, UseQueryState } from '../hooks';
 
-export interface QueryProps<Data = any, Variables = object>
-  extends UseQueryArgs<Variables, Data> {
+export type QueryProps<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = UseQueryArgs<Variables, Data> & {
   children: (arg: QueryState<Data, Variables>) => ReactElement<any>;
-}
+};
 
-export interface QueryState<Data = any, Variables = object>
-  extends UseQueryState<Data, Variables> {
+export interface QueryState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> extends UseQueryState<Data, Variables> {
   executeQuery: (opts?: Partial<OperationContext>) => void;
 }
 

--- a/packages/react-urql/src/components/Subscription.ts
+++ b/packages/react-urql/src/components/Subscription.ts
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { OperationContext } from '@urql/core';
+import { AnyVariables, OperationContext } from '@urql/core';
 
 import {
   useSubscription,
@@ -8,23 +8,27 @@ import {
   SubscriptionHandler,
 } from '../hooks';
 
-export interface SubscriptionProps<
+export type SubscriptionProps<
   Data = any,
   Result = Data,
-  Variables = object
-> extends UseSubscriptionArgs<Variables, Data> {
+  Variables extends AnyVariables = AnyVariables
+> = UseSubscriptionArgs<Variables, Data> & {
   handler?: SubscriptionHandler<Data, Result>;
   children: (arg: SubscriptionState<Result, Variables>) => ReactElement<any>;
-}
+};
 
-export interface SubscriptionState<Data = any, Variables = object>
-  extends UseSubscriptionState<Data, Variables> {
+export interface SubscriptionState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> extends UseSubscriptionState<Data, Variables> {
   executeSubscription: (opts?: Partial<OperationContext>) => void;
 }
 
-export function Subscription<Data = any, Result = Data, Variables = object>(
-  props: SubscriptionProps<Data, Result, Variables>
-): ReactElement<any> {
+export function Subscription<
+  Data = any,
+  Result = Data,
+  Variables extends AnyVariables = AnyVariables
+>(props: SubscriptionProps<Data, Result, Variables>): ReactElement<any> {
   const subscription = useSubscription<Data, Result, Variables>(
     props,
     props.handler

--- a/packages/react-urql/src/hooks/useMutation.ts
+++ b/packages/react-urql/src/hooks/useMutation.ts
@@ -3,6 +3,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { pipe, toPromise } from 'wonka';
 
 import {
+  AnyVariables,
   TypedDocumentNode,
   OperationResult,
   OperationContext,
@@ -14,7 +15,10 @@ import {
 import { useClient } from '../context';
 import { initialState } from './state';
 
-export interface UseMutationState<Data = any, Variables = object> {
+export interface UseMutationState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> {
   fetching: boolean;
   stale: boolean;
   data?: Data;
@@ -23,15 +27,21 @@ export interface UseMutationState<Data = any, Variables = object> {
   operation?: Operation<Data, Variables>;
 }
 
-export type UseMutationResponse<Data = any, Variables = object> = [
+export type UseMutationResponse<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = [
   UseMutationState<Data, Variables>,
   (
-    variables?: Variables,
+    variables: Variables,
     context?: Partial<OperationContext>
   ) => Promise<OperationResult<Data, Variables>>
 ];
 
-export function useMutation<Data = any, Variables = object>(
+export function useMutation<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
   query: DocumentNode | TypedDocumentNode<Data, Variables> | string
 ): UseMutationResponse<Data, Variables> {
   const isMounted = useRef(true);
@@ -42,7 +52,7 @@ export function useMutation<Data = any, Variables = object>(
   );
 
   const executeMutation = useCallback(
-    (variables?: Variables, context?: Partial<OperationContext>) => {
+    (variables: Variables, context?: Partial<OperationContext>) => {
       setState({ ...initialState, fetching: true });
 
       return pipe(

--- a/packages/react-urql/src/hooks/useRequest.ts
+++ b/packages/react-urql/src/hooks/useRequest.ts
@@ -1,11 +1,19 @@
 import { DocumentNode } from 'graphql';
 import { useRef, useMemo } from 'react';
-import { TypedDocumentNode, GraphQLRequest, createRequest } from '@urql/core';
+import {
+  AnyVariables,
+  TypedDocumentNode,
+  GraphQLRequest,
+  createRequest,
+} from '@urql/core';
 
 /** Creates a request from a query and variables but preserves reference equality if the key isn't changing */
-export function useRequest<Data = any, Variables = object>(
+export function useRequest<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
   query: string | DocumentNode | TypedDocumentNode<Data, Variables>,
-  variables?: Variables
+  variables: Variables
 ): GraphQLRequest<Data, Variables> {
   const prev = useRef<undefined | GraphQLRequest<Data, Variables>>(undefined);
 

--- a/packages/svelte-urql/src/common.ts
+++ b/packages/svelte-urql/src/common.ts
@@ -1,16 +1,19 @@
 import type { Readable, Writable } from 'svelte/store';
-import type { OperationResult } from '@urql/core';
+import type { AnyVariables, OperationResult } from '@urql/core';
 import { Source, make } from 'wonka';
 
-export interface OperationResultState<Data = any, Variables = object>
-  extends OperationResult<Data, Variables> {
+export interface OperationResultState<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> extends OperationResult<Data, Variables> {
   fetching: boolean;
 }
 
 /** A Readable containing an `OperationResult` with a fetching flag. */
-export type OperationResultStore<Data = any, Variables = object> = Readable<
-  OperationResultState<Data, Variables>
->;
+export type OperationResultStore<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = Readable<OperationResultState<Data, Variables>>;
 
 export const fromStore = <T>(store$: Readable<T>): Source<T> =>
   make(observer => store$.subscribe(observer.next));

--- a/packages/svelte-urql/src/mutationStore.ts
+++ b/packages/svelte-urql/src/mutationStore.ts
@@ -1,5 +1,6 @@
 import type { DocumentNode } from 'graphql';
 import {
+  AnyVariables,
   Client,
   OperationContext,
   TypedDocumentNode,
@@ -16,18 +17,26 @@ import {
 
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 
-export interface MutationArgs<Data = any, Variables = object> {
+export type MutationArgs<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = {
   client: Client;
   query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
-  variables?: Variables;
   context?: Partial<OperationContext>;
-}
+} & (Variables extends void
+  ? {
+      variables?: Variables;
+    }
+  : {
+      variables: Variables;
+    });
 
 export function mutationStore<Data = any, Result = Data, Variables = object>(
   args: MutationArgs<Data, Variables>,
   handler?: SubscriptionHandler<Data, Result>
 ): OperationResultStore<Result, Variables> {
-  const request = createRequest(args.query, args.variables);
+  const request = createRequest(args.query, args.variables as Variables);
   const operation = args.client.createRequestOperation(
     'mutation',
     request,

--- a/packages/svelte-urql/src/queryStore.ts
+++ b/packages/svelte-urql/src/queryStore.ts
@@ -1,6 +1,7 @@
 import type { DocumentNode } from 'graphql';
 import {
   Client,
+  AnyVariables,
   OperationContext,
   TypedDocumentNode,
   RequestPolicy,
@@ -28,19 +29,30 @@ import {
   fromStore,
 } from './common';
 
-export interface QueryArgs<Data = any, Variables = object> {
+export type QueryArgs<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = {
   client: Client;
   query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
-  variables?: Variables;
   context?: Partial<OperationContext>;
   requestPolicy?: RequestPolicy;
   pause?: boolean;
-}
+} & (Variables extends void
+  ? {
+      variables?: Variables;
+    }
+  : {
+      variables: Variables;
+    });
 
-export function queryStore<Data = any, Variables = object>(
+export function queryStore<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
   args: QueryArgs<Data, Variables>
 ): OperationResultStore<Data, Variables> & Pausable {
-  const request = createRequest(args.query, args.variables);
+  const request = createRequest(args.query, args.variables as Variables);
 
   const context: Partial<OperationContext> = {
     requestPolicy: args.requestPolicy,

--- a/packages/svelte-urql/src/subscriptionStore.ts
+++ b/packages/svelte-urql/src/subscriptionStore.ts
@@ -1,5 +1,6 @@
 import type { DocumentNode } from 'graphql';
 import {
+  AnyVariables,
   Client,
   OperationContext,
   TypedDocumentNode,
@@ -27,18 +28,29 @@ import {
   fromStore,
 } from './common';
 
-export interface SubscriptionArgs<Data = any, Variables = object> {
+export type SubscriptionArgs<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+> = {
   client: Client;
   query: string | DocumentNode | TypedDocumentNode<Data, Variables>;
-  variables?: Variables;
   context?: Partial<OperationContext>;
   pause?: boolean;
-}
+} & (Variables extends void
+  ? {
+      variables?: Variables;
+    }
+  : {
+      variables: Variables;
+    });
 
-export function subscriptionStore<Data, Variables extends object = {}>(
+export function subscriptionStore<
+  Data,
+  Variables extends AnyVariables = AnyVariables
+>(
   args: SubscriptionArgs<Data, Variables>
 ): OperationResultStore<Data, Variables> & Pausable {
-  const request = createRequest(args.query, args.variables);
+  const request = createRequest(args.query, args.variables as Variables);
 
   const operation = args.client.createRequestOperation(
     'subscription',

--- a/packages/vue-urql/src/useMutation.ts
+++ b/packages/vue-urql/src/useMutation.ts
@@ -6,6 +6,7 @@ import { pipe, toPromise, take } from 'wonka';
 
 import {
   Client,
+  AnyVariables,
   TypedDocumentNode,
   CombinedError,
   Operation,
@@ -32,13 +33,13 @@ export interface UseMutationState<T, V> {
 
 export type UseMutationResponse<T, V> = UseMutationState<T, V>;
 
-export function useMutation<T = any, V = any>(
+export function useMutation<T = any, V = AnyVariables>(
   query: TypedDocumentNode<T, V> | DocumentNode | string
 ): UseMutationResponse<T, V> {
   return callUseMutation(query);
 }
 
-export function callUseMutation<T = any, V = any>(
+export function callUseMutation<T = any, V = AnyVariables>(
   query: TypedDocumentNode<T, V> | DocumentNode | string,
   client: Ref<Client> = useClient()
 ): UseMutationResponse<T, V> {
@@ -64,12 +65,12 @@ export function callUseMutation<T = any, V = any>(
 
       return pipe(
         client.value.executeMutation<T, V>(
-          createRequest<T, V>(query, unwrapPossibleProxy<V>(variables)),
+          createRequest<T, V>(query, unwrapPossibleProxy(variables)),
           context || {}
         ),
         take(1),
         toPromise
-      ).then((res: OperationResult) => {
+      ).then((res: OperationResult<T, V>) => {
         data.value = res.data;
         stale.value = !!res.stale;
         fetching.value = false;

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -8,6 +8,7 @@ import { Source, pipe, subscribe, onEnd } from 'wonka';
 
 import {
   Client,
+  AnyVariables,
   OperationResult,
   TypedDocumentNode,
   CombinedError,
@@ -23,19 +24,25 @@ import { unwrapPossibleProxy } from './utils';
 
 type MaybeRef<T> = T | Ref<T>;
 
-export interface UseQueryArgs<T = any, V = object> {
+export type UseQueryArgs<T = any, V extends AnyVariables = AnyVariables> = {
   query: MaybeRef<TypedDocumentNode<T, V> | DocumentNode | string>;
-  variables?: MaybeRef<V>;
   requestPolicy?: MaybeRef<RequestPolicy>;
   context?: MaybeRef<Partial<OperationContext>>;
   pause?: MaybeRef<boolean>;
-}
+} & (V extends void
+  ? {
+      variables?: MaybeRef<V>;
+    }
+  : {
+      variables: MaybeRef<V>;
+    });
 
-export type QueryPartialState<T = any, V = object> = Partial<
-  OperationResult<T, V>
-> & { fetching?: boolean };
+export type QueryPartialState<
+  T = any,
+  V extends AnyVariables = AnyVariables
+> = Partial<OperationResult<T, V>> & { fetching?: boolean };
 
-export interface UseQueryState<T = any, V = object> {
+export interface UseQueryState<T = any, V extends AnyVariables = AnyVariables> {
   fetching: Ref<boolean>;
   stale: Ref<boolean>;
   data: Ref<T | undefined>;
@@ -55,13 +62,13 @@ const watchOptions = {
   flush: 'pre' as const,
 };
 
-export function useQuery<T = any, V = object>(
+export function useQuery<T = any, V extends AnyVariables = AnyVariables>(
   args: UseQueryArgs<T, V>
 ): UseQueryResponse<T, V> {
   return callUseQuery(args);
 }
 
-export function callUseQuery<T = any, V = object>(
+export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   _args: UseQueryArgs<T, V>,
   client: Ref<Client> = useClient(),
   stops: WatchStopHandle[] = []
@@ -86,7 +93,7 @@ export function callUseQuery<T = any, V = object>(
     ) as any
   );
 
-  const source: Ref<Source<OperationResult> | undefined> = ref();
+  const source: Ref<Source<OperationResult<T, V>> | undefined> = ref();
 
   stops.push(
     watchEffect(() => {

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -34,7 +34,7 @@ export type UseQueryArgs<T = any, V extends AnyVariables = AnyVariables> = {
       variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     }
   : {
-      variables: MaybeRef<V>;
+      variables: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;;
     });
 
 export type QueryPartialState<

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -34,7 +34,7 @@ export type UseQueryArgs<T = any, V extends AnyVariables = AnyVariables> = {
       variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     }
   : {
-      variables: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;;
+      variables: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     });
 
 export type QueryPartialState<

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -31,7 +31,7 @@ export type UseQueryArgs<T = any, V extends AnyVariables = AnyVariables> = {
   pause?: MaybeRef<boolean>;
 } & (V extends void
   ? {
-      variables?: MaybeRef<V>;
+      variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     }
   : {
       variables: MaybeRef<V>;

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -7,6 +7,7 @@ import { WatchStopHandle, Ref, ref, watchEffect, reactive, isRef } from 'vue';
 
 import {
   Client,
+  AnyVariables,
   OperationResult,
   TypedDocumentNode,
   CombinedError,
@@ -21,17 +22,29 @@ import { unwrapPossibleProxy } from './utils';
 
 type MaybeRef<T> = T | Ref<T>;
 
-export interface UseSubscriptionArgs<T = any, V = object> {
+export type UseSubscriptionArgs<
+  T = any,
+  V extends AnyVariables = AnyVariables
+> = {
   query: MaybeRef<TypedDocumentNode<T, V> | DocumentNode | string>;
-  variables?: MaybeRef<V>;
   pause?: MaybeRef<boolean>;
   context?: MaybeRef<Partial<OperationContext>>;
-}
+} & (V extends void
+  ? {
+      variables?: MaybeRef<V>;
+    }
+  : {
+      variables: MaybeRef<V>;
+    });
 
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;
 export type SubscriptionHandlerArg<T, R> = MaybeRef<SubscriptionHandler<T, R>>;
 
-export interface UseSubscriptionState<T = any, R = T, V = object> {
+export interface UseSubscriptionState<
+  T = any,
+  R = T,
+  V extends AnyVariables = AnyVariables
+> {
   fetching: Ref<boolean>;
   stale: Ref<boolean>;
   data: Ref<R | undefined>;
@@ -54,14 +67,22 @@ const watchOptions = {
   flush: 'pre' as const,
 };
 
-export function useSubscription<T = any, R = T, V = object>(
+export function useSubscription<
+  T = any,
+  R = T,
+  V extends AnyVariables = AnyVariables
+>(
   args: UseSubscriptionArgs<T, V>,
   handler?: SubscriptionHandlerArg<T, R>
 ): UseSubscriptionResponse<T, R, V> {
   return callUseSubscription(args, handler);
 }
 
-export function callUseSubscription<T = any, R = T, V = object>(
+export function callUseSubscription<
+  T = any,
+  R = T,
+  V extends AnyVariables = AnyVariables
+>(
   _args: UseSubscriptionArgs<T, V>,
   handler?: SubscriptionHandlerArg<T, R>,
   client: Ref<Client> = useClient(),
@@ -73,7 +94,7 @@ export function callUseSubscription<T = any, R = T, V = object>(
   const stale: Ref<boolean> = ref(false);
   const fetching: Ref<boolean> = ref(false);
   const error: Ref<CombinedError | undefined> = ref();
-  const operation: Ref<Operation | undefined> = ref();
+  const operation: Ref<Operation<T, V> | undefined> = ref();
   const extensions: Ref<Record<string, any> | undefined> = ref();
 
   const scanHandler: Ref<SubscriptionHandler<T, R> | undefined> = ref(handler);

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -31,10 +31,10 @@ export type UseSubscriptionArgs<
   context?: MaybeRef<Partial<OperationContext>>;
 } & (V extends void
   ? {
-      variables?: MaybeRef<V>;
+      variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     }
   : {
-      variables: MaybeRef<V>;
+      variables: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     });
 
 export type SubscriptionHandler<T, R> = (prev: R | undefined, data: T) => R;

--- a/packages/vue-urql/src/utils.ts
+++ b/packages/vue-urql/src/utils.ts
@@ -1,8 +1,6 @@
 import { Ref, isRef } from 'vue';
 
-export function unwrapPossibleProxy<V>(
-  possibleProxy: V | Ref<V> | undefined
-): V | undefined {
+export function unwrapPossibleProxy<V>(possibleProxy: V | Ref<V>): V {
   return possibleProxy && isRef(possibleProxy)
     ? possibleProxy.value
     : possibleProxy;


### PR DESCRIPTION
Resolve #2606

## Summary

This attempts to introduce a stricter type for variables preventing it from being an optional property or argument (i.e. `variables?: Variables`) in all parts of the codebase. To do this, we also need to make its type a little more strict with `AnyVariables`, which explicitly defaults the generic to a type of `void | undefined | { ... }`. In case of a generic that's passed in, this also becomes the extension type.

This is currently a draft because some methods on `Client` and some utility functions, like `createRequest`, are affected by this change. We have to check that these behave as expected (as per the change and RFC) and that we don't break them if that isn't necessary

## Set of changes

- Add `AnyVariables` and make generics `Variables extends AnyVariables = AnyVariables`
- Update core typings where `variables` were optional
- Update all typings across bindings (wherever `variables?:` was used, a special type must be implemented)
