### PR TITLE
fix(graphcache): Fix partial optimistic mutation results

### DIFF
--- a/.changeset/lovely-monkeys-wink.md
+++ b/.changeset/lovely-monkeys-wink.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix optimistic mutations containing partial results (`undefined` fields), which previously actually caused a hidden cache miss, which may then affect a subsequent non-optimistic mutation result.

--- a/exchanges/graphcache/src/operations/write.ts
+++ b/exchanges/graphcache/src/operations/write.ts
@@ -259,7 +259,9 @@ const writeSelection = (
       // Skip typename fields and assume they've already been written above
       fieldName === '__typename' ||
       // Fields marked as deferred that aren't defined must be skipped
-      (fieldValue === undefined && deferRef.current)
+      // Otherwise, we also ignore undefined values in optimistic updaters
+      (fieldValue === undefined &&
+        (deferRef.current || (ctx.optimistic && !isRoot)))
     ) {
       continue;
     }


### PR DESCRIPTION
Resolve #2701

(NOTE: This is a missing piece that's also required to fix a new optimistic mutation case)

## Summary

This adds a missing piece of logic that we forgot to update in #2616, which allows optimistic mutations to not only be based on the field name (not alias) and nested functions, but also to return partial results.

Previously to this fix, partial mutation updates would cause cache misses by deleting cache values instead of skipping them.

## Set of changes

- Skip `undefined` fields on optimistic mutation results
