### PR TITLE
fix(graphcache): avoid removing subscription layers

### DIFF
--- a/.changeset/lucky-terms-greet.md
+++ b/.changeset/lucky-terms-greet.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Ensure we aren't eagerly removing layers that are caused by subscriptions

--- a/exchanges/graphcache/src/store/data.test.ts
+++ b/exchanges/graphcache/src/store/data.test.ts
@@ -499,6 +499,27 @@ describe('deferred changes', () => {
     expect(data.optimisticOrder).toEqual([]);
   });
 
+  it('does not erase data from a prior deferred layer when updating it', () => {
+    // initially it's unknown whether a layer is deferred
+    InMemoryData.reserveLayer(data, 1, true);
+    InMemoryData.reserveLayer(data, 2, true);
+
+    InMemoryData.initDataState('write', data, 2);
+    InMemoryData.writeRecord('Query', 'index', 2);
+    InMemoryData.clearDataState();
+
+    InMemoryData.initDataState('read', data, null);
+    expect(InMemoryData.readRecord('Query', 'index')).toBe(2);
+
+    // A subsequent reserve layer call should not erase the layer
+    InMemoryData.reserveLayer(data, 2, true);
+    InMemoryData.initDataState('read', data, null);
+    expect(InMemoryData.readRecord('Query', 'index')).toBe(2);
+
+    // The layers must not be squashed
+    expect(data.optimisticOrder).toEqual([2, 1]);
+  });
+
   it('keeps a deferred layer around even if it is the lowest', () => {
     // initially it's unknown whether a layer is deferred
     InMemoryData.reserveLayer(data, 1);

--- a/exchanges/graphcache/src/store/data.ts
+++ b/exchanges/graphcache/src/store/data.ts
@@ -535,7 +535,7 @@ export const reserveLayer = (
 
   let index = data.optimisticOrder.indexOf(layerKey);
   if (index > -1) {
-    if (hasNext || !data.commutativeKeys.has(layerKey)) {
+    if (!data.commutativeKeys.has(layerKey) && !hasNext) {
       data.optimisticOrder.splice(index, 1);
       // Protect optimistic layers from being turned into non-optimistic layers
       // while preserving optimistic data


### PR DESCRIPTION
Resolve #2766

## Summary

Previously we included subscriptions in the logic we use to layer when a result has more results coming in due to `@stream` or `@defer`. We forgot to port this line over so when we are dealing with a result that isn't optimistic but comes from a subscription we erroneously removed the previous to-be squashed layer.
