### PR TITLE
chore: update @react-native-async-storage/async-storage to version 2.0

### DIFF
--- a/.changeset/sweet-buses-invite.md
+++ b/.changeset/sweet-buses-invite.md
@@ -1,0 +1,5 @@
+---
+'@urql/storage-rn': patch
+---
+
+Add support for `@react-native-async-storage/async-storage` v2.0.0.

--- a/packages/storage-rn/package.json
+++ b/packages/storage-rn/package.json
@@ -49,12 +49,12 @@
     "prepublishOnly": "run-s clean build"
   },
   "peerDependencies": {
-    "@react-native-async-storage/async-storage": "^1.15.5",
+    "@react-native-async-storage/async-storage": "^1.15.5 || ^2.0.0",
     "@react-native-community/netinfo": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^11.0.0",
     "@urql/exchange-graphcache": ">=5.0.0"
   },
   "devDependencies": {
-    "@react-native-async-storage/async-storage": "^1.21.0",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "^11.2.1",
     "@urql/core": "workspace:*",
     "@urql/exchange-graphcache": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,8 +575,8 @@ importers:
   packages/storage-rn:
     devDependencies:
       '@react-native-async-storage/async-storage':
-        specifier: ^1.21.0
-        version: 1.21.0(react-native@0.75.3(@babel/core@7.28.3)(@babel/preset-env@7.13.15(@babel/core@7.28.3))(@types/react@18.3.8)(encoding@0.1.13)(react@18.3.1)(typescript@5.6.2))
+        specifier: ^2.2.0
+        version: 2.2.0(react-native@0.75.3(@babel/core@7.28.3)(@babel/preset-env@7.13.15(@babel/core@7.28.3))(@types/react@18.3.8)(encoding@0.1.13)(react@18.3.1)(typescript@5.6.2))
       '@react-native-community/netinfo':
         specifier: ^11.2.1
         version: 11.2.1(react-native@0.75.3(@babel/core@7.28.3)(@babel/preset-env@7.13.15(@babel/core@7.28.3))(@types/react@18.3.8)(encoding@0.1.13)(react@18.3.1)(typescript@5.6.2))
@@ -2298,10 +2298,10 @@ packages:
       react: 15.x || 16.x || 16.4.0-alpha.0911da3
       react-dom: 15.x || 16.x || 16.4.0-alpha.0911da3
 
-  '@react-native-async-storage/async-storage@1.21.0':
-    resolution: {integrity: sha512-JL0w36KuFHFCvnbOXRekqVAUplmOyT/OuCQkogo6X98MtpSaJOKEAeZnYO8JB0U/RIEixZaGI5px73YbRm/oag==}
+  '@react-native-async-storage/async-storage@2.2.0':
+    resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
     peerDependencies:
-      react-native: ^0.0.0-0 || >=0.60 <1.0
+      react-native: ^0.0.0-0 || >=0.65 <1.0
 
   '@react-native-community/cli-clean@14.1.0':
     resolution: {integrity: sha512-/C4j1yntLo6faztNgZnsDtgpGqa6j0+GYrxOY8LqaKAN03OCnoeUUKO6w78dycbYSGglc1xjJg2RZI/M2oF2AA==}
@@ -12685,14 +12685,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -12714,7 +12714,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -13159,7 +13159,7 @@ snapshots:
       react-dom: 16.14.0(react@16.14.0)
       react-lifecycles-compat: 3.0.4
 
-  '@react-native-async-storage/async-storage@1.21.0(react-native@0.75.3(@babel/core@7.28.3)(@babel/preset-env@7.13.15(@babel/core@7.28.3))(@types/react@18.3.8)(encoding@0.1.13)(react@18.3.1)(typescript@5.6.2))':
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.75.3(@babel/core@7.28.3)(@babel/preset-env@7.13.15(@babel/core@7.28.3))(@types/react@18.3.8)(encoding@0.1.13)(react@18.3.1)(typescript@5.6.2))':
     dependencies:
       merge-options: 3.0.4
       react-native: 0.75.3(@babel/core@7.28.3)(@babel/preset-env@7.13.15(@babel/core@7.28.3))(@types/react@18.3.8)(encoding@0.1.13)(react@18.3.1)(typescript@5.6.2)
@@ -13705,7 +13705,7 @@ snapshots:
 
   '@types/node-forge@1.3.14':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
 
   '@types/node@12.20.55': {}
 
@@ -13718,6 +13718,7 @@ snapshots:
   '@types/node@24.3.0':
     dependencies:
       undici-types: 7.10.0
+    optional: true
 
   '@types/parse-json@4.0.2': {}
 
@@ -15106,7 +15107,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -15117,7 +15118,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -18083,7 +18084,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -18104,13 +18105,13 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
       jest-util: 29.7.0
 
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -18127,7 +18128,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 18.19.50
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -22196,7 +22197,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@7.10.0: {}
+  undici-types@7.10.0:
+    optional: true
 
   undici@5.28.4:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves #3710

Add support for `@react-native-async-storage/async-storage` v2.0.0 in `@urql/storage-rn`. This allows users who have upgraded to the latest major version of async-storage to use the package without peer dependency warnings.

## Set of changes

**Package affected:** `@urql/storage-rn`

- Updated `peerDependencies` to accept both v1.x and v2.x of `@react-native-async-storage/async-storage` (`^1.15.5 || ^2.0.0`)
- Updated `devDependencies` to use `^2.2.0` for development/testing

**Files changed:**
- `packages/storage-rn/package.json`

**Breaking change:** No — this is backwards compatible. Existing users on async-storage v1.x are unaffected.