### PR TITLE
fix(vue): update types to support nested refs

### DIFF
--- a/.changeset/four-dots-camp.md
+++ b/.changeset/four-dots-camp.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Support nested refs in variables

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -25,7 +25,7 @@ type MaybeRef<T> = T | Ref<T>;
 
 export interface UseQueryArgs<T = any, V = object> {
   query: MaybeRef<TypedDocumentNode<T, V> | DocumentNode | string>;
-  variables?: MaybeRef<V>;
+  variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
   requestPolicy?: MaybeRef<RequestPolicy>;
   context?: MaybeRef<Partial<OperationContext>>;
   pause?: MaybeRef<boolean>;

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -23,7 +23,7 @@ type MaybeRef<T> = T | Ref<T>;
 
 export interface UseSubscriptionArgs<T = any, V = object> {
   query: MaybeRef<TypedDocumentNode<T, V> | DocumentNode | string>;
-  variables?: MaybeRef<V>;
+  variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
   pause?: MaybeRef<boolean>;
   context?: MaybeRef<Partial<OperationContext>>;
 }


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/urql/issues/2274

## Summary

We update the types here to support nested refs in the `variables` for `useSubscription` and `useQuery`. We currently don't support refs in the callback for `useMutation`, I would leave it be for now personally.

## Set of changes

- add the updated type
