### PR TITLE
fix(bindings): omit variables when all keys are nullable

### DIFF
--- a/.changeset/stupid-lizards-eat.md
+++ b/.changeset/stupid-lizards-eat.md
@@ -1,0 +1,8 @@
+---
+'@urql/preact': patch
+'urql': patch
+'@urql/svelte': patch
+'@urql/vue': patch
+---
+
+Tweak the variables type for when generics only contain nullable keys

--- a/packages/preact-urql/src/hooks/useQuery.ts
+++ b/packages/preact-urql/src/hooks/useQuery.ts
@@ -41,6 +41,8 @@ export type UseQueryArgs<
   ? {
       variables?: Variables;
     }
+  : Variables extends { [P in keyof Variables]: Variables[P] | null }
+  ? { variables?: Variables }
   : {
       variables: Variables;
     });

--- a/packages/preact-urql/src/hooks/useSubscription.ts
+++ b/packages/preact-urql/src/hooks/useSubscription.ts
@@ -26,6 +26,8 @@ export type UseSubscriptionArgs<
   ? {
       variables?: Variables;
     }
+  : Variables extends { [P in keyof Variables]: Variables[P] | null }
+  ? { variables?: Variables }
   : {
       variables: Variables;
     });

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -32,6 +32,8 @@ export type UseQueryArgs<
   ? {
       variables?: Variables;
     }
+  : Variables extends { [P in keyof Variables]: Variables[P] | null }
+  ? { variables?: Variables }
   : {
       variables: Variables;
     });

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -27,6 +27,8 @@ export type UseSubscriptionArgs<
   ? {
       variables?: Variables;
     }
+  : Variables extends { [P in keyof Variables]: Variables[P] | null }
+  ? { variables?: Variables }
   : {
       variables: Variables;
     });

--- a/packages/svelte-urql/src/mutationStore.ts
+++ b/packages/svelte-urql/src/mutationStore.ts
@@ -28,6 +28,8 @@ export type MutationArgs<
   ? {
       variables?: Variables;
     }
+  : Variables extends { [P in keyof Variables]: Variables[P] | null }
+  ? { variables?: Variables }
   : {
       variables: Variables;
     });

--- a/packages/svelte-urql/src/queryStore.ts
+++ b/packages/svelte-urql/src/queryStore.ts
@@ -42,6 +42,8 @@ export type QueryArgs<
   ? {
       variables?: Variables;
     }
+  : Variables extends { [P in keyof Variables]: Variables[P] | null }
+  ? { variables?: Variables }
   : {
       variables: Variables;
     });

--- a/packages/svelte-urql/src/subscriptionStore.ts
+++ b/packages/svelte-urql/src/subscriptionStore.ts
@@ -40,6 +40,8 @@ export type SubscriptionArgs<
   ? {
       variables?: Variables;
     }
+  : Variables extends { [P in keyof Variables]: Variables[P] | null }
+  ? { variables?: Variables }
   : {
       variables: Variables;
     });

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -33,6 +33,8 @@ export type UseQueryArgs<T = any, V extends AnyVariables = AnyVariables> = {
   ? {
       variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     }
+  : V extends { [P in keyof V]: V[P] | null }
+  ? { variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }> }
   : {
       variables: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     });

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -33,6 +33,8 @@ export type UseSubscriptionArgs<
   ? {
       variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     }
+  : V extends { [P in keyof V]: V[P] | null }
+  ? { variables?: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }> }
   : {
       variables: MaybeRef<{ [K in keyof V]: MaybeRef<V[K]> }>;
     });


### PR DESCRIPTION
Resolves #2622 

## Summary

When all keys are nullable we should make the variables nullable as well, this fixes an issue we had with graphql-code-generator when encountering a shape like `{ key: T | null }`
