### PR TITLE
fix(react): set `fetching` to the lack or presence of `source`

### DIFF
--- a/.changeset/tame-crews-grab.md
+++ b/.changeset/tame-crews-grab.md
@@ -1,0 +1,5 @@
+---
+"urql": patch
+---
+
+Fix `fetching` going to `false` after changing variables in a subscription

--- a/packages/react-urql/src/hooks/useSubscription.ts
+++ b/packages/react-urql/src/hooks/useSubscription.ts
@@ -114,7 +114,7 @@ export function useSubscription<
       return pipe(
         state[0],
         onEnd(() => {
-          updateResult({ fetching: false });
+          updateResult({ fetching: !!source });
         }),
         subscribe(updateResult)
       ).unsubscribe;


### PR DESCRIPTION
Resolves #2648 

## Summary

When we changes `variables` `onEnd` seems to fire later than us establishing the new connection, this means we set `fetching` to a truthy value and then switch it off as we assume that we aren't fetching anymore.

Now when a subscription ends we check whether there is a new source already and base our fetching state off that, [sandbox](https://codesandbox.io/s/kind-currying-8v8yvw?file=/src/components/Messages.js)

CC @elias-pap

## Set of changes

- rely on `source` to flip `fetching` state