### PR TITLE
fix(storybook): remove dependency on `react-urql`

### DIFF
--- a/.changeset/flat-plants-pull.md
+++ b/.changeset/flat-plants-pull.md
@@ -1,0 +1,5 @@
+---
+"@urql/storybook-addon": patch
+---
+
+remove dependency on `react-urql` from storybook exchange

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -39,6 +39,10 @@
     "prepare": "node ../../scripts/prepare/index.js",
     "prepublishOnly": "run-s clean build"
   },
+  "dependencies": {
+    "@urql/core": "^3.0.0",
+    "wonka": "^6.0.0"
+  },
   "devDependencies": {
     "@storybook/preact": ">=6.0.28",
     "@storybook/react": ">=6.0.28",

--- a/packages/storybook-addon/src/exchange.ts
+++ b/packages/storybook-addon/src/exchange.ts
@@ -1,4 +1,4 @@
-import { Exchange, makeResult } from 'urql';
+import { Exchange, makeResult } from '@urql/core';
 import { pipe, map, mergeMap, fromPromise, fromValue } from 'wonka';
 
 export const getStorybookExchange = <T extends { parameters: any }>(


### PR DESCRIPTION
## Summary

Currently we depend on `react-urql` in the storybook exchange, we should change this to `@urql/core` so we can allow for all integrations.

## Set of changes

- rename `urql` import to `@urql/core`
