### PR TITLE
major(graphcache): stop buffering operations while the cache hydrates

### DIFF
--- a/.changeset/great-eggs-battle.md
+++ b/.changeset/great-eggs-battle.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': major
+---
+
+Prevent cache-hydration from buffering operations

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -157,19 +157,22 @@ export const offlineExchange = <C extends Partial<CacheExchangeOpts>>(
       }
     });
 
-    const oldReadData = storage.readData;
     let isFirstInvocation = true;
-    storage.readData = () => {
-      return oldReadData().then(data => {
-        if (isFirstInvocation) {
-          isFirstInvocation = false;
-          flushQueue();
-        }
-        return data;
-      });
-    };
-
-    const cacheResults$ = cacheExchange(opts)({
+    const cacheResults$ = cacheExchange({
+      ...opts,
+      storage: {
+        ...storage,
+        readData() {
+          return storage.readData().then(data => {
+            if (isFirstInvocation) {
+              isFirstInvocation = false;
+              flushQueue();
+            }
+            return data;
+          });
+        },
+      },
+    })({
       client,
       dispatchDebug,
       forward,

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -157,19 +157,12 @@ export const offlineExchange = <C extends Partial<CacheExchangeOpts>>(
       }
     });
 
-    let isFirstInvocation = true;
     const cacheResults$ = cacheExchange({
       ...opts,
       storage: {
         ...storage,
         readData() {
-          return storage.readData().then(data => {
-            if (isFirstInvocation) {
-              isFirstInvocation = false;
-              flushQueue();
-            }
-            return data;
-          });
+          return storage.readData().finally(flushQueue);
         },
       },
     })({

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -157,6 +157,18 @@ export const offlineExchange = <C extends Partial<CacheExchangeOpts>>(
       }
     });
 
+    const oldReadData = storage.readData;
+    let isFirstInvocation = true;
+    storage.readData = () => {
+      return oldReadData().then(data => {
+        if (isFirstInvocation) {
+          isFirstInvocation = false;
+          flushQueue();
+        }
+        return data;
+      });
+    };
+
     const cacheResults$ = cacheExchange(opts)({
       client,
       dispatchDebug,

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -674,9 +674,11 @@ export const hydrateData = (
     if (value !== undefined) {
       const { entityKey, fieldKey } = deserializeKeyInfo(key);
       if (value[0] === ':') {
-        writeLink(entityKey, fieldKey, JSON.parse(value.slice(1)));
+        if (readLink(entityKey, fieldKey) === undefined)
+          writeLink(entityKey, fieldKey, JSON.parse(value.slice(1)));
       } else {
-        writeRecord(entityKey, fieldKey, JSON.parse(value));
+        if (readRecord(entityKey, fieldKey) === undefined)
+          writeRecord(entityKey, fieldKey, JSON.parse(value));
       }
     }
   }


### PR DESCRIPTION
Resolves #1512 

## Summary

This enables graph-cache to forward operations while hydration is ongoing, this benefits application in various ways

- they can benefit from synchronous rehydration due to the `ssrExchange`
- does not cause an extra delay for empty caches or missing operations

## Set of changes

- remove buffering of operations
