### PR TITLE
Pass-through the context to fetchBody

### DIFF
--- a/packages/core/src/internal/fetchOptions.ts
+++ b/packages/core/src/internal/fetchOptions.ts
@@ -5,7 +5,7 @@ import {
   extractFiles,
 } from '../utils';
 
-import { AnyVariables, GraphQLRequest, Operation } from '../types';
+import { AnyVariables, Operation } from '../types';
 
 /** Abstract definition of the JSON data sent during GraphQL HTTP POST requests. */
 export interface FetchBody {
@@ -24,7 +24,7 @@ export interface FetchBody {
 export function makeFetchBody<
   Data = any,
   Variables extends AnyVariables = AnyVariables
->(request: Omit<GraphQLRequest<Data, Variables>, 'key'>): FetchBody {
+>(request: Omit<Operation<Data, Variables>, 'key'>): FetchBody {
   const isAPQ =
     request.extensions &&
     request.extensions.persistedQuery &&
@@ -34,7 +34,7 @@ export function makeFetchBody<
     operationName: getOperationName(request.query),
     variables: request.variables || undefined,
     extensions: request.extensions,
-    context: request.context
+    context: request.context,
   };
 }
 


### PR DESCRIPTION
This enables runtime-customizable exchange handlers, this available in previous version but in the latest it doesn't seem to be available anymore. Let me know if this pattern was replaced, but I couldn't find a reference (or alternate way through debugging) .

## Summary
Allows for runtime-customizable exchanges in the framework (vue) versions, example of my use-case:
```ts
     ...
      subscriptionExchange({
        forwardSubscription: (request) => {
          if (request.context.endpoint === 'Hasura') {
            // graphql-ws usage
            const input = { ...request, query: request.query || '' };
            return {
              subscribe(sink) {
                const unsubscribe = Hasura.subscribe(input, sink);
                return { unsubscribe };
              },
            };
          } else if (request.context.endpoint === 'dGraph') {
            // subscriptions-transport-ws usage
            return dGraph.request(request)
          }
        },
      }),
```

```ts
const {fetching: fetchingUpdate, data: lastUpdateWorkplaceEvents, isPaused, pause, resume} = useOnWorkplaceEventUpdateSubscription({context: {endpoint: 'dGraph'}});
```
<!-- What's the motivation of this change? What does it solve? -->

## Set of changes
* Passed through the context argument to the fetchBody, this was the behavior in certain prior version iirc

EDIT: it seems I misread the debugger, I'll edit it if it's still possible