### PR TITLE
fix(vue): enforce types so nested refs can't be in variables

### DIFF
--- a/.changeset/fresh-birds-juggle.md
+++ b/.changeset/fresh-birds-juggle.md
@@ -2,4 +2,4 @@
 '@urql/vue': patch
 ---
 
-Fix Vue query variable serialization so `ref` values inside plain variable objects are unwrapped before sending a request.
+Narrow down the variables type so we don't allow for nested reactive variables

--- a/packages/vue-urql/src/useQuery.test.ts
+++ b/packages/vue-urql/src/useQuery.test.ts
@@ -201,26 +201,6 @@ describe('useQuery', () => {
     expect(query$.operation.value).toHaveProperty('variables.nested.prop', 2);
   });
 
-  it('reacts to object variables containing refs', async () => {
-    const skip = ref(0);
-
-    const { executeQuery, query$ } = createQuery({
-      query: ref('{ test }'),
-      variables: {
-        skip,
-      },
-    });
-
-    await query$;
-    expect(executeQuery).toHaveBeenCalledTimes(1);
-    expect(query$.operation.value).toHaveProperty('variables.skip', 0);
-
-    skip.value = 1;
-    await query$;
-    expect(executeQuery).toHaveBeenCalledTimes(2);
-    expect(query$.operation.value).toHaveProperty('variables.skip', 1);
-  });
-
   it('reacts to reactive variables changing', async () => {
     const prop = ref(1);
     const variables = reactive({ prop: 1, deep: { nested: { prop } } });

--- a/packages/vue-urql/src/useQuery.ts
+++ b/packages/vue-urql/src/useQuery.ts
@@ -73,7 +73,7 @@ export type UseQueryArgs<
    * documentation on the `pause` option.
    */
   pause?: MaybeRefOrGetter<boolean>;
-} & MaybeRefOrGetterObj<GraphQLRequestParams<Data, Variables>>;
+} & MaybeRefOrGetterObj<GraphQLRequestParams<Data, Variables>, 'variables'>;
 
 /** State of the current query, your {@link useQuery} function is executing.
  *

--- a/packages/vue-urql/src/useSubscription.ts
+++ b/packages/vue-urql/src/useSubscription.ts
@@ -55,7 +55,7 @@ export type UseSubscriptionArgs<
    * ```
    */
   context?: MaybeRefOrGetter<Partial<OperationContext>>;
-} & MaybeRefOrGetterObj<GraphQLRequestParams<Data, Variables>>;
+} & MaybeRefOrGetterObj<GraphQLRequestParams<Data, Variables>, 'variables'>;
 
 /** Combines previous data with an incoming subscription result’s data.
  *


### PR DESCRIPTION
Resolves https://github.com/urql-graphql/urql/issues/3834

## Summary

- Add type constraint so `variables` can be reactive but it's children can't be
