### PR TITLE
exchanges/graphcache: add rootFields option

### DIFF
--- a/exchanges/graphcache/src/store/store.ts
+++ b/exchanges/graphcache/src/store/store.ts
@@ -75,9 +75,11 @@ export class Store<
       ? new Set(opts.globalIDs)
       : !!opts.globalIDs;
 
-    let queryName = 'Query';
-    let mutationName = 'Mutation';
-    let subscriptionName = 'Subscription';
+    let queryName = (opts.rootFields && opts.rootFields.query) || 'Query';
+    let mutationName =
+      (opts.rootFields && opts.rootFields.mutation) || 'Mutation';
+    let subscriptionName =
+      (opts.rootFields && opts.rootFields.subscription) || 'Subscription';
     if (opts.schema) {
       const schema = buildClientSchema(opts.schema);
       queryName = schema.query || queryName;

--- a/exchanges/graphcache/src/types.ts
+++ b/exchanges/graphcache/src/types.ts
@@ -657,6 +657,18 @@ export type CacheExchangeOpts = {
    * @see {@link https://urql.dev/goto/docs/graphcache/offline} for the full Offline Support docs.
    */
   storage?: StorageAdapter;
+  /**
+   * Configures the default root type names, which are assumed to be `Query`,
+   * `Mutation`, and `Subscription`.
+   *
+   * When both `rootFields` and `schema` is set, `rootFields` value will be
+   * ignored.
+   */
+  rootFields?: {
+    query?: string;
+    mutation?: string;
+    subscription?: string;
+  };
 };
 
 /** Cache Resolver, which may resolve or replace data during cache reads.


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

Fixes #3821

## Set of changes

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->

Non-breaking change to `@urql/exchange-graphcache`:

- Adds a new, optional property to [CacheExchangeOpts](https://github.com/urql-graphql/urql/blob/046c6e5eacde0732429508cf86757f4af2122e58/exchanges/graphcache/src/types.ts#L540C13-L540C30) called `rootFields` that allows specifying these name overrides
- Updates [Store](https://github.com/urql-graphql/urql/blob/046c6e5eacde0732429508cf86757f4af2122e58/exchanges/graphcache/src/store/store.ts#L78-L80) to observe the new `rootFields` property, allowing it to still be overridden by `schema` (if provided).