### PR TITLE
fix(graphcache): case where a mutation would also be counted in the loop-protection

### DIFF
--- a/.changeset/flat-feet-look.md
+++ b/.changeset/flat-feet-look.md
@@ -1,0 +1,5 @@
+---
+"@urql/exchange-graphcache": patch
+---
+
+Fix case where a mutation would also be counted in the loop-protection, this prevented partial queries from initiating refetches

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -103,7 +103,9 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
     // Upon completion, all dependent operations become reexecuting operations, preventing
     // them from reexecuting prior operations again, causing infinite loops
     const _reexecutingOperations = reexecutingOperations;
-    (reexecutingOperations = dependentOperations).add(operation.key);
+    if (operation.kind === 'query') { 
+      (reexecutingOperations = dependentOperations).add(operation.key);
+    }
     (dependentOperations = _reexecutingOperations).clear();
   };
 

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -103,7 +103,7 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
     // Upon completion, all dependent operations become reexecuting operations, preventing
     // them from reexecuting prior operations again, causing infinite loops
     const _reexecutingOperations = reexecutingOperations;
-    if (operation.kind === 'query') { 
+    if (operation.kind === 'query') {
       (reexecutingOperations = dependentOperations).add(operation.key);
     }
     (dependentOperations = _reexecutingOperations).clear();


### PR DESCRIPTION
## Summary

Currently we initiate loop protection for all operations, this should actually only happen for queries reexecuting one another