### PR TITLE
feat(refocus): opt out operations from refetching

### DIFF
--- a/.changeset/kind-planes-strive.md
+++ b/.changeset/kind-planes-strive.md
@@ -1,0 +1,5 @@
+---
+'@urql/exchange-refocus': patch
+---
+
+feat(refocus): opt out operations from refetching

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -2,6 +2,15 @@ import { pipe, tap } from 'wonka';
 import type { Exchange, Operation } from '@urql/core';
 
 export interface RefocusOptions {
+  /** Predicate allowing you to selectively opt out `Operation`s from reexecuting.
+   *
+   * @remarks
+   * `refetchIf` is called for all active queries. If this function returns false
+   * query is not reexecuted.
+   *
+   * By default, all queries will be refetched.
+   */
+  refetchIf?: (op: Operation) => boolean;
   /** The minimum time in milliseconds to wait before another refocus can trigger.
    * @defaultValue `0`
    */
@@ -24,7 +33,7 @@ export interface RefocusOptions {
  * only refetch queries that are currently active.
  */
 export const refocusExchange = (opts: RefocusOptions = {}): Exchange => {
-  const { minimumTime = 0 } = opts;
+  const { minimumTime = 0, refetchIf } = opts;
 
   return ({ client, forward }) =>
     ops$ => {
@@ -56,7 +65,7 @@ export const refocusExchange = (opts: RefocusOptions = {}): Exchange => {
       });
 
       const processIncomingOperation = (op: Operation) => {
-        if (op.kind === 'query' && !observedOperations.has(op.key)) {
+        if (op.kind === 'query' && !observedOperations.has(op.key) && (!refetchIf || refetchIf(operation))) {
           observedOperations.set(op.key, 1);
           watchedOperations.set(op.key, op);
         }

--- a/exchanges/refocus/src/refocusExchange.ts
+++ b/exchanges/refocus/src/refocusExchange.ts
@@ -65,7 +65,11 @@ export const refocusExchange = (opts: RefocusOptions = {}): Exchange => {
       });
 
       const processIncomingOperation = (op: Operation) => {
-        if (op.kind === 'query' && !observedOperations.has(op.key) && (!refetchIf || refetchIf(operation))) {
+        if (
+          op.kind === 'query' &&
+          !observedOperations.has(op.key) &&
+          (!refetchIf || refetchIf(op))
+        ) {
           observedOperations.set(op.key, 1);
           watchedOperations.set(op.key, op);
         }


### PR DESCRIPTION
## Reason for change

- I am cleaning up and migrating a large application and would like to remove all custom patches

## Changes and Summary

- Added a `refetchIf` option to refocusExchange
  - Allows consumers to explicitly opt in or out of refetching
  - Mirrors patterns used in other exchanges:
    - `requestPolicyExchange` → `shouldUpgrade`
    - `retryExchange` → `retryIf`
  - Enables per-operation control instead of relying on global configuration
  - Aligns well with React Query’s useQuery, allowing behavior to be customized at the operation level where application context is available