### PR TITLE
fix(core): prevent inputting undefined overriding defaults

### DIFF
--- a/.changeset/quick-crabs-tickle.md
+++ b/.changeset/quick-crabs-tickle.md
@@ -1,0 +1,6 @@
+---
+"@urql/core": patch
+---
+
+fix setting a client default requestPolicy, we set `context.requestPolicy: undefined`
+from our bindings which makes a spread override the client-set default.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -289,6 +289,7 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         _instance: kind === 'mutation' ? [] : undefined,
         ...baseOpts,
         ...opts,
+        requestPolicy: opts.requestPolicy || baseOpts.requestPolicy,
         suspense: opts.suspense || (opts.suspense !== false && client.suspense),
       });
     },


### PR DESCRIPTION
Resolves #2631 

## Summary

Currently we input `requestPolicy: undefined` from the bindings making it override client-set defaults.

## Set of changes

- explicitly set cache-and-network
