### PR TITLE
fix(core): build debug target correctly

### DIFF
--- a/.changeset/quiet-turkeys-brake.md
+++ b/.changeset/quiet-turkeys-brake.md
@@ -1,0 +1,5 @@
+---
+'@urql/core': patch
+---
+
+Fix case where our transform-debug-target babel plugin would override the root dispatchDebug in `compose.ts` with the latest found exchange, in this case `fetchExchange`

--- a/scripts/babel/transform-debug-target.js
+++ b/scripts/babel/transform-debug-target.js
@@ -21,14 +21,14 @@ const plugin = ({ template, types: t }) => {
           if (/Exchange$/i.test(exportName)) name = exportName;
         }
       },
-      CallExpression(path) {
+      CallExpression(path, meta) {
         if (
           !path.node[visited] &&
           path.node.callee &&
           path.node.callee.name === dispatchProperty
         ) {
           path.node[visited] = true;
-          if (t.isObjectExpression(path.node.arguments[0])) {
+          if (t.isObjectExpression(path.node.arguments[0]) && !meta.filename.endsWith('compose.ts')) {
             path.node.arguments[0].properties.push(
               t.objectProperty(
                 t.stringLiteral('source'),


### PR DESCRIPTION
Resolves #2690 

## Summary

When leveraging `transform-debug-target`  we fill in the `source` everywhere, this does not work for the `compose.ts` file as it's not an exchange. The bug is caused by us taking the latest transformed exchange and pushing `source: name` into the object invocation, resulting in [this](https://www.runpkg.com/?@urql/core@3.0.4/dist/urql-core.js#689). This PR effectively excludes `compose.ts` and hence fixes our future builds.
