### PR TITLE
fix(graphcache): Fix typo in results cache

### DIFF
--- a/.changeset/twelve-beds-appear.md
+++ b/.changeset/twelve-beds-appear.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Fix referential equality preservation in Graphcache failing after API results, due to a typo writing the API result rather than the updated cache result.

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -233,7 +233,7 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
         // Collect the query's dependencies for future pending operation updates
         queryDependencies = queryResult.dependencies;
         collectPendingOperations(pendingOperations, queryDependencies);
-        results.set(operation.key, result.data);
+        results.set(operation.key, data);
       }
     } else {
       noopDataState(store.data, operation.key);


### PR DESCRIPTION
Resolve #2701

## Summary

This fixes a small typo that causes the results cache to be updated with the API result rather than the updated cache result

## Set of changes

- Fix typo
