### PR TITLE
chore(docs): update comparison chart with Apollo Client defer support

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -51,7 +51,7 @@ All features are marked to indicate the following:
 | Persisted Queries                          | ✅ `@urql/exchange-persisted-fetch` | ✅ `apollo-link-persisted-queries`            | ✅                             |
 | Batched Queries                            | 🛑                                  | ✅ `apollo-link-batch-http`                   | 🟡 `react-relay-network-layer` |
 | Live Queries                               | 🛑                                  | 🛑                                            | ✅                             |
-| Defer & Stream Directives                  | ✅                                  | 🛑                                            | 🟡 (unreleased)                |
+| Defer & Stream Directives                  | ✅                                  | ✅ / 🛑 (`@defer` is supported in >=3.7.0, `@stream` is not yet supported)                                            | 🟡 (unreleased)                |
 | Switching to `GET` method                  | ✅                                  | ✅                                            | 🟡 `react-relay-network-layer` |
 | File Uploads                               | ✅ `@urql/exchange-multipart-fetch` | 🟡 `apollo-upload-client`                     | 🛑                             |
 | Retrying Failed Queries                    | ✅ `@urql/exchange-retry`           | ✅ `apollo-link-retry`                        | ✅ `DefaultNetworkLayer`       |


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Hi there! This PR contains a small update to the comparison chart to reflect that Apollo Client now supports the `@defer` directive as of v3.7.0, though `@stream` is not yet supported ([release notes](https://github.com/apollographql/apollo-client/releases/tag/v3.7.0)).

Happy to format it differently - I went with ✅/🛑 to communicate both statuses since they're contained in a single cell.

## Set of changes

This is a docs-only change.
