### PR TITLE
fix(graphcache): use vi.stubGlobal for navigator mock in tests

### DIFF
--- a/exchanges/graphcache/src/offlineExchange.test.ts
+++ b/exchanges/graphcache/src/offlineExchange.test.ts
@@ -5,7 +5,7 @@ import {
   Operation,
   OperationResult,
 } from '@urql/core';
-import { vi, expect, it, describe, beforeAll } from 'vitest';
+import { vi, expect, it, describe, beforeAll, afterAll } from 'vitest';
 
 import { pipe, share, map, makeSubject, tap, publish } from 'wonka';
 import { queryResponse } from '../../../packages/core/src/test-utils';
@@ -105,7 +105,11 @@ describe('storage', () => {
 describe('offline', () => {
   beforeAll(() => {
     vi.resetAllMocks();
-    globalThis.navigator = { onLine: true } as any;
+    vi.stubGlobal('navigator', { onLine: true });
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
   });
 
   it('should intercept errored mutations', () => {


### PR DESCRIPTION
## Summary
- Fix failing test in `offlineExchange.test.ts` on Node.js 22+

## Problem
Node.js 22+ makes `navigator` a read-only global property with only a getter, causing the test to fail with:
```
TypeError: Cannot set property navigator of #<Object> which has only a getter
```

## Solution
Replace direct assignment `globalThis.navigator = { onLine: true }` with vitest's `vi.stubGlobal('navigator', { onLine: true })` which properly handles read-only properties.

## Test plan
- [x] Run `pnpm test` - all 67 test files pass (595 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)