### PR TITLE
fix(docs): remove `query` ref from svelte docs

### DIFF
--- a/docs/basics/svelte.md
+++ b/docs/basics/svelte.md
@@ -204,8 +204,6 @@ model as well and cause the `query` utility to start a new operation.
     variables: { from, limit }
   );
 
-  query(todos);
-
   function nextPage() {
     from = from + 10
   }


### PR DESCRIPTION
## Summary

Had a leftover from the old API