### PR TITLE
fix(graphcache): set operation when updating the cache with a result

### DIFF
--- a/.changeset/pink-melons-joke.md
+++ b/.changeset/pink-melons-joke.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-graphcache': patch
+---
+
+Set operations when updating the cache with a result

--- a/exchanges/graphcache/src/cacheExchange.ts
+++ b/exchanges/graphcache/src/cacheExchange.ts
@@ -254,6 +254,7 @@ export const cacheExchange = <C extends Partial<CacheExchangeOpts>>(
 
     // Update this operation's dependencies if it's a query
     if (queryDependencies) {
+      operations.set(operation.key, operation);
       updateDependencies(result.operation, queryDependencies);
     }
 


### PR DESCRIPTION
Resolves #2768 

## Summary

When we update the cache we aren't writing to the `operations` map anymore because we moved this setter from the `updateDependencies` loop to the relevant functions in https://github.com/FormidableLabs/urql/pull/2736.
