### PR TITLE
fix(core): Fix ssrExchange dropping network-only operations

### DIFF
--- a/.changeset/beige-paws-draw.md
+++ b/.changeset/beige-paws-draw.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix `ssrExchange` bug which prevented `staleWhileRevalidate` from sending off requests as network-only requests, and caused unrelated `network-only` operations to be dropped.

--- a/packages/core/src/exchanges/ssr.ts
+++ b/packages/core/src/exchanges/ssr.ts
@@ -126,7 +126,10 @@ export const ssrExchange = (params: SSRExchangeParams = {}): SSRExchange => {
     let forwardedOps$ = pipe(
       sharedOps$,
       filter(
-        operation => !data[operation.key] || !!data[operation.key]!.hasNext
+        operation =>
+          !data[operation.key] ||
+          !!data[operation.key]!.hasNext ||
+          operation.context.requestPolicy === 'network-only'
       ),
       forward
     );


### PR DESCRIPTION
Resolve #2689
Resolve #2588

## Summary

This fixes a not so subtle bug which caused all `network-only` operations to be dropped.
Essentially, this prevented `staleWhileRevalidate` from working on the `ssrExchange` itself, but also prevented other `network-only` operations from being forwarded to the next exchange at all, which caused no operation from being sent when this policy was used.

## Set of changes

- Add missing `network-only` exception to forwarded operations
