### PR TITLE
fix(core): Fix OperationContext._identity not allowing operation contexts to be deeply cloned

### DIFF
--- a/.changeset/stupid-rules-mix.md
+++ b/.changeset/stupid-rules-mix.md
@@ -1,5 +1,7 @@
 ---
 '@urql/core': patch
+'@urql/exchange-graphcache': patch
 ---
 
 Fix operation identities preventing users from deeply cloning operation contexts. Instead, we now use a client-wide counter (rolling over as needed).
+While this changes an internal data structure in `@urql/core` only, this change also affects the `offlineExchange` in `@urql/exchange-graphcache` due to it relying on the identity being previously an object rather than an integer.

--- a/.changeset/stupid-rules-mix.md
+++ b/.changeset/stupid-rules-mix.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix operation identities preventing users from deeply cloning operation contexts. Instead, we now use a client-wide counter (rolling over as needed).

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -159,6 +159,7 @@ describe('offline', () => {
   updateAuthor {
     id
     name
+    __typename
   }
 }`,
         variables: {},
@@ -279,6 +280,7 @@ describe('offline', () => {
   updateAuthor {
     id
     name
+    __typename
   }
 }`,
         variables: {},
@@ -288,13 +290,5 @@ describe('offline', () => {
     flush!();
     expect(reexecuteOperation).toHaveBeenCalledTimes(1);
     expect((reexecuteOperation.mock.calls[0][0] as any).key).toEqual(1);
-    expect((reexecuteOperation.mock.calls[0][0] as any).query).toEqual(gql`
-      mutation {
-        updateAuthor {
-          id
-          name
-        }
-      }
-    `);
   });
 });

--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -5,6 +5,7 @@ import {
   Operation,
   OperationResult,
 } from '@urql/core';
+import { print } from 'graphql';
 
 import { pipe, map, makeSubject, tap, publish } from 'wonka';
 import { offlineExchange } from './offlineExchange';
@@ -290,5 +291,16 @@ describe('offline', () => {
     flush!();
     expect(reexecuteOperation).toHaveBeenCalledTimes(1);
     expect((reexecuteOperation.mock.calls[0][0] as any).key).toEqual(1);
+    expect(print((reexecuteOperation.mock.calls[0][0] as any).query)).toEqual(
+      print(gql`
+        mutation {
+          updateAuthor {
+            id
+            name
+            __typename
+          }
+        }
+      `)
+    );
   });
 });

--- a/exchanges/graphcache/src/offlineExchange.ts
+++ b/exchanges/graphcache/src/offlineExchange.ts
@@ -1,4 +1,4 @@
-import { pipe, merge, makeSubject, share, filter, tap } from 'wonka';
+import { pipe, merge, makeSubject, share, filter } from 'wonka';
 import { print, SelectionNode } from 'graphql';
 
 import {
@@ -124,16 +124,9 @@ export const offlineExchange = <C extends Partial<CacheExchangeOpts>>(
             isOfflineError(res.error) &&
             isOptimisticMutation(optimisticMutations, res.operation)
           ) {
-            failedQueue.push(
-              incomingMutations.get(res.operation.context._instance as []) ||
-                res.operation
-            );
+            failedQueue.push(res.operation);
             updateMetadata();
             return false;
-          }
-
-          if (res.operation.kind === 'mutation' && !res.error) {
-            incomingMutations.delete(res.operation.context._instance as []);
           }
 
           return true;
@@ -171,17 +164,8 @@ export const offlineExchange = <C extends Partial<CacheExchangeOpts>>(
       forward,
     });
 
-    const incomingMutations = new WeakMap<[], Operation>();
     return ops$ => {
-      const sharedOps$ = pipe(
-        ops$,
-        tap(operation => {
-          if (operation.kind === 'mutation') {
-            incomingMutations.set(operation.context._instance as [], operation);
-          }
-        }),
-        share
-      );
+      const sharedOps$ = pipe(ops$, share);
 
       const opsAndRebound$ = merge([reboundOps$, sharedOps$]);
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -33,6 +33,7 @@ import {
   ExchangeInput,
   GraphQLRequest,
   Operation,
+  OperationInstance,
   OperationContext,
   OperationResult,
   OperationType,
@@ -148,6 +149,8 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
   if (process.env.NODE_ENV !== 'production' && !opts.url) {
     throw new Error('You are creating an urql-client without a url.');
   }
+
+  let ids = 0;
 
   const replays = new Map<number, OperationResult>();
   const active: Map<number, Source<OperationResult>> = new Map();
@@ -286,7 +289,10 @@ export const Client: new (opts: ClientOptions) => Client = function Client(
         );
       }
       return makeOperation(kind, request, {
-        _instance: kind === 'mutation' ? [] : undefined,
+        _instance:
+          kind === 'mutation'
+            ? ((ids = (ids + 1) | 0) as OperationInstance)
+            : undefined,
         ...baseOpts,
         ...opts,
         requestPolicy: opts.requestPolicy || baseOpts.requestPolicy,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,10 +61,13 @@ export interface OperationDebugMeta {
   startTime?: number;
 }
 
+/** A unique marker that marks the operation's identity when multiple mutation operations with identical keys are issued. */
+export type OperationInstance = number & { readonly _opaque: unique symbol };
+
 /** Additional metadata passed to [exchange]{@link Exchange} functions. */
 export interface OperationContext {
   [key: string]: any;
-  readonly _instance?: [] | undefined;
+  readonly _instance?: OperationInstance | undefined;
   additionalTypenames?: string[];
   fetch?: typeof fetch;
   fetchOptions?: RequestInit | (() => RequestInit);


### PR DESCRIPTION
Resolve #2726

## Summary

While we don't imply or implicitly disallow cloning `OperationContext`, and it's definitely not expected and encouraged, if it's done, it can have some unexpected consequences.

Specifically, if an `OperationContext` is deeply cloned rather than spread, then `OperationContext._identity` is destroyed. This leads to the `Client` not being able to find the right mutation result for a given operation with an unknown `_identity`.

Previously, we assigned identities with an empty array (`[]`). There are alternatives, of course, like `{}`, symbols, functions, etc. But all may be instances that will be swapped out by users.
Instead, we now assign a numeric ID to the field, which is marked as an opaque type in TypeScript. This is a rolling-over 32-bit counter, which is sufficient to prevent mutation results from being confused.

**More importantly, this change makes `OperationContext` serializable in all cases again.**

## Set of changes

- Replace `OperationContext._identity` with a `number` ID based on a 32-bit roll-over
