### PR TITLE
fix(graphcache): consistent __typename addition

### DIFF
--- a/.changeset/hot-turkeys-walk.md
+++ b/.changeset/hot-turkeys-walk.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Ensure we are consistent in returning `__typename` in results

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -158,7 +158,19 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
   const operationResultFromCache = (
     operation: Operation
   ): OperationResultWithMeta => {
-    const result = query(store, operation, results.get(operation.key));
+    const result = query(
+      store,
+      makeOperation(
+        operation.kind,
+        {
+          key: operation.key,
+          query: formatDocument(operation.query),
+          variables: operation.variables,
+        },
+        operation.context
+      ),
+      results.get(operation.key)
+    );
     const cacheOutcome: CacheOutcome = result.data
       ? !result.partial
         ? 'hit'


### PR DESCRIPTION
## Summary

While investigating https://github.com/FormidableLabs/urql/issues/2701 I noticed that we invalidate the result for a cache-hit due to not having `__typename` there, on a closer look this is because when we [`foward`](https://github.com/FormidableLabs/urql/blob/main/exchanges/graphcache/src/cacheExchange.ts#L134) we add the `__typename` in `formatDocument`, this is also returned to the user because we have changed the operation itself, but when we get a result from cache we use the supplied query which might be missing these `__typename` additions. This operation is basically free because we have the operation cached either way.

## Set of changes

- add `__typename` consistently
