### PR TITLE
chore(core): Refactor utilities to reduce size (*.min.mjs) by -50B gzip'd

### DIFF
--- a/packages/core/src/exchanges/dedup.ts
+++ b/packages/core/src/exchanges/dedup.ts
@@ -7,12 +7,8 @@ export const dedupExchange: Exchange = ({ forward, dispatchDebug }) => {
 
   const filterIncomingOperation = (operation: Operation) => {
     const { key, kind } = operation;
-    if (kind === 'teardown') {
+    if (kind === 'teardown' || kind === 'mutation') {
       inFlightKeys.delete(key);
-      return true;
-    }
-
-    if (kind !== 'query' && kind !== 'subscription') {
       return true;
     }
 

--- a/packages/core/src/exchanges/fetch.ts
+++ b/packages/core/src/exchanges/fetch.ts
@@ -39,26 +39,34 @@ export const fetchExchange: Exchange = ({ forward, dispatchDebug }) => {
           },
         });
 
-        return pipe(
+        const source = pipe(
           makeFetchSource(operation, url, fetchOptions),
-          takeUntil(teardown$),
-          onPush(result => {
-            const error = !result.data ? result.error : undefined;
-
-            dispatchDebug({
-              type: error ? 'fetchError' : 'fetchSuccess',
-              message: `A ${
-                error ? 'failed' : 'successful'
-              } fetch response has been returned.`,
-              operation,
-              data: {
-                url,
-                fetchOptions,
-                value: error || result,
-              },
-            });
-          })
+          takeUntil(teardown$)
         );
+
+        if (process.env.NODE_ENV !== 'production') {
+          return pipe(
+            source,
+            onPush(result => {
+              const error = !result.data ? result.error : undefined;
+
+              dispatchDebug({
+                type: error ? 'fetchError' : 'fetchSuccess',
+                message: `A ${
+                  error ? 'failed' : 'successful'
+                } fetch response has been returned.`,
+                operation,
+                data: {
+                  url,
+                  fetchOptions,
+                  value: error || result,
+                },
+              });
+            })
+          );
+        }
+
+        return source;
       })
     );
 

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -7,6 +7,7 @@ import {
   mergeMap,
   pipe,
   share,
+  Subscription,
   Source,
   takeUntil,
 } from 'wonka';
@@ -76,7 +77,7 @@ export const subscriptionExchange = ({
 
     return make<OperationResult>(({ next, complete }) => {
       let isComplete = false;
-      let sub;
+      let sub: Subscription | void;
 
       Promise.resolve().then(() => {
         if (isComplete) return;

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -101,8 +101,7 @@ export const createRequest = <
  * Finds the Name value from the OperationDefinition of a Document
  */
 export const getOperationName = (query: DocumentNode): string | undefined => {
-  for (let i = 0, l = query.definitions.length; i < l; i++) {
-    const node = query.definitions[i];
+  for (const node of query.definitions) {
     if (node.kind === Kind.OPERATION_DEFINITION && node.name) {
       return node.name.value;
     }
@@ -113,8 +112,7 @@ export const getOperationName = (query: DocumentNode): string | undefined => {
  * Finds the operation-type
  */
 export const getOperationType = (query: DocumentNode): string | undefined => {
-  for (let i = 0, l = query.definitions.length; i < l; i++) {
-    const node = query.definitions[i];
+  for (const node of query.definitions) {
     if (node.kind === Kind.OPERATION_DEFINITION) {
       return node.operation;
     }

--- a/packages/core/src/utils/stringifyVariables.ts
+++ b/packages/core/src/utils/stringifyVariables.ts
@@ -10,9 +10,9 @@ const stringify = (x: any): string => {
     return stringify(x.toJSON());
   } else if (Array.isArray(x)) {
     let out = '[';
-    for (let i = 0, l = x.length; i < l; i++) {
-      if (i > 0) out += ',';
-      const value = stringify(x[i]);
+    for (let value of x) {
+      if (out !== '[') out += ',';
+      value = stringify(value);
       out += value.length > 0 ? value : 'null';
     }
 
@@ -29,8 +29,7 @@ const stringify = (x: any): string => {
 
   seen.add(x);
   let out = '{';
-  for (let i = 0, l = keys.length; i < l; i++) {
-    const key = keys[i];
+  for (const key of keys) {
     const value = stringify(x[key]);
     if (value) {
       if (out.length > 1) out += ',';


### PR DESCRIPTION
- Simplify `dedupExchange` logic
- Prevent `onPush` in `fetch` for production environments
- Replace several `for`-loops with `for-of` loops
- Use `Set` in `collectTypes`
- Remove `.some` from `formatNode`

I'm explicitly not adding a changeset, since it doesn't actually affect the output code and to not pollute the eventual changelog with irrelevant entries.