### PR TITLE
fix(graphcache): infinite loop in dependent queries

### DIFF
--- a/.changeset/sixty-years-judge.md
+++ b/.changeset/sixty-years-judge.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix case where dependent operations would keep re-triggering each other because their dependencies overlapped with differnt operation-keys

--- a/exchanges/graphcache/default-storage/package.json
+++ b/exchanges/graphcache/default-storage/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@urql/core": ">=2.5.0",
-    "wonka": "^4.0.14"
+    "@urql/core": ">=3.0.0",
+    "wonka": "^6.0.0"
   }
 }

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -97,7 +97,8 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
             requestedRefetch.delete(key);
             policy = 'cache-and-network';
           }
-          op.context = { ...op.context, reexectued: true };
+          if (operation.kind === 'query')
+            op.context = { ...op.context, reexectued: true };
           client.reexecuteOperation(toRequestPolicy(op, policy));
         }
       }


### PR DESCRIPTION
## Summary

When we have a data relationship between x queries we currently end up re-triggering them when we have a cache-miss, this because of how we collect `dependencies` and `reexecute` them. To circumvent this we keep track of the operation that creates these reexecutions and we keep track of the ones that were targeted by these reexecuting origins.

This means that A can trigger B but B can't re-trigger A if B is a cache-miss. 