### PR TITLE
fix(execute): end iterator on teardown

### DIFF
--- a/.changeset/healthy-hornets-warn.md
+++ b/.changeset/healthy-hornets-warn.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-execute': patch
+---
+
+End iterator when teardown functions runs, previously it waited for one extra call to next, then ended the iterator


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR! However, if you're starting to work on a large
  change, it's best to make sure to open an issue first.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

<!-- What's the motivation of this change? What does it solve? -->
When using useSubscription, I expected that when the teardown function runs in exchange execute, the iterator would also end. But it made one call to next() and then ended the iterator. By adding iterator.return() to the teardown function, the iterator will not make any extra call to next() when the subscription ends.

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
- Call iterator.return() when teardown function runs in exhange execute