### PR TITLE
fix(graphcache): Use original operation document when updating the cache

### DIFF
--- a/.changeset/good-kids-sleep.md
+++ b/.changeset/good-kids-sleep.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Preserve the original `DocumentNode` AST when updating the cache, to prevent results after a network request from differing and breaking referential equality due to added `__typename` fields.

--- a/exchanges/graphcache/src/cacheExchange.test.ts
+++ b/exchanges/graphcache/src/cacheExchange.test.ts
@@ -59,10 +59,23 @@ describe('data dependencies', () => {
       query: queryOne,
     });
 
+    const expected = {
+      __typename: 'Query',
+      author: {
+        id: '123',
+        name: 'Author',
+        __typename: 'Author',
+      },
+      unrelated: {
+        id: 'unrelated',
+        __typename: 'Unrelated',
+      },
+    };
+
     const response = jest.fn(
       (forwardOp: Operation): OperationResult => {
         expect(forwardOp.key).toBe(op.key);
-        return { operation: forwardOp, data: queryOneData };
+        return { operation: forwardOp, data: expected };
       }
     );
 
@@ -85,10 +98,14 @@ describe('data dependencies', () => {
       'operation.context.meta.cacheOutcome',
       'miss'
     );
+    expect(result.mock.calls[0][0].data).toEqual(expected);
     expect(result.mock.calls[1][0]).toHaveProperty(
       'operation.context.meta.cacheOutcome',
       'hit'
     );
+    expect(result.mock.calls[1][0].data).toEqual(expected);
+
+    expect(result.mock.calls[1][0].data).toBe(result.mock.calls[0][0].data);
   });
 
   it('respects cache-only operations', () => {


### PR DESCRIPTION
Resolve #2701

## Summary

This prevents us from using the formatted GraphQL document, as per the output of `@urql/core`'s `formatDocument`, in Graphcache's later stage to query data against the cache. This is problematic because it changes the shape of data and hence disallows us to preserve referential equality of any given data.

Instead, we now use existing data structures to retrieve the original operation before it's been forwarded to the next exchanges.

## Set of changes

- Retrieve the original operation when writing a query result to the cache
