### PR TITLE
fix(core): variable types for makeOperation

### DIFF
--- a/.changeset/wet-nails-develop.md
+++ b/.changeset/wet-nails-develop.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix variable types in core makeOperation

--- a/packages/core/src/utils/operation.ts
+++ b/packages/core/src/utils/operation.ts
@@ -1,17 +1,24 @@
 import {
+  AnyVariables,
   GraphQLRequest,
   Operation,
   OperationContext,
   OperationType,
 } from '../types';
 
-function makeOperation<Data = any, Variables = object>(
+function makeOperation<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
   kind: OperationType,
   request: GraphQLRequest<Data, Variables>,
   context: OperationContext
 ): Operation<Data, Variables>;
 
-function makeOperation<Data = any, Variables = object>(
+function makeOperation<
+  Data = any,
+  Variables extends AnyVariables = AnyVariables
+>(
   kind: OperationType,
   request: Operation<Data, Variables>,
   context?: OperationContext


### PR DESCRIPTION
Related to https://github.com/pmndrs/jotai/issues/1384

## Summary

Fixes the `makeOperation` types to adhere to the changes made in #2607
