### PR TITLE
fix(vue): Fix immediate result by Client causing useQuery to fail

### DIFF
--- a/.changeset/afraid-islands-stare.md
+++ b/.changeset/afraid-islands-stare.md
@@ -1,0 +1,5 @@
+---
+'@urql/vue': patch
+---
+
+Fix an issue that caused `useQuery` to fail for promise-based access, if a result is delivered by the `Client` immediately.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@actions/artifact": "^0.5.1",
     "@babel/core": "^7.18.10",
+    "@babel/plugin-transform-block-scoping": "^7.18.9",
     "@babel/plugin-transform-react-jsx": "^7.18.10",
     "@changesets/cli": "^2.16.0",
     "@changesets/get-github-info": "0.5.0",

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -4,7 +4,7 @@ import { DocumentNode } from 'graphql';
 
 import { WatchStopHandle, Ref, ref, watchEffect, reactive, isRef } from 'vue';
 
-import { Source, pipe, subscribe, onEnd } from 'wonka';
+import { Subscription, Source, pipe, subscribe, onEnd } from 'wonka';
 
 import {
   Client,
@@ -138,9 +138,10 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
       return {
         ...response,
         then(onFulfilled, onRejected) {
+          let sub: Subscription | void;
           return new Promise<UseQueryState<T, V>>(resolve => {
             let hasResult = false;
-            const sub = pipe(
+            sub = pipe(
               s,
               subscribe(() => {
                 if (!state.fetching.value && !state.stale.value) {
@@ -203,10 +204,11 @@ export function callUseQuery<T = any, V extends AnyVariables = AnyVariables>(
   const response: UseQueryResponse<T, V> = {
     ...state,
     then(onFulfilled, onRejected) {
+      let sub: Subscription | void;
       const promise = new Promise<UseQueryState<T, V>>(resolve => {
         if (!source.value) return resolve(state);
         let hasResult = false;
-        const sub = pipe(
+        sub = pipe(
           source.value,
           subscribe(() => {
             if (!state.fetching.value && !state.stale.value) {

--- a/scripts/rollup/plugins.js
+++ b/scripts/rollup/plugins.js
@@ -60,6 +60,7 @@ export const makePlugins = () => [
     exclude: 'node_modules/**',
     presets: [],
     plugins: [
+      '@babel/plugin-transform-block-scoping',
       babelPluginTransformDebugTarget,
       babelPluginTransformPipe,
       babelPluginTransformInvariant,

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,6 +673,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.13.0"
 
+"@babel/plugin-transform-block-scoping@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.18.9.tgz#f9b7e018ac3f373c81452d6ada8bd5a18928926d"
+  integrity sha512-5sDIJRV1KtQVEbt/EIBwGy4T01uYIo4KRB3VUqzkhrAIOGx7AoctL9+Ux88btY0zXdDyPJ9mW+bg+v+XEkGmtw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.9"
+
 "@babel/plugin-transform-classes@^7.12.1", "@babel/plugin-transform-classes@^7.13.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.13.0.tgz#0265155075c42918bf4d3a4053134176ad9b533b"


### PR DESCRIPTION
Resolve #2628

## Summary

We previously transpiled `let`/`const` to `var` as a standard transpilation by Buble, since it's an extremely safe transpilation step. However, this altered some of the characteristics of the code.
Specifically, it caused an issue (and I'm not sure why TypeScript didn't object) where we forgot to instantiate the variable before calling it inside a closure passed to a function that may be immediately invoked.

Specifically, if our Vue binding's `useQuery` hook was used with its promise-based (suspense) feature, and a result was delivered synchronously it'd be unable to call `sub.unsubscribe`.

I've readded the transpilation step while also fixing the code, since, as I said, it's very safe and simply sidesteps these issues entirely. But I'm refraining from bumping any versions on other packages for now.

## Set of changes

- Add const/let transpilation plugin to Rollup's babel step
- Declare `subscription` variables separately in the Vue binding's `useQuery`
