### PR TITLE
feat(graphcache): support passing in name for fragments

### DIFF
--- a/.changeset/hungry-swans-tell.md
+++ b/.changeset/hungry-swans-tell.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': minor
+---
+
+Allow passing in `fragmentName` for `write` and `read` operations

--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -351,7 +351,7 @@ import { gql } from '@urql/core';
 
 cache.readFragment(
   gql`
-    fragment todoFields on User {
+    fragment todoFields on Todo {
       id
     }
 
@@ -460,7 +460,7 @@ import { gql } from '@urql/core';
 
 cache.writeFragment(
   gql`
-    fragment todoFields on User {
+    fragment todoFields on Todo {
       id
       text
     }

--- a/docs/api/graphcache.md
+++ b/docs/api/graphcache.md
@@ -343,6 +343,28 @@ cache.readFragment(
 );
 ```
 
+If you need a specific fragment in a document containing multiple you can leverage
+the fourth argument like this:
+
+```js
+import { gql } from '@urql/core';
+
+cache.readFragment(
+  gql`
+    fragment todoFields on User {
+      id
+    }
+
+    fragment userFields on User {
+      id
+    }
+  `,
+  { id: 1 }, // this identifies the fragment (User) entity
+  undefined,
+  'userFields' // if not passed we take the first fragment, in this case todoFields
+);
+```
+
 [Read more about using `readFragment` on the ["Local Resolvers"
 page.](../graphcache/local-resolvers.md#reading-a-fragment)
 
@@ -429,6 +451,30 @@ cache.writeFragment(
 In the example we can see that the `writeFragment` method returns `undefined`. Furthermore we pass
 `id` in our `data` object so that an entity key can be written, but the fragment itself doesn't have
 to include these fields.
+
+If you need a specific fragment in a document containing multiple you can leverage
+the fourth argument like this:
+
+```js
+import { gql } from '@urql/core';
+
+cache.writeFragment(
+  gql`
+    fragment todoFields on User {
+      id
+      text
+    }
+
+    fragment userFields on User {
+      id
+      name
+    }
+  `,
+  { id: 1, name: 'New Name' }
+  undefined,
+  'userFields' // if not passed we take the first fragment, in this case todoFields
+);
+```
 
 [Read more about using `writeFragment` on the ["Custom Updates"
 page.](../graphcache/cache-updates.md#cachewritefragment)

--- a/docs/graphcache/errors.md
+++ b/docs/graphcache/errors.md
@@ -107,6 +107,9 @@ is maybe empty or does not contain fragments.
 When you're calling a fragment method, please ensure that you're only passing fragments
 in your GraphQL document. The first fragment will be used to start writing data.
 
+This also occurs when you pass in a `fragmentName` but a fragment with the given name
+can't be found in the `DocumentNode`.
+
 ## (7) Can't generate a key for readFragment(...)
 
 > Can't generate a key for readFragment(...).
@@ -170,6 +173,9 @@ is maybe empty or does not contain fragments.
 
 When you're calling a fragment method, please ensure that you're only passing fragments
 in your GraphQL document. The first fragment will be used to start writing data.
+
+This also occurs when you pass in a `fragmentName` but a fragment with the given name
+can't be found in the `DocumentNode`.
 
 ## (12) Can't generate a key for writeFragment(...) or link(...)
 

--- a/exchanges/graphcache/src/operations/query.ts
+++ b/exchanges/graphcache/src/operations/query.ts
@@ -202,19 +202,39 @@ export const readFragment = (
   store: Store,
   query: DocumentNode,
   entity: Partial<Data> | string,
-  variables?: Variables
+  variables?: Variables,
+  fragmentName?: string
 ): Data | null => {
   const fragments = getFragments(query);
-  const names = Object.keys(fragments);
-  const fragment = fragments[names[0]] as FragmentDefinitionNode;
-  if (!fragment) {
-    warn(
-      'readFragment(...) was called with an empty fragment.\n' +
-        'You have to call it with at least one fragment in your GraphQL document.',
-      6
-    );
 
-    return null;
+  let fragment: FragmentDefinitionNode;
+  if (fragmentName) {
+    fragment = fragments[fragmentName] as FragmentDefinitionNode;
+    if (!fragment) {
+      warn(
+        'readFragment(...) was called with a fragment name that does not exist.\n' +
+          'You provided ' +
+          fragmentName +
+          ' but could only find ' +
+          Object.keys(fragments).join(', ') +
+          '.',
+        6
+      );
+
+      return null;
+    }
+  } else {
+    const names = Object.keys(fragments);
+    fragment = fragments[names[0]] as FragmentDefinitionNode;
+    if (!fragment) {
+      warn(
+        'readFragment(...) was called with an empty fragment.\n' +
+          'You have to call it with at least one fragment in your GraphQL document.',
+        6
+      );
+
+      return null;
+    }
   }
 
   const typename = getFragmentTypeName(fragment);

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -133,13 +133,13 @@ export const writeFragment = (
     fragment = fragments[fragmentName] as FragmentDefinitionNode;
     if (!fragment) {
       warn(
-        'readFragment(...) was called with a fragment name that does not exist.\n' +
+        'writeFragment(...) was called with a fragment name that does not exist.\n' +
           'You provided ' +
           fragmentName +
           ' but could only find ' +
           Object.keys(fragments).join(', ') +
           '.',
-        6
+        11
       );
 
       return null;
@@ -149,9 +149,9 @@ export const writeFragment = (
     fragment = fragments[names[0]] as FragmentDefinitionNode;
     if (!fragment) {
       warn(
-        'readFragment(...) was called with an empty fragment.\n' +
+        'writeFragment(...) was called with an empty fragment.\n' +
           'You have to call it with at least one fragment in your GraphQL document.',
-        6
+        11
       );
 
       return null;

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -124,17 +124,38 @@ export const writeFragment = (
   store: Store,
   query: DocumentNode,
   data: Partial<Data>,
-  variables?: Variables
+  variables?: Variables,
+  fragmentName?: string
 ) => {
   const fragments = getFragments(query);
-  const names = Object.keys(fragments);
-  const fragment = fragments[names[0]] as FragmentDefinitionNode;
-  if (!fragment) {
-    return warn(
-      'writeFragment(...) was called with an empty fragment.\n' +
-        'You have to call it with at least one fragment in your GraphQL document.',
-      11
-    );
+  let fragment: FragmentDefinitionNode;
+  if (fragmentName) {
+    fragment = fragments[fragmentName] as FragmentDefinitionNode;
+    if (!fragment) {
+      warn(
+        'readFragment(...) was called with a fragment name that does not exist.\n' +
+          'You provided ' +
+          fragmentName +
+          ' but could only find ' +
+          Object.keys(fragments).join(', ') +
+          '.',
+        6
+      );
+
+      return null;
+    }
+  } else {
+    const names = Object.keys(fragments);
+    fragment = fragments[names[0]] as FragmentDefinitionNode;
+    if (!fragment) {
+      warn(
+        'readFragment(...) was called with an empty fragment.\n' +
+          'You have to call it with at least one fragment in your GraphQL document.',
+        6
+      );
+
+      return null;
+    }
   }
 
   const typename = getFragmentTypeName(fragment);

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -545,6 +545,42 @@ describe('Store with OptimisticMutationConfig', () => {
     InMemoryData.clearDataState();
   });
 
+  it('should be able to read a fragment by name', () => {
+    InMemoryData.initDataState('read', store.data, null);
+    const result = store.readFragment(
+      gql`
+        fragment authorFields on Author {
+          id
+          text
+          complete
+          __typename
+        }
+
+        fragment todoFields on Todo {
+          id
+          text
+          complete
+          __typename
+        }
+      `,
+      { id: '0' },
+      undefined,
+      'todoFields'
+    );
+
+    const deps = InMemoryData.getCurrentDependencies();
+    expect(deps).toEqual({ 'Todo:0': true });
+
+    expect(result).toEqual({
+      id: '0',
+      text: 'Go to the shops',
+      complete: false,
+      __typename: 'Todo',
+    });
+
+    InMemoryData.clearDataState();
+  });
+
   it('should be able to update a query', () => {
     InMemoryData.initDataState('read', store.data, null);
     store.updateQuery({ query: Todos }, data => ({

--- a/exchanges/graphcache/src/store/store.test.ts
+++ b/exchanges/graphcache/src/store/store.test.ts
@@ -518,6 +518,49 @@ describe('Store with OptimisticMutationConfig', () => {
     });
   });
 
+  it('should be able to write a fragment by name', () => {
+    InMemoryData.initDataState('read', store.data, null);
+
+    store.writeFragment(
+      gql`
+        fragment authorFields on Author {
+          id
+        }
+
+        fragment todoFields on Todo {
+          id
+          text
+          complete
+        }
+      `,
+      {
+        id: '0',
+        text: 'update',
+        complete: true,
+      },
+      undefined,
+      'todoFields'
+    );
+
+    const deps = InMemoryData.getCurrentDependencies();
+    expect(deps).toEqual({ 'Todo:0': true });
+
+    const { data } = query(store, { query: Todos });
+
+    expect(data).toEqual({
+      __typename: 'Query',
+      todos: [
+        {
+          ...todosData.todos[0],
+          text: 'update',
+          complete: true,
+        },
+        todosData.todos[1],
+        todosData.todos[2],
+      ],
+    });
+  });
+
   it('should be able to read a fragment', () => {
     InMemoryData.initDataState('read', store.data, null);
     const result = store.readFragment(

--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -180,22 +180,31 @@ export class Store<
   readFragment<T = Data, V = Variables>(
     fragment: DocumentNode | TypedDocumentNode<T, V>,
     entity: string | Data | T,
-    variables?: V
+    variables?: V,
+    fragmentName?: string
   ): T | null {
     return readFragment(
       this,
       formatDocument(fragment),
       entity,
-      variables as any
+      variables as any,
+      fragmentName
     ) as T | null;
   }
 
   writeFragment<T = Data, V = Variables>(
     fragment: DocumentNode | TypedDocumentNode<T, V>,
     data: T,
-    variables?: V
+    variables?: V,
+    fragmentName?: string
   ): void {
-    writeFragment(this, formatDocument(fragment), data, variables as any);
+    writeFragment(
+      this,
+      formatDocument(fragment),
+      data,
+      variables as any,
+      fragmentName
+    );
   }
 
   link(


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/urql/issues/2566

## Summary

When re-using document-nodes that contain queries/multiple fragments we might need to target a fragment rather than going for the first one. This PR introduces a new argument named `fragmentName` which allows people to target a specific `FragmentDefinitionNode` in a `DocumentNode` by name.

## Set of changes

- add `fragmentName` argument to write and read operations
