### PR TITLE
fix(react-preact): variable types for render-props components

### DIFF
--- a/.changeset/selfish-wolves-poke.md
+++ b/.changeset/selfish-wolves-poke.md
@@ -1,0 +1,6 @@
+---
+'@urql/preact': patch
+'urql': patch
+---
+
+Update generics for components

--- a/packages/preact-urql/src/components/Mutation.ts
+++ b/packages/preact-urql/src/components/Mutation.ts
@@ -26,9 +26,10 @@ export interface MutationState<
   ) => Promise<OperationResult<Data, Variables>>;
 }
 
-export function Mutation<Data = any, Variables = any>(
-  props: MutationProps<Data, Variables>
-): VNode<any> {
+export function Mutation<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(props: MutationProps<Data, Variables>): VNode<any> {
   const mutation = useMutation<Data, Variables>(props.query);
   return props.children({ ...mutation[0], executeMutation: mutation[1] });
 }

--- a/packages/preact-urql/src/components/Query.ts
+++ b/packages/preact-urql/src/components/Query.ts
@@ -16,9 +16,10 @@ export interface QueryState<
   executeQuery: (opts?: Partial<OperationContext>) => void;
 }
 
-export function Query<Data = any, Variables = any>(
-  props: QueryProps<Data, Variables>
-): VNode<any> {
+export function Query<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(props: QueryProps<Data, Variables>): VNode<any> {
   const query = useQuery<Data, Variables>(props);
   return props.children({ ...query[0], executeQuery: query[1] });
 }

--- a/packages/react-urql/src/components/Mutation.ts
+++ b/packages/react-urql/src/components/Mutation.ts
@@ -26,9 +26,10 @@ export interface MutationState<
   ) => Promise<OperationResult<Data, Variables>>;
 }
 
-export function Mutation<Data = any, Variables = any>(
-  props: MutationProps<Data, Variables>
-): ReactElement<any> {
+export function Mutation<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(props: MutationProps<Data, Variables>): ReactElement<any> {
   const mutation = useMutation<Data, Variables>(props.query);
   return props.children({ ...mutation[0], executeMutation: mutation[1] });
 }

--- a/packages/react-urql/src/components/Query.ts
+++ b/packages/react-urql/src/components/Query.ts
@@ -16,9 +16,10 @@ export interface QueryState<
   executeQuery: (opts?: Partial<OperationContext>) => void;
 }
 
-export function Query<Data = any, Variables = any>(
-  props: QueryProps<Data, Variables>
-): ReactElement<any> {
+export function Query<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(props: QueryProps<Data, Variables>): ReactElement<any> {
   const query = useQuery<Data, Variables>(props);
   return props.children({ ...query[0], executeQuery: query[1] });
 }


### PR DESCRIPTION
Resolves #2662 

## Summary

We hadn't updated the Variables for the render-props components, this equalizes them to their hook equivalent.

Follow up to #2607
