### PR TITLE
Fix a docs link in comparison.md

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -139,7 +139,7 @@ writing your own logic for offline caching, which can be particularly successful
 guarantees that the cache makes.
 
 Relay does in fact have similar guarantees as [`urql`'s Commutativity
-Guarantees](./graphcache/under-the-hood.md),
+Guarantees](./graphcache/normalized-caching/#deterministic-cache-updates),
 which are more evident when applying list updates out of order under more complex network
 conditions.
 


### PR DESCRIPTION
Updated to match the [the redirect](https://github.com/FormidableLabs/urql/blob/53dec134328be48e25ba78e54b21acfe8df5cb42/packages/site/static.config.js#L84-L87) — also added the #anchor for the most pertinent section for the link.