### PR TITLE
docs: remove relative url's

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -55,7 +55,7 @@ import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql'
 import { authExchange } from '@urql/exchange-auth';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [
     dedupExchange,
     cacheExchange,
@@ -335,7 +335,7 @@ import { createClient, dedupExchange, cacheExchange, fetchExchange, errorExchang
 import { authExchange } from '@urql/exchange-auth';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [
     dedupExchange,
     cacheExchange,

--- a/docs/advanced/authoring-exchanges.md
+++ b/docs/advanced/authoring-exchanges.md
@@ -68,7 +68,7 @@ result.
 import { createClient, dedupExchange, fetchExchange, cacheExchange } from 'urql';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [dedupExchange, cacheExchange, fetchExchange],
 });
 ```
@@ -80,7 +80,7 @@ global callback whenever it sees [a `CombinedError`](../basics/errors.md) on an 
 import { createClient, dedupExchange, fetchExchange, cacheExchange, errorExchange } from 'urql';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [
     dedupExchange,
     cacheExchange,

--- a/docs/advanced/persistence-and-uploads.md
+++ b/docs/advanced/persistence-and-uploads.md
@@ -152,7 +152,7 @@ import { createClient, dedupExchange, cacheExchange } from 'urql';
 import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [dedupExchange, cacheExchange, multipartFetchExchange],
 });
 ```

--- a/docs/advanced/subscriptions.md
+++ b/docs/advanced/subscriptions.md
@@ -16,7 +16,7 @@ To add support for subscriptions we need to add the `subscriptionExchange` to ou
 import { Client, defaultExchanges, subscriptionExchange } from 'urql';
 
 const client = new Client({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [
     ...defaultExchanges,
     subscriptionExchange({

--- a/docs/api/auth-exchange.md
+++ b/docs/api/auth-exchange.md
@@ -28,7 +28,7 @@ import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql'
 import { authExchange } from '@urql/exchange-auth';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [
     dedupExchange,
     cacheExchange,

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -204,7 +204,7 @@ properties you'll likely see some options that exist on the `Client` as well.
 | `fetchOptions`        | `?RequestInit \| (() => RequestInit)` | Additional `fetchOptions` that `fetch` in `fetchExchange` should use to make a request.                                         |
 | `fetch`               | `typeof fetch`                        | An alternative implementation of `fetch` that will be used by the `fetchExchange` instead of `window.fetch`                     |
 | `requestPolicy`       | `RequestPolicy`                       | An optional [request policy](../basics/document-caching.md#request-policies) that should be used specifying the cache strategy. |
-| `url`                 | `string`                              | The GraphQL endpoint                                                                                                            |
+| `url`                 | `string`                              | The GraphQL endpoint, when using GET you should use absolute url's                                                           |
 | `meta`                | `?OperationDebugMeta`                 | Metadata that is only available in development for devtools.                                                                    |
 | `suspense`            | `?boolean`                            | Whether suspense is enabled.                                                                                                    |
 | `preferGetMethod`     | `?boolean`                            | Instructs the `fetchExchange` to use HTTP GET for queries.                                                                      |

--- a/docs/api/execute-exchange.md
+++ b/docs/api/execute-exchange.md
@@ -28,7 +28,7 @@ import { createClient, dedupExchange, cacheExchange } from 'urql';
 import { executeExchange } from '@urql/exchange-execute';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [
     dedupExchange,
     cacheExchange,

--- a/docs/api/multipart-fetch-exchange.md
+++ b/docs/api/multipart-fetch-exchange.md
@@ -36,7 +36,7 @@ import { createClient, dedupExchange, cacheExchange } from 'urql';
 import { multipartFetchExchange } from '@urql/exchange-multipart-fetch';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [dedupExchange, cacheExchange, multipartFetchExchange],
 });
 ```

--- a/docs/api/refocus-exchange.md
+++ b/docs/api/refocus-exchange.md
@@ -26,7 +26,7 @@ import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql'
 import { refocusExchange } from '@urql/exchange-refocus';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [dedupExchange, refocusExchange(), cacheExchange, fetchExchange],
 });
 ```

--- a/docs/api/request-policy-exchange.md
+++ b/docs/api/request-policy-exchange.md
@@ -35,7 +35,7 @@ import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql'
 import { requestPolicyExchange } from '@urql/exchange-request-policy';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [
     dedupExchange,
     requestPolicyExchange({

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ extra information on how the GraphQL requests are executed.
 import { Client } from '@urql/core';
 
 new Client({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   requestPolicy: 'cache-first',
 });
 ```

--- a/exchanges/refocus/README.md
+++ b/exchanges/refocus/README.md
@@ -21,7 +21,7 @@ import { createClient, dedupExchange, cacheExchange, fetchExchange } from 'urql'
 import { refocusExchange } from '@urql/exchange-refocus';
 
 const client = createClient({
-  url: '/graphql',
+  url: 'http://localhost:3000/graphql',
   exchanges: [dedupExchange, refocusExchange(), cacheExchange, fetchExchange],
 });
 ```


### PR DESCRIPTION
## Summary

In `@urql/core` we don't support relative URL's anymore when using the `GET` method because we use the `URL` constructor.
