### PR TITLE
Prevent caching errored queries in suspense

### DIFF
--- a/.changeset/dry-grapes-grow.md
+++ b/.changeset/dry-grapes-grow.md
@@ -1,0 +1,5 @@
+---
+'urql': patch
+---
+
+Prevent caching errors when resolving a suspending query

--- a/packages/react-urql/src/hooks/useQuery.ts
+++ b/packages/react-urql/src/hooks/useQuery.ts
@@ -238,7 +238,7 @@ export function useQuery<
       ? pipe(
           source,
           onPush(result => {
-            cache.set(request.key, result);
+            cache.set(request.key, result.error ? undefined : result);
           })
         )
       : source;
@@ -377,7 +377,7 @@ export function useQuery<
           ? pipe(
               client.executeQuery(request, context),
               onPush(result => {
-                cache.set(request.key, result);
+                cache.set(request.key, result.error ? undefined : result);
               })
             )
           : client.executeQuery(request, context);


### PR DESCRIPTION
Resolves #3826

## Summary

This prevents caching errors during suspending queries, one thing that sprung to mind while implementing this fix is that it's not strictly necessary to cache the results. This hinges on the premise of the user using a cache and not having any async exchanges before that cache though.

Another thing worth noting is that it looks like our cache-exchanges cache errors as well meaning that for a retry to happen we'd need an explicit network-only or cache-and-network type of fetch

## Set of changes

- Add guard for caching errored queries
