### PR TITLE
docs(storybook): fix wrong function name

### DIFF
--- a/packages/storybook-addon/README.md
+++ b/packages/storybook-addon/README.md
@@ -66,13 +66,15 @@ MyStory.parameters = {
 Returning data for multiple queries (conditional response).
 
 ```tsx
+import { getOperationName } from 'urql';
+
 MyStory.parameters = {
   urql: op => {
-    if (getQueryName(op.query) === 'GetUser') {
+    if (getOperationName(op.query) === 'GetUser') {
       return { data: { user: { id: 1234, name: 'Steve' } } };
     }
 
-    if (getQueryName(op.query) === 'GetFeed') {
+    if (getOperationName(op.query) === 'GetFeed') {
       return { data: { feed: [{ id: 1, title: 'Fake news' }] } };
     }
   },


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->

The README for `@urql/storybook-addon` uses the `getQueryName` function, but urql does not seem to export it.
For clarity, I have replaced it with the `getOperationName` function that urql exports.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
- README of `@urql/storybook-addon`
